### PR TITLE
Need space between : and ; (case null statement)

### DIFF
--- a/verilog/formatting/token_annotator.cc
+++ b/verilog/formatting/token_annotator.cc
@@ -113,6 +113,10 @@ static WithReason<int> SpacesRequiredBetween(const PreFormatToken& left,
   if (right.TokenEnum() == ',') return {0, "No space before comma"};
   if (left.TokenEnum() == ',') return {1, "Require space after comma"};
 
+  if (left.TokenEnum() == ':' && right.TokenEnum() == ';') {
+    return {1, "Require space after null statement in case statement"};
+  }
+
   if (right.TokenEnum() == ';') return {0, "No space before semicolon"};
   if (left.TokenEnum() == ';') return {1, "Require space after semicolon"};
 


### PR DESCRIPTION
#18 says that the space is needed only for the default statement, but I guess it should be applied for each null statement in case, is that correct?

So with this change the following:
```
function f;
  case (x)
    1:;
    default :;
  endcase
endfunction
```

Is formatted to:

```
function f;
  case (x)
    1: ; // <- the space is added here too
    default : ;
  endcase
endfunction
```

Fixes #18