### PR TITLE
& binary operator needs space on both sides

### DIFF
--- a/verilog/formatting/formatter_test.cc
+++ b/verilog/formatting/formatter_test.cc
@@ -370,6 +370,44 @@ static const std::initializer_list<FormatterTestCase> kFormatterTestCases = {
         "  parameter int a=--b- --c;",
         "parameter int a = --b - --c;\n"
     },
+    // ^~ and ~^ are bitwise nor, but ^ ~ isn't
+    {
+        "  parameter int a=b^~(c<<d);",
+        "parameter int a = b ^~ (c << d);\n"
+    },
+    {
+        "  parameter int a=b~^(c<<d);",
+        "parameter int a = b ~^ (c << d);\n"
+    },
+    {
+        "  parameter int a=b^ ~ (c<<d);",
+        "parameter int a = b ^ ~(c << d);\n"
+    },
+    {
+        "  parameter int a=b ^ ~(c<<d);",
+        "parameter int a = b ^ ~(c << d);\n"
+    },
+    // ~| is unary reduction NOR, |~ and | ~ aren't
+    {
+        "  parameter int a=b| ~(c<<d);",
+        "parameter int a = b | ~(c << d);\n"
+    },
+    {
+        "  parameter int a=b|~(c<<d);",
+        "parameter int a = b | ~(c << d);\n"
+    },
+    {
+        "  parameter int a=b| ~| ( c<<d);",
+        "parameter int a = b | ~|(c << d);\n"
+    },
+    {
+        "  parameter int a=b| ~| ~| ( c<<d);",
+        "parameter int a = b | ~|~|(c << d);\n"
+    },
+    {
+        "  parameter int a=b| ~~~( c<<d);",
+        "parameter int a = b | ~~~(c << d);\n"
+    },
     {
         "  parameter  int   foo=- - 1 ;",   // double negative
         "parameter int foo = - -1;\n",

--- a/verilog/formatting/formatter_test.cc
+++ b/verilog/formatting/formatter_test.cc
@@ -342,11 +342,38 @@ static const std::initializer_list<FormatterTestCase> kFormatterTestCases = {
         "  parameter  int   foo=$bar(-  z,- y ) ;",
         "parameter int foo = $bar(-z, -y);\n",
     },
-    /* TODO(b/143739545): prevent token joining
-    {"  parameter  int   foo=- - 1 ;",   // double negative
-    "parameter int foo = - -1;\n",
+    {
+        "  parameter int a=b&~(c<<d);",
+        "parameter int a = b & ~(c << d);\n"
     },
-    */
+    {
+        "  parameter int a=~~~~b;",
+        "parameter int a = ~~~~b;\n"
+    },
+    {
+        "  parameter int a = ~ ~ ~ ~ b;",
+        "parameter int a = ~~~~b;\n"
+    },
+    {
+        "  parameter int a   =   ~--b;",
+        "parameter int a = ~--b;\n"
+    },
+    {
+        "  parameter int a   =   ~ --b;",
+        "parameter int a = ~--b;\n"
+    },
+    {
+        "  parameter int a = ~ ++ b;",
+        "parameter int a = ~++b;\n"
+    },
+    {
+        "  parameter int a=--b- --c;",
+        "parameter int a = --b - --c;\n"
+    },
+    {
+        "  parameter  int   foo=- - 1 ;",   // double negative
+        "parameter int foo = - -1;\n",
+    },
     {
         "  parameter  int   ternary=1?2:3;",
         "parameter int ternary = 1 ? 2 : 3;\n",

--- a/verilog/formatting/token_annotator.cc
+++ b/verilog/formatting/token_annotator.cc
@@ -146,10 +146,12 @@ static WithReason<int> SpacesRequiredBetween(const PreFormatToken& left,
   }
 
   // Unary operators (context-sensitive)
-  if (IsUnaryPrefixExpressionOperand(left, context)) {
-    // TODO(b/143739545): Don't accidentally join into valid tokens, e.g.:
-    //   '-' and '-' could form '--' (decrement).
-    //   '-' and '=' could form '-=' (subtract-assign).
+  if (IsUnaryPrefixExpressionOperand(left, context) &&
+      (left.format_token_enum != FormatTokenType::binary_operator ||
+       !IsUnaryOperator(static_cast<yytokentype>(right.TokenEnum())))) {
+    // TODO: There are _some_ unary operators on the right that could
+    // be formatted with 0-space, for example:
+    // 'a = & ~b'; could be 'a = &~b;'
     return {0, "Bind unary prefix operator close to its operand."};
   }
 

--- a/verilog/formatting/token_annotator_test.cc
+++ b/verilog/formatting/token_annotator_test.cc
@@ -1581,6 +1581,31 @@ TEST(TokenAnnotatorTest, AnnotateFormattingWithContextTest) {
           {0, SpacingOptions::MustAppend},
       },
 
+      // Test '~' unary token
+      {
+          DefaultStyle,
+          {'~', "~"},
+          {'(', "("},
+          {NodeEnum::kUnaryPrefixExpression},
+          {0, SpacingOptions::MustAppend},
+      },
+      {
+          DefaultStyle,
+          {'~', "~"},
+          {yytokentype::SymbolIdentifier, "foo"},
+          {NodeEnum::kUnaryPrefixExpression},
+          {0, SpacingOptions::MustAppend},
+      },
+
+      // Two unary operators
+      {
+          DefaultStyle,
+          {'~', "~"},
+          {'~', "~"},
+          {NodeEnum::kUnaryPrefixExpression},
+          {0, SpacingOptions::MustAppend},
+      },
+
       // Inside dimension ranges, force space preservation
       {
           DefaultStyle,

--- a/verilog/formatting/token_annotator_test.cc
+++ b/verilog/formatting/token_annotator_test.cc
@@ -1549,6 +1549,38 @@ TEST(TokenAnnotatorTest, AnnotateFormattingWithContextTest) {
           {0, SpacingOptions::MustAppend},
       },
 
+      // Handle '&' as binary
+      {
+          DefaultStyle,
+          {'&', "&"},
+          {'~', "~"},
+          {},  // unspecified context
+          {1, SpacingOptions::Undecided},
+      },
+
+      // Handle '&' as unary
+      {
+          DefaultStyle,
+          {'&', "&"},
+          {yytokentype::TK_DecNumber, "42"},
+          {NodeEnum::kUnaryPrefixExpression},
+          {0, SpacingOptions::MustAppend},
+      },
+      {
+          DefaultStyle,
+          {'&', "&"},
+          {yytokentype::SymbolIdentifier, "foo"},
+          {NodeEnum::kUnaryPrefixExpression},
+          {0, SpacingOptions::MustAppend},
+      },
+      {
+          DefaultStyle,
+          {'&', "&"},
+          {'(', "("},
+          {NodeEnum::kUnaryPrefixExpression},
+          {0, SpacingOptions::MustAppend},
+      },
+
       // Inside dimension ranges, force space preservation
       {
           DefaultStyle,

--- a/verilog/formatting/verilog_token.cc
+++ b/verilog/formatting/verilog_token.cc
@@ -563,6 +563,7 @@ FTT GetFormatTokenType(yytokentype e) {
       case '+':
       case '*':
       case '-':
+      case '&':
         return FTT::binary_operator;
       case '?':
         // Technically, ?: is a ternary operator, but nonetheless we

--- a/verilog/formatting/verilog_token.cc
+++ b/verilog/formatting/verilog_token.cc
@@ -489,8 +489,6 @@ static const auto* FormatTokenTypeMap =
         {yytokentype::TK_LOR, FTT::binary_operator},
         {yytokentype::TK_LAND, FTT::binary_operator},
         {yytokentype::TK_TAND, FTT::binary_operator},
-        {yytokentype::TK_NAND, FTT::binary_operator},
-        {yytokentype::TK_NOR, FTT::binary_operator},
         {yytokentype::TK_NXOR, FTT::binary_operator},
         {yytokentype::TK_LOGEQUIV, FTT::binary_operator},
         {yytokentype::TK_TRIGGER, FTT::binary_operator},
@@ -535,6 +533,8 @@ static const auto* FormatTokenTypeMap =
         // unary operators
         {yytokentype::TK_INCR, FTT::unary_operator},
         {yytokentype::TK_DECR, FTT::unary_operator},
+        {yytokentype::TK_NAND, FTT::unary_operator},
+        {yytokentype::TK_NOR, FTT::unary_operator},
 
         // hierarchy
         {yytokentype::TK_SCOPE_RES, FTT::hierarchy},

--- a/verilog/formatting/verilog_token.cc
+++ b/verilog/formatting/verilog_token.cc
@@ -560,10 +560,16 @@ FTT GetFormatTokenType(yytokentype e) {
   } else {
     // single char tokens which use ASCII values as enum.
     switch (static_cast<int>(e)) {
+      /* arithmetic */
       case '+':
-      case '*':
       case '-':
+      case '*':
+      case '/':
+      case '%':
+      /* bitwise */
       case '&':
+      case '|':
+      case '^':
         return FTT::binary_operator;
       case '?':
         // Technically, ?: is a ternary operator, but nonetheless we


### PR DESCRIPTION
Fixes #37.

I've also removed the message about not accidentally joining `-` and `-` into `--` as it has been solved by the same change.

I am not sure about `-` and `=` though - could you please give an example of where this would be legal (other than the actual `-=`);