### PR TITLE
Sort lint violations

### DIFF
--- a/common/analysis/line_linter_test.cc
+++ b/common/analysis/line_linter_test.cc
@@ -40,14 +40,14 @@ class BlankLineRule : public LineLintRule {
   void HandleLine(absl::string_view line) override {
     if (line.empty()) {
       const TokenInfo token(0, line);
-      violations_.push_back(LintViolation(token, "some reason"));
+      violations_.insert(LintViolation(token, "some reason"));
     }
   }
 
   LintRuleStatus Report() const override { return LintRuleStatus(violations_); }
 
  private:
-  std::vector<LintViolation> violations_;
+  std::set<LintViolation> violations_;
 };
 
 std::unique_ptr<LineLintRule> MakeBlankLineRule() {
@@ -96,7 +96,7 @@ class EmptyFileRule : public LineLintRule {
 
   void Finalize() override {
     if (lines_ == 0) {
-      violations_.push_back(
+      violations_.insert(
           LintViolation(TokenInfo::EOFToken(), "insufficient bytes"));
     }
   }
@@ -106,7 +106,7 @@ class EmptyFileRule : public LineLintRule {
   size_t lines_ = 0;
 
  private:
-  std::vector<LintViolation> violations_;
+  std::set<LintViolation> violations_;
 };
 
 std::unique_ptr<LineLintRule> MakeEmptyFileRule() {

--- a/common/analysis/lint_rule_status.cc
+++ b/common/analysis/lint_rule_status.cc
@@ -75,10 +75,11 @@ void LintStatusFormatter::FormatViolation(std::ostream* stream,
 
 void LintRuleStatus::WaiveViolations(
     std::function<bool(const LintViolation&)>&& is_waived) {
-  std::vector<LintViolation> filtered_violations;
-  filtered_violations.reserve(violations.size());
+  std::set<LintViolation> filtered_violations;
   std::remove_copy_if(violations.begin(), violations.end(),
-                      std::back_inserter(filtered_violations), is_waived);
+                      std::inserter(filtered_violations,
+                                    filtered_violations.begin()),
+                      is_waived);
   violations.swap(filtered_violations);
 }
 

--- a/common/analysis/lint_rule_status.h
+++ b/common/analysis/lint_rule_status.h
@@ -21,6 +21,7 @@
 #include <iosfwd>
 #include <string>
 #include <vector>
+#include <set>
 
 #include "absl/strings/string_view.h"
 #include "common/text/line_column_map.h"
@@ -63,17 +64,23 @@ struct LintViolation {
   // The context (list of ancestors) of the offending token.
   // For non-syntax-tree analyses, leave this blank.
   const SyntaxTreeContext context;
+
+  bool operator<(const LintViolation& r) const {
+    // compares addresses of violations, which correspond to substring
+    // locations
+    return token.text.data() < r.token.text.data();
+  };
 };
 
 // LintRuleStatus represents the result of running a single lint rule.
 struct LintRuleStatus {
   LintRuleStatus() : violations() {}
 
-  LintRuleStatus(const std::vector<LintViolation>& vs,
+  LintRuleStatus(const std::set<LintViolation>& vs,
                  absl::string_view rule_name, const std::string& url)
       : lint_rule_name(rule_name), url(url), violations(vs) {}
 
-  explicit LintRuleStatus(const std::vector<LintViolation>& vs)
+  explicit LintRuleStatus(const std::set<LintViolation>& vs)
       : violations(vs) {}
 
   bool isOk() const { return violations.empty(); }
@@ -89,7 +96,7 @@ struct LintRuleStatus {
   std::string url;
 
   // Contains all violations of the LintRule
-  std::vector<LintViolation> violations;
+  std::set<LintViolation> violations;
 };
 
 // LintStatusFormatter is a class for printing LintRuleStatus's and

--- a/common/analysis/lint_rule_status.h
+++ b/common/analysis/lint_rule_status.h
@@ -123,6 +123,18 @@ class LintStatusFormatter {
                             absl::string_view base,
                             absl::string_view path) const;
 
+  // Formats, sorts and outputs status to stream.
+  // The violations contained in the statuses are sorted by their occurrence
+  // in the code and are not grouped by the status object.
+  // Path is the file path of original file. This is needed because it is not
+  // contained in status.
+  // Base is the string_view of the entire contents, used only for byte offset
+  // calculation.
+  void FormatLintRuleStatuses(std::ostream* stream,
+                              const std::vector<LintRuleStatus> &statuses,
+                              absl::string_view base,
+                              absl::string_view path) const;
+
   // Formats and outputs violation on stream.
   // Path is file path of original file and url is a link to the ratified rule
   // that is being violated.

--- a/common/analysis/lint_rule_status_test.cc
+++ b/common/analysis/lint_rule_status_test.cc
@@ -30,7 +30,7 @@ namespace {
 
 // Tests initialization of LintRuleStatus.
 TEST(LintRuleStatusTest, Construction) {
-  std::vector<LintViolation> violations;
+  std::set<LintViolation> violations;
   LintRuleStatus status(violations, "RULE_NAME", "http://example.com/svstyle");
   EXPECT_TRUE(status.violations.empty());
   EXPECT_EQ(status.lint_rule_name, "RULE_NAME");
@@ -41,7 +41,7 @@ TEST(LintRuleStatusTest, Construction) {
 // Tests adding violations to LintRuleStatus.
 TEST(LintRuleStatusTest, ConstructWithViolation) {
   const TokenInfo token(1, "1bad-id");
-  std::vector<LintViolation> violations({LintViolation(token, "invalid id")});
+  std::set<LintViolation> violations({LintViolation(token, "invalid id")});
   LintRuleStatus status(violations, "RULE_NAME", "http://example.com/svstyle");
   EXPECT_FALSE(status.violations.empty());
   EXPECT_FALSE(status.isOk());
@@ -50,7 +50,7 @@ TEST(LintRuleStatusTest, ConstructWithViolation) {
 // Tests waiving violations and removing them from LintRuleStatus.
 TEST(LintRuleStatusTest, WaiveViolations) {
   const TokenInfo token(1, "1bad-id");
-  std::vector<LintViolation> violations({LintViolation(token, "invalid id")});
+  std::set<LintViolation> violations({LintViolation(token, "invalid id")});
   LintRuleStatus status(violations, "RULE_NAME", "http://example.com/svstyle");
   EXPECT_FALSE(status.violations.empty());
   EXPECT_FALSE(status.isOk());
@@ -92,7 +92,7 @@ void RunLintStatusTest(const LintStatusTest& test) {
   status.url = test.url;
   status.lint_rule_name = test.rule_name;
   for (const auto& violation_test : test.violations) {
-    status.violations.push_back(
+    status.violations.insert(
         LintViolation(violation_test.token, violation_test.reason));
   }
 

--- a/common/analysis/lint_rule_status_test.cc
+++ b/common/analysis/lint_rule_status_test.cc
@@ -144,5 +144,67 @@ TEST(LintRuleStatusFormatterTest, NoOutput) {
   RunLintStatusTest(test);
 }
 
+void RunLintStatusesTest(const LintStatusTest& test)
+{
+  // Dummy tree so we have something for test cases to point at
+  SymbolPtr root = Node();
+
+  std::vector<LintRuleStatus> statuses;
+  LintRuleStatus status0;
+  status0.url = test.url;
+  status0.lint_rule_name = test.rule_name;
+
+  LintRuleStatus status1;
+  status1.url = test.url;
+  status1.lint_rule_name = test.rule_name;
+
+  ASSERT_EQ(test.violations.size(), 2);
+
+  // Insert the violations in the wrong order
+  status0.violations.insert(
+      LintViolation(test.violations[1].token,
+                    test.violations[1].reason));
+
+  status1.violations.insert(
+      LintViolation(test.violations[0].token,
+                    test.violations[0].reason));
+
+  statuses.push_back(status0);
+  statuses.push_back(status1);
+
+  std::ostringstream ss;
+
+  LintStatusFormatter formatter(test.text);
+  formatter.FormatLintRuleStatuses(&ss, statuses, test.text, test.path);
+  auto result_parts = absl::StrSplit(ss.str(), '\n');
+  auto part_iterator = result_parts.begin();
+
+  for (const auto& violation_test : test.violations) {
+    EXPECT_EQ(*part_iterator, violation_test.expected_output);
+    part_iterator++;
+  }
+}
+
+TEST(LintRuleStatusFormatterTest, MultipleStatusesSimpleOutput) {
+  SymbolPtr root = Node();
+  static const int dont_care_tag = 0;
+  constexpr absl::string_view text(
+      "This is some code\n"
+      "That you are looking at right now\n"
+      "It is nice code, make no mistake\n"
+      "Very nice");
+  LintStatusTest test = {
+      "test-rule",
+      "http://foobar",
+      "some/path/to/somewhere.fvg",
+      text,
+      {{"reason1", TokenInfo(dont_care_tag, text.substr(0, 5)),
+        "some/path/to/somewhere.fvg:1:1: reason1 http://foobar [test-rule]"},
+       {"reason2", TokenInfo(dont_care_tag, text.substr(21, 4)),
+        "some/path/to/somewhere.fvg:2:4: reason2 http://foobar [test-rule]"}}};
+
+  RunLintStatusesTest(test);
+}
+
 }  // namespace
 }  // namespace verible

--- a/common/analysis/linter_test_utils.cc
+++ b/common/analysis/linter_test_utils.cc
@@ -48,7 +48,7 @@ static int CompareViolation(const LintViolation& lhs, const TokenInfo& rhs) {
 }
 
 bool LintTestCase::ExactMatchFindings(
-    const std::vector<LintViolation>& found_violations, absl::string_view base,
+    const std::set<LintViolation>& found_violations, absl::string_view base,
     std::ostream* diffstream) const {
   // Due to the order in which violations are visited, we can assert that
   // the reported violations are thus ordered.

--- a/common/analysis/linter_test_utils.h
+++ b/common/analysis/linter_test_utils.h
@@ -46,7 +46,7 @@ struct LintTestCase : public SynthesizedLexerTestData {
   // Returns true if every element is an exact match to the expected set.
   // TODO(b/141875806): Take a symbol translator function to produce a
   // human-readable, language-specific enum name.
-  bool ExactMatchFindings(const std::vector<LintViolation>& found_violations,
+  bool ExactMatchFindings(const std::set<LintViolation>& found_violations,
                           absl::string_view base,
                           std::ostream* diffstream) const;
 };

--- a/common/analysis/linter_test_utils_test.cc
+++ b/common/analysis/linter_test_utils_test.cc
@@ -29,7 +29,7 @@ namespace {
 
 TEST(LintTestCaseExactMatchFindingsTest, AllEmpty) {
   const LintTestCase test{};
-  const std::vector<LintViolation> found_violations;
+  const std::set<LintViolation> found_violations;
   const absl::string_view text;
   std::ostringstream diffstream;
   EXPECT_TRUE(test.ExactMatchFindings(found_violations, text, &diffstream));
@@ -49,7 +49,7 @@ TEST(LintTestCaseExactMatchFindingsTest, OneMatchingViolation) {
   EXPECT_FALSE(BoundsEqual(absl::string_view(test.code), text_view));
 
   const absl::string_view bad_text = text_view.substr(3, 3);
-  const std::vector<LintViolation> found_violations{
+  const std::set<LintViolation> found_violations{
       {{kToken, bad_text}, "some reason"},
   };
   std::ostringstream diffstream;
@@ -74,7 +74,7 @@ TEST(LintTestCaseExactMatchFindingsTest, MultipleMatchingViolations) {
 
   const absl::string_view bad_text1 = text_view.substr(3, 3);
   const absl::string_view bad_text2 = text_view.substr(9, 3);
-  const std::vector<LintViolation> found_violations{
+  const std::set<LintViolation> found_violations{
       // must be sorted on location
       {{kToken, bad_text1}, "some reason"},
       {{kToken, bad_text2}, "different reason"},
@@ -100,7 +100,7 @@ TEST(LintTestCaseExactMatchFindingsTest, OneFoundNotExpected) {
   EXPECT_FALSE(BoundsEqual(absl::string_view(test.code), text_view));
 
   const absl::string_view bad_text = text_view.substr(3, 3);
-  const std::vector<LintViolation> found_violations{
+  const std::set<LintViolation> found_violations{
       {{kToken, bad_text}, "some reason"},
   };
   std::ostringstream diffstream;
@@ -121,7 +121,7 @@ TEST(LintTestCaseExactMatchFindingsTest, OneExpectedNotFound) {
   EXPECT_FALSE(BoundsEqual(absl::string_view(test.code), text_view));
 
   const absl::string_view bad_text = text_view.substr(3, 3);
-  const std::vector<LintViolation> found_violations;  // none expected
+  const std::set<LintViolation> found_violations;  // none expected
   std::ostringstream diffstream;
   EXPECT_FALSE(
       test.ExactMatchFindings(found_violations, text_view, &diffstream));
@@ -140,7 +140,7 @@ TEST(LintTestCaseExactMatchFindingsTest, OneMismatchEach) {
   EXPECT_FALSE(BoundsEqual(absl::string_view(test.code), text_view));
 
   const absl::string_view bad_text = text_view.substr(4, 3);  // "efg"
-  const std::vector<LintViolation> found_violations{
+  const std::set<LintViolation> found_violations{
       {{kToken, bad_text}, "some reason"},
   };
   std::ostringstream diffstream;

--- a/common/analysis/text_structure_linter_test.cc
+++ b/common/analysis/text_structure_linter_test.cc
@@ -43,14 +43,14 @@ class RequireHelloRule : public TextStructureLintRule {
     const absl::string_view contents = text_structure.Contents();
     if (!lines.empty() && !absl::StartsWith(contents, "Hello")) {
       const TokenInfo token(1, lines[0]);
-      violations_.emplace_back(token, "Text must begin with Hello");
+      violations_.emplace(token, "Text must begin with Hello");
     }
   }
 
   LintRuleStatus Report() const override { return LintRuleStatus(violations_); }
 
  private:
-  std::vector<LintViolation> violations_;
+  std::set<LintViolation> violations_;
 };
 
 std::unique_ptr<TextStructureLintRule> MakeHelloRule() {

--- a/common/analysis/token_stream_linter_test.cc
+++ b/common/analysis/token_stream_linter_test.cc
@@ -38,14 +38,14 @@ class ForbidTokenRule : public TokenStreamLintRule {
 
   void HandleToken(const TokenInfo& token) override {
     if (token.token_enum == target_) {
-      violations_.push_back(LintViolation(token, "some reason"));
+      violations_.insert(LintViolation(token, "some reason"));
     }
   }
 
   LintRuleStatus Report() const override { return LintRuleStatus(violations_); }
 
  private:
-  std::vector<LintViolation> violations_;
+  std::set<LintViolation> violations_;
   int target_;
 };
 

--- a/verilog/analysis/checkers/always_comb_blocking_rule.cc
+++ b/verilog/analysis/checkers/always_comb_blocking_rule.cc
@@ -15,7 +15,7 @@
 #include "verilog/analysis/checkers/always_comb_blocking_rule.h"
 
 #include <string>
-#include <vector>
+#include <set>
 
 #include "absl/strings/str_cat.h"
 #include "absl/strings/string_view.h"
@@ -68,7 +68,7 @@ void AlwaysCombBlockingRule::HandleSymbol(const verible::Symbol& symbol,
           *node, NodeEnum::kNonblockingAssignmentStatement, 1);
 
       if (leaf.get().token_enum == TK_LE)
-        violations_.push_back(LintViolation(leaf, kMessage, match.context));
+        violations_.insert(LintViolation(leaf, kMessage, match.context));
     }
   }
 }

--- a/verilog/analysis/checkers/always_comb_blocking_rule.h
+++ b/verilog/analysis/checkers/always_comb_blocking_rule.h
@@ -16,7 +16,7 @@
 #define VERIBLE_VERILOG_ANALYSIS_CHECKERS_ALWAYS_COMB_BLOCKING_RULE_H_
 
 #include <string>
-#include <vector>
+#include <set>
 
 #include "common/analysis/lint_rule_status.h"
 #include "common/analysis/matcher/matcher.h"
@@ -56,7 +56,7 @@ class AlwaysCombBlockingRule : public verible::SyntaxTreeLintRule {
   const Matcher always_comb_matcher_ =
       NodekAlwaysStatement(AlwaysCombKeyword());
 
-  std::vector<verible::LintViolation> violations_;
+  std::set<verible::LintViolation> violations_;
 };
 
 }  // namespace analysis

--- a/verilog/analysis/checkers/always_comb_rule.cc
+++ b/verilog/analysis/checkers/always_comb_rule.cc
@@ -15,7 +15,7 @@
 #include "verilog/analysis/checkers/always_comb_rule.h"
 
 #include <string>
-#include <vector>
+#include <set>
 
 #include "absl/strings/str_cat.h"
 #include "absl/strings/string_view.h"
@@ -55,7 +55,7 @@ void AlwaysCombRule::HandleSymbol(const verible::Symbol& symbol,
   // Check for offending use of always @*
   verible::matcher::BoundSymbolManager manager;
   if (always_star_matcher_.Matches(symbol, &manager)) {
-    violations_.push_back(LintViolation(symbol, kMessage, context));
+    violations_.insert(LintViolation(symbol, kMessage, context));
   }
 }
 

--- a/verilog/analysis/checkers/always_comb_rule.h
+++ b/verilog/analysis/checkers/always_comb_rule.h
@@ -16,7 +16,7 @@
 #define VERIBLE_VERILOG_ANALYSIS_CHECKERS_ALWAYS_COMB_RULE_H_
 
 #include <string>
-#include <vector>
+#include <set>
 
 #include "common/analysis/lint_rule_status.h"
 #include "common/analysis/matcher/matcher.h"
@@ -64,7 +64,7 @@ class AlwaysCombRule : public verible::SyntaxTreeLintRule {
   const Matcher always_star_matcher_ = NodekAlwaysStatement(
       AlwaysKeyword(), AlwaysStatementHasEventControlStar());
 
-  std::vector<verible::LintViolation> violations_;
+  std::set<verible::LintViolation> violations_;
 };
 
 }  // namespace analysis

--- a/verilog/analysis/checkers/always_ff_non_blocking_rule.cc
+++ b/verilog/analysis/checkers/always_ff_non_blocking_rule.cc
@@ -15,7 +15,7 @@
 #include "verilog/analysis/checkers/always_ff_non_blocking_rule.h"
 
 #include <string>
-#include <vector>
+#include <set>
 
 #include "absl/strings/str_cat.h"
 #include "absl/strings/string_view.h"
@@ -74,7 +74,7 @@ void AlwaysFFNonBlockingRule::HandleSymbol(const verible::Symbol &symbol,
       if (leaf == nullptr) continue;
 
       if (leaf->get().token_enum == '=')
-        violations_.push_back(LintViolation(*leaf, kMessage, match.context));
+        violations_.insert(LintViolation(*leaf, kMessage, match.context));
     }
   }
 }

--- a/verilog/analysis/checkers/always_ff_non_blocking_rule.h
+++ b/verilog/analysis/checkers/always_ff_non_blocking_rule.h
@@ -16,7 +16,7 @@
 #define VERIBLE_VERILOG_ANALYSIS_CHECKERS_ALWAYS_FF_NON_BLOCKING_RULE_H_
 
 #include <string>
-#include <vector>
+#include <set>
 
 #include "common/analysis/lint_rule_status.h"
 #include "common/analysis/matcher/matcher.h"
@@ -55,7 +55,7 @@ class AlwaysFFNonBlockingRule : public verible::SyntaxTreeLintRule {
 
   const Matcher always_ff_matcher_ = NodekAlwaysStatement(AlwaysFFKeyword());
 
-  std::vector<verible::LintViolation> violations_;
+  std::set<verible::LintViolation> violations_;
 };
 
 }  // namespace analysis

--- a/verilog/analysis/checkers/case_missing_default_rule.cc
+++ b/verilog/analysis/checkers/case_missing_default_rule.cc
@@ -15,7 +15,7 @@
 #include "verilog/analysis/checkers/case_missing_default_rule.h"
 
 #include <string>
-#include <vector>
+#include <set>
 
 #include "absl/strings/str_cat.h"
 #include "common/analysis/citation.h"
@@ -54,7 +54,7 @@ void CaseMissingDefaultRule::HandleSymbol(
     const verible::Symbol& symbol, const verible::SyntaxTreeContext& context) {
   verible::matcher::BoundSymbolManager manager;
   if (matcher_.Matches(symbol, &manager))
-    violations_.push_back(LintViolation(symbol, kMessage, context));
+    violations_.insert(LintViolation(symbol, kMessage, context));
 }
 
 LintRuleStatus CaseMissingDefaultRule::Report() const {

--- a/verilog/analysis/checkers/case_missing_default_rule.h
+++ b/verilog/analysis/checkers/case_missing_default_rule.h
@@ -16,7 +16,7 @@
 #define VERIBLE_VERILOG_ANALYSIS_CHECKERS_CASE_MISSING_DEFAULT_RULE_H_
 
 #include <string>
-#include <vector>
+#include <set>
 
 #include "common/analysis/lint_rule_status.h"
 #include "common/analysis/matcher/core_matchers.h"
@@ -58,7 +58,7 @@ class CaseMissingDefaultRule : public verible::SyntaxTreeLintRule {
   Matcher matcher_ =
       NodekCaseItemList(verible::matcher::Unless(HasDefaultCase()));
 
-  std::vector<verible::LintViolation> violations_;
+  std::set<verible::LintViolation> violations_;
 };
 
 }  // namespace analysis

--- a/verilog/analysis/checkers/create_object_name_match_rule.cc
+++ b/verilog/analysis/checkers/create_object_name_match_rule.cc
@@ -17,7 +17,7 @@
 #include <cstddef>
 #include <memory>
 #include <string>
-#include <vector>
+#include <set>
 
 #include "absl/strings/str_cat.h"
 #include "absl/strings/string_view.h"
@@ -173,7 +173,7 @@ void CreateObjectNameMatchRule::HandleSymbol(const verible::Symbol& symbol,
     if (const auto* expr = GetFirstExpressionFromArgs(*args)) {
       if (const TokenInfo* name_token = ExtractStringLiteralToken(*expr)) {
         if (StripOuterQuotes(name_token->text) != lval_token.text) {
-          violations_.push_back(LintViolation(
+          violations_.insert(LintViolation(
               *name_token, FormatReason(lval_token.text, name_token->text)));
         }
       }

--- a/verilog/analysis/checkers/create_object_name_match_rule.h
+++ b/verilog/analysis/checkers/create_object_name_match_rule.h
@@ -16,7 +16,7 @@
 #define VERIBLE_VERILOG_ANALYSIS_CHECKERS_CREATE_OBJECT_NAME_MATCH_RULE_H_
 
 #include <string>
-#include <vector>
+#include <set>
 
 #include "common/analysis/lint_rule_status.h"
 #include "common/analysis/matcher/core_matchers.h"
@@ -78,7 +78,7 @@ class CreateObjectNameMatchRule : public verible::SyntaxTreeLintRule {
                            FunctionCallArguments().Bind("args")));
 
   // Record of found violations.
-  std::vector<verible::LintViolation> violations_;
+  std::set<verible::LintViolation> violations_;
 };
 
 }  // namespace analysis

--- a/verilog/analysis/checkers/endif_comment_rule.cc
+++ b/verilog/analysis/checkers/endif_comment_rule.cc
@@ -17,7 +17,7 @@
 #include <deque>
 #include <stack>
 #include <string>
-#include <vector>
+#include <set>
 
 #include "absl/strings/str_cat.h"
 #include "absl/strings/string_view.h"
@@ -107,7 +107,7 @@ void EndifCommentRule::HandleToken(const TokenInfo& token) {
           const absl::string_view contents =
               verible::StripCommentAndSpacePadding(token.text);
           if (contents != expect) {
-            violations_.push_back(LintViolation(
+            violations_.insert(LintViolation(
                 last_endif_, absl::StrCat(kMessage, " (", expect, ")")));
           }
           conditional_scopes_.pop();
@@ -116,7 +116,7 @@ void EndifCommentRule::HandleToken(const TokenInfo& token) {
         }
         default:
           // includes TK_NEWLINE and TK_EOF.
-          violations_.push_back(LintViolation(
+          violations_.insert(LintViolation(
               last_endif_, absl::StrCat(kMessage, " (", expect, ")")));
           conditional_scopes_.pop();
           state_ = State::kNormal;

--- a/verilog/analysis/checkers/endif_comment_rule.h
+++ b/verilog/analysis/checkers/endif_comment_rule.h
@@ -17,7 +17,7 @@
 
 #include <stack>
 #include <string>
-#include <vector>
+#include <set>
 
 #include "common/analysis/lint_rule_status.h"
 #include "common/analysis/token_stream_lint_rule.h"
@@ -83,7 +83,7 @@ class EndifCommentRule : public verible::TokenStreamLintRule {
   std::stack<verible::TokenInfo> conditional_scopes_;
 
   // Collection of found violations.
-  std::vector<verible::LintViolation> violations_;
+  std::set<verible::LintViolation> violations_;
 };
 
 }  // namespace analysis

--- a/verilog/analysis/checkers/explicit_function_lifetime_rule.cc
+++ b/verilog/analysis/checkers/explicit_function_lifetime_rule.cc
@@ -15,7 +15,7 @@
 #include "verilog/analysis/checkers/explicit_function_lifetime_rule.h"
 
 #include <string>
-#include <vector>
+#include <set>
 
 #include "absl/strings/str_cat.h"
 #include "common/analysis/citation.h"
@@ -74,7 +74,7 @@ void ExplicitFunctionLifetimeRule::HandleSymbol(
       // Point to the function id.
       const verible::TokenInfo token(SymbolIdentifier,
                                      verible::StringSpanOfSymbol(*function_id));
-      violations_.push_back(LintViolation(token, kMessage, context));
+      violations_.insert(LintViolation(token, kMessage, context));
     }
   }
 }

--- a/verilog/analysis/checkers/explicit_function_lifetime_rule.h
+++ b/verilog/analysis/checkers/explicit_function_lifetime_rule.h
@@ -16,7 +16,7 @@
 #define VERIBLE_VERILOG_ANALYSIS_CHECKERS_EXPLICIT_FUNCTION_LIFETIME_RULE_H_
 
 #include <string>
-#include <vector>
+#include <set>
 
 #include "common/analysis/lint_rule_status.h"
 #include "common/analysis/matcher/matcher.h"
@@ -57,7 +57,7 @@ class ExplicitFunctionLifetimeRule : public verible::SyntaxTreeLintRule {
 
   Matcher matcher_ = NodekFunctionDeclaration();
 
-  std::vector<verible::LintViolation> violations_;
+  std::set<verible::LintViolation> violations_;
 };
 
 }  // namespace analysis

--- a/verilog/analysis/checkers/explicit_function_task_parameter_type_rule.cc
+++ b/verilog/analysis/checkers/explicit_function_task_parameter_type_rule.cc
@@ -15,7 +15,7 @@
 #include "verilog/analysis/checkers/explicit_function_task_parameter_type_rule.h"
 
 #include <string>
-#include <vector>
+#include <set>
 
 #include "absl/strings/str_cat.h"
 #include "common/analysis/citation.h"
@@ -64,7 +64,7 @@ void ExplicitFunctionTaskParameterTypeRule::HandleSymbol(
     const auto* type_node = GetTypeOfTaskFunctionPortItem(symbol);
     if (!IsStorageTypeOfDataTypeSpecified(*ABSL_DIE_IF_NULL(type_node))) {
       const auto* port_id = GetIdentifierFromTaskFunctionPortItem(symbol);
-      violations_.push_back(LintViolation(*port_id, kMessage, context));
+      violations_.insert(LintViolation(*port_id, kMessage, context));
     }
   }
 }

--- a/verilog/analysis/checkers/explicit_function_task_parameter_type_rule.h
+++ b/verilog/analysis/checkers/explicit_function_task_parameter_type_rule.h
@@ -16,7 +16,7 @@
 #define VERIBLE_VERILOG_ANALYSIS_CHECKERS_EXPLICIT_FUNCTION_TASK_PARAMETER_TYPE_RULE_H_
 
 #include <string>
-#include <vector>
+#include <set>
 
 #include "common/analysis/lint_rule_status.h"
 #include "common/analysis/matcher/matcher.h"
@@ -58,7 +58,7 @@ class ExplicitFunctionTaskParameterTypeRule
 
   Matcher matcher_ = NodekPortItem();
 
-  std::vector<verible::LintViolation> violations_;
+  std::set<verible::LintViolation> violations_;
 };
 
 }  // namespace analysis

--- a/verilog/analysis/checkers/explicit_function_task_parameter_type_rule_test.cc
+++ b/verilog/analysis/checkers/explicit_function_task_parameter_type_rule_test.cc
@@ -16,7 +16,7 @@
 
 #include <initializer_list>
 #include <memory>
-#include <vector>
+#include <set>
 
 #include "gtest/gtest.h"
 #include "absl/memory/memory.h"

--- a/verilog/analysis/checkers/explicit_parameter_storage_type_rule.cc
+++ b/verilog/analysis/checkers/explicit_parameter_storage_type_rule.cc
@@ -15,7 +15,7 @@
 #include "verilog/analysis/checkers/explicit_parameter_storage_type_rule.h"
 
 #include <string>
-#include <vector>
+#include <set>
 
 #include "absl/strings/str_cat.h"
 #include "common/analysis/citation.h"
@@ -65,7 +65,7 @@ void ExplicitParameterStorageTypeRule::HandleSymbol(
     const auto* type_info_symbol = GetParamTypeInfoSymbol(symbol);
     if (IsTypeInfoEmpty(*ABSL_DIE_IF_NULL(type_info_symbol))) {
       const verible::TokenInfo& param_name = GetParameterNameToken(symbol);
-      violations_.push_back(LintViolation(
+      violations_.insert(LintViolation(
           param_name, absl::StrCat(kMessage, "(", param_name.text, ")."),
           context));
     }

--- a/verilog/analysis/checkers/explicit_parameter_storage_type_rule.h
+++ b/verilog/analysis/checkers/explicit_parameter_storage_type_rule.h
@@ -16,7 +16,7 @@
 #define VERIBLE_VERILOG_ANALYSIS_CHECKERS_EXPLICIT_PARAMETER_STORAGE_TYPE_RULE_H_
 
 #include <string>
-#include <vector>
+#include <set>
 
 #include "common/analysis/lint_rule_status.h"
 #include "common/analysis/matcher/matcher.h"
@@ -57,7 +57,7 @@ class ExplicitParameterStorageTypeRule : public verible::SyntaxTreeLintRule {
 
   Matcher matcher_ = NodekParamDeclaration();
 
-  std::vector<verible::LintViolation> violations_;
+  std::set<verible::LintViolation> violations_;
 };
 
 }  // namespace analysis

--- a/verilog/analysis/checkers/explicit_task_lifetime_rule.cc
+++ b/verilog/analysis/checkers/explicit_task_lifetime_rule.cc
@@ -15,7 +15,7 @@
 #include "verilog/analysis/checkers/explicit_task_lifetime_rule.h"
 
 #include <string>
-#include <vector>
+#include <set>
 
 #include "absl/strings/str_cat.h"
 #include "common/analysis/citation.h"
@@ -74,7 +74,7 @@ void ExplicitTaskLifetimeRule::HandleSymbol(const verible::Symbol& symbol,
       // Point to the task id.
       const verible::TokenInfo token(SymbolIdentifier,
                                      verible::StringSpanOfSymbol(*task_id));
-      violations_.push_back(LintViolation(token, kMessage, context));
+      violations_.insert(LintViolation(token, kMessage, context));
     }
   }
 }

--- a/verilog/analysis/checkers/explicit_task_lifetime_rule.h
+++ b/verilog/analysis/checkers/explicit_task_lifetime_rule.h
@@ -16,7 +16,7 @@
 #define VERIBLE_VERILOG_ANALYSIS_CHECKERS_EXPLICIT_TASK_LIFETIME_RULE_H_
 
 #include <string>
-#include <vector>
+#include <set>
 
 #include "common/analysis/lint_rule_status.h"
 #include "common/analysis/matcher/matcher.h"
@@ -57,7 +57,7 @@ class ExplicitTaskLifetimeRule : public verible::SyntaxTreeLintRule {
 
   Matcher matcher_ = NodekTaskDeclaration();
 
-  std::vector<verible::LintViolation> violations_;
+  std::set<verible::LintViolation> violations_;
 };
 
 }  // namespace analysis

--- a/verilog/analysis/checkers/forbid_defparam_rule.cc
+++ b/verilog/analysis/checkers/forbid_defparam_rule.cc
@@ -15,7 +15,7 @@
 #include "verilog/analysis/checkers/forbid_defparam_rule.h"
 
 #include <string>
-#include <vector>
+#include <set>
 
 #include "absl/strings/str_cat.h"
 #include "common/analysis/citation.h"
@@ -52,7 +52,7 @@ void ForbidDefparamRule::HandleSymbol(
     const auto& defparam_token =
         GetSubtreeAsLeaf(symbol, NodeEnum::kParameterOverride, 0).get();
     CHECK_EQ(defparam_token.token_enum, TK_defparam);
-    violations_.push_back(
+    violations_.insert(
         verible::LintViolation(defparam_token, kMessage, context));
   }
 }

--- a/verilog/analysis/checkers/forbid_defparam_rule.h
+++ b/verilog/analysis/checkers/forbid_defparam_rule.h
@@ -16,7 +16,7 @@
 #define VERIBLE_VERILOG_ANALYSIS_CHECKERS_FORBID_DEFPARAM_RULE_H_
 
 #include <string>
-#include <vector>
+#include <set>
 
 #include "common/analysis/lint_rule_status.h"
 #include "common/analysis/matcher/matcher.h"
@@ -56,7 +56,7 @@ class ForbidDefparamRule : public verible::SyntaxTreeLintRule {
   // Diagnostic message.
   static const char kMessage[];
 
-  std::vector<verible::LintViolation> violations_;
+  std::set<verible::LintViolation> violations_;
 };
 
 }  // namespace analysis

--- a/verilog/analysis/checkers/forbidden_anonymous_enums_rule.cc
+++ b/verilog/analysis/checkers/forbidden_anonymous_enums_rule.cc
@@ -15,7 +15,7 @@
 #include "verilog/analysis/checkers/forbidden_anonymous_enums_rule.h"
 
 #include <string>
-#include <vector>
+#include <set>
 
 #include "absl/strings/str_cat.h"
 #include "common/analysis/citation.h"
@@ -58,7 +58,7 @@ void ForbiddenAnonymousEnumsRule::HandleSymbol(
     // Check if it is preceded by a typedef
     if (!context.DirectParentsAre(
             {NodeEnum::kDataTypePrimitive, NodeEnum::kTypeDeclaration})) {
-      violations_.push_back(LintViolation(symbol, kMessage, context));
+      violations_.insert(LintViolation(symbol, kMessage, context));
     }
   }
 }

--- a/verilog/analysis/checkers/forbidden_anonymous_enums_rule.h
+++ b/verilog/analysis/checkers/forbidden_anonymous_enums_rule.h
@@ -16,7 +16,7 @@
 #define VERIBLE_VERILOG_ANALYSIS_CHECKERS_FORBIDDEN_ANONYMOUS_ENUMS_RULE_H_
 
 #include <string>
-#include <vector>
+#include <set>
 
 #include "common/analysis/lint_rule_status.h"
 #include "common/analysis/matcher/matcher.h"
@@ -71,7 +71,7 @@ class ForbiddenAnonymousEnumsRule : public verible::SyntaxTreeLintRule {
   Matcher matcher_ = NodekEnumDataType();
 
   // Collection of found violations.
-  std::vector<verible::LintViolation> violations_;
+  std::set<verible::LintViolation> violations_;
 };
 
 }  // namespace analysis

--- a/verilog/analysis/checkers/forbidden_anonymous_structs_unions_rule.cc
+++ b/verilog/analysis/checkers/forbidden_anonymous_structs_unions_rule.cc
@@ -15,7 +15,7 @@
 #include "verilog/analysis/checkers/forbidden_anonymous_structs_unions_rule.h"
 
 #include <string>
-#include <vector>
+#include <set>
 
 #include "absl/strings/str_cat.h"
 #include "common/analysis/citation.h"
@@ -62,13 +62,13 @@ void ForbiddenAnonymousStructsUnionsRule::HandleSymbol(
     // Check if it is preceded by a typedef
     if (!context.DirectParentsAre(
             {NodeEnum::kDataTypePrimitive, NodeEnum::kTypeDeclaration})) {
-      violations_.push_back(LintViolation(symbol, kMessageStruct, context));
+      violations_.insert(LintViolation(symbol, kMessageStruct, context));
     }
   } else if (matcher_union_.Matches(symbol, &manager)) {
     // Check if it is preceded by a typedef
     if (!context.DirectParentsAre(
             {NodeEnum::kDataTypePrimitive, NodeEnum::kTypeDeclaration})) {
-      violations_.push_back(LintViolation(symbol, kMessageUnion, context));
+      violations_.insert(LintViolation(symbol, kMessageUnion, context));
     }
   }
 }

--- a/verilog/analysis/checkers/forbidden_anonymous_structs_unions_rule.h
+++ b/verilog/analysis/checkers/forbidden_anonymous_structs_unions_rule.h
@@ -16,7 +16,7 @@
 #define VERIBLE_VERILOG_ANALYSIS_CHECKERS_FORBIDDEN_ANONYMOUS_STRUCTS_UNIONS_RULE_H_  // NOLINT
 
 #include <string>
-#include <vector>
+#include <set>
 
 #include "common/analysis/lint_rule_status.h"
 #include "common/analysis/matcher/matcher.h"
@@ -74,7 +74,7 @@ class ForbiddenAnonymousStructsUnionsRule : public verible::SyntaxTreeLintRule {
   Matcher matcher_union_ = NodekUnionDataType();
 
   // Collection of found violations.
-  std::vector<verible::LintViolation> violations_;
+  std::set<verible::LintViolation> violations_;
 };
 
 }  // namespace analysis

--- a/verilog/analysis/checkers/forbidden_macro_rule.cc
+++ b/verilog/analysis/checkers/forbidden_macro_rule.cc
@@ -16,7 +16,7 @@
 
 #include <map>
 #include <string>
-#include <vector>
+#include <set>
 
 #include "absl/strings/str_cat.h"
 #include "absl/strings/string_view.h"
@@ -67,7 +67,7 @@ void ForbiddenMacroRule::HandleSymbol(
     if (auto leaf = manager.GetAs<verible::SyntaxTreeLeaf>("name")) {
       const auto& imm = InvalidMacrosMap();
       if (imm.find(std::string(leaf->get().text)) != imm.end()) {
-        violations_.push_back(
+        violations_.insert(
             verible::LintViolation(leaf->get(), FormatReason(*leaf), context));
       }
     }

--- a/verilog/analysis/checkers/forbidden_macro_rule.h
+++ b/verilog/analysis/checkers/forbidden_macro_rule.h
@@ -17,7 +17,7 @@
 
 #include <map>
 #include <string>
-#include <vector>
+#include <set>
 
 #include "common/analysis/lint_rule_status.h"
 #include "common/analysis/matcher/matcher.h"
@@ -68,7 +68,7 @@ class ForbiddenMacroRule : public verible::SyntaxTreeLintRule {
   const verible::matcher::Matcher matcher_ = MacroCallIdLeaf().Bind("name");
 
  private:
-  std::vector<verible::LintViolation> violations_;
+  std::set<verible::LintViolation> violations_;
 };
 
 }  // namespace analysis

--- a/verilog/analysis/checkers/forbidden_symbol_rule.cc
+++ b/verilog/analysis/checkers/forbidden_symbol_rule.cc
@@ -16,7 +16,7 @@
 
 #include <map>
 #include <string>
-#include <vector>
+#include <set>
 
 #include "absl/strings/str_cat.h"
 #include "absl/strings/string_view.h"
@@ -85,7 +85,7 @@ void ForbiddenSystemTaskFunctionRule::HandleSymbol(
     if (auto leaf = manager.GetAs<verible::SyntaxTreeLeaf>("name")) {
       const auto& ism = InvalidSymbolsMap();
       if (ism.find(std::string(leaf->get().text)) != ism.end()) {
-        violations_.push_back(
+        violations_.insert(
             verible::LintViolation(leaf->get(), FormatReason(*leaf), context));
       }
     }

--- a/verilog/analysis/checkers/forbidden_symbol_rule.h
+++ b/verilog/analysis/checkers/forbidden_symbol_rule.h
@@ -17,7 +17,7 @@
 
 #include <map>
 #include <string>
-#include <vector>
+#include <set>
 
 #include "common/analysis/lint_rule_status.h"
 #include "common/analysis/matcher/matcher.h"
@@ -68,7 +68,7 @@ class ForbiddenSystemTaskFunctionRule : public verible::SyntaxTreeLintRule {
       SystemTFIdentifierLeaf().Bind("name");
 
  private:
-  std::vector<verible::LintViolation> violations_;
+  std::set<verible::LintViolation> violations_;
 };
 
 }  // namespace analysis

--- a/verilog/analysis/checkers/generate_label_rule.cc
+++ b/verilog/analysis/checkers/generate_label_rule.cc
@@ -15,7 +15,7 @@
 #include "verilog/analysis/checkers/generate_label_rule.h"
 
 #include <string>
-#include <vector>
+#include <set>
 
 #include "absl/strings/str_cat.h"
 #include "common/analysis/citation.h"
@@ -51,7 +51,7 @@ void GenerateLabelRule::HandleSymbol(
     const verible::Symbol& symbol, const verible::SyntaxTreeContext& context) {
   verible::matcher::BoundSymbolManager manager;
   if (matcher_.Matches(symbol, &manager)) {
-    violations_.push_back(verible::LintViolation(symbol, kMessage, context));
+    violations_.insert(verible::LintViolation(symbol, kMessage, context));
   }
 }
 

--- a/verilog/analysis/checkers/generate_label_rule.h
+++ b/verilog/analysis/checkers/generate_label_rule.h
@@ -16,7 +16,7 @@
 #define VERIBLE_VERILOG_ANALYSIS_CHECKERS_GENERATE_LABEL_RULE_H_
 
 #include <string>
-#include <vector>
+#include <set>
 
 #include "common/analysis/lint_rule_status.h"
 #include "common/analysis/matcher/core_matchers.h"
@@ -75,7 +75,7 @@ class GenerateLabelRule : public verible::SyntaxTreeLintRule {
   // Diagnostic message.
   static const char kMessage[];
 
-  std::vector<verible::LintViolation> violations_;
+  std::set<verible::LintViolation> violations_;
 };
 
 }  // namespace analysis

--- a/verilog/analysis/checkers/line_length_rule.cc
+++ b/verilog/analysis/checkers/line_length_rule.cc
@@ -17,7 +17,7 @@
 #include <cstddef>
 #include <iterator>
 #include <string>
-#include <vector>
+#include <set>
 
 #include "absl/strings/ascii.h"
 #include "absl/strings/match.h"
@@ -153,7 +153,7 @@ void LineLengthRule::Lint(const TextStructureView& text_structure,
       if (!AllowLongLineException(token_range.begin(), token_range.end())) {
         // Fake a token that marks the offending range of text.
         TokenInfo token(TK_OTHER, line.substr(kMaxLineLength));
-        violations_.push_back(LintViolation(token, kMessage));
+        violations_.insert(LintViolation(token, kMessage));
       }
     }
     ++lineno;

--- a/verilog/analysis/checkers/line_length_rule.h
+++ b/verilog/analysis/checkers/line_length_rule.h
@@ -16,7 +16,7 @@
 #define VERIBLE_VERILOG_ANALYSIS_CHECKERS_LINE_LENGTH_RULE_H_
 
 #include <string>
-#include <vector>
+#include <set>
 
 #include "absl/strings/string_view.h"
 #include "common/analysis/lint_rule_status.h"
@@ -59,7 +59,7 @@ class LineLengthRule : public verible::TextStructureLintRule {
   static const char kMessage[];
 
   // Collection of found violations.
-  std::vector<verible::LintViolation> violations_;
+  std::set<verible::LintViolation> violations_;
 };
 
 }  // namespace analysis

--- a/verilog/analysis/checkers/macro_name_style_rule.cc
+++ b/verilog/analysis/checkers/macro_name_style_rule.cc
@@ -15,7 +15,7 @@
 #include "verilog/analysis/checkers/macro_name_style_rule.h"
 
 #include <string>
-#include <vector>
+#include <set>
 
 #include "absl/strings/str_cat.h"
 #include "common/analysis/citation.h"
@@ -71,7 +71,7 @@ void MacroNameStyleRule::HandleToken(const TokenInfo& token) {
           break;
         case PP_Identifier: {
           if (!verible::IsNameAllCapsUnderscoresDigits(token.text))
-            violations_.push_back(LintViolation(token, kMessage));
+            violations_.insert(LintViolation(token, kMessage));
           state_ = State::kNormal;
           break;
         }

--- a/verilog/analysis/checkers/macro_name_style_rule.h
+++ b/verilog/analysis/checkers/macro_name_style_rule.h
@@ -16,7 +16,7 @@
 #define VERIBLE_VERILOG_ANALYSIS_CHECKERS_MACRO_NAME_STYLE_RULE_H_
 
 #include <string>
-#include <vector>
+#include <set>
 
 #include "common/analysis/lint_rule_status.h"
 #include "common/analysis/token_stream_lint_rule.h"
@@ -59,7 +59,7 @@ class MacroNameStyleRule : public verible::TokenStreamLintRule {
   // Internal lexical analysis state.
   State state_;
 
-  std::vector<verible::LintViolation> violations_;
+  std::set<verible::LintViolation> violations_;
 };
 
 }  // namespace analysis

--- a/verilog/analysis/checkers/module_begin_block_rule.cc
+++ b/verilog/analysis/checkers/module_begin_block_rule.cc
@@ -15,7 +15,7 @@
 #include "verilog/analysis/checkers/module_begin_block_rule.h"
 
 #include <string>
-#include <vector>
+#include <set>
 
 #include "absl/strings/str_cat.h"
 #include "common/analysis/citation.h"
@@ -52,7 +52,7 @@ void ModuleBeginBlockRule::HandleSymbol(
     const verible::Symbol& symbol, const verible::SyntaxTreeContext& context) {
   verible::matcher::BoundSymbolManager manager;
   if (matcher_.Matches(symbol, &manager)) {
-    violations_.push_back(verible::LintViolation(symbol, kMessage, context));
+    violations_.insert(verible::LintViolation(symbol, kMessage, context));
   }
 }
 

--- a/verilog/analysis/checkers/module_begin_block_rule.h
+++ b/verilog/analysis/checkers/module_begin_block_rule.h
@@ -16,7 +16,7 @@
 #define VERIBLE_VERILOG_ANALYSIS_CHECKERS_MODULE_BEGIN_BLOCK_RULE_H_
 
 #include <string>
-#include <vector>
+#include <set>
 
 #include "common/analysis/lint_rule_status.h"
 #include "common/analysis/matcher/matcher.h"
@@ -63,7 +63,7 @@ class ModuleBeginBlockRule : public verible::SyntaxTreeLintRule {
   // Diagnostic message.
   static const char kMessage[];
 
-  std::vector<verible::LintViolation> violations_;
+  std::set<verible::LintViolation> violations_;
 };
 
 }  // namespace analysis

--- a/verilog/analysis/checkers/module_filename_rule.cc
+++ b/verilog/analysis/checkers/module_filename_rule.cc
@@ -18,6 +18,7 @@
 #include <iterator>
 #include <memory>
 #include <string>
+#include <set>
 #include <vector>
 
 #include "absl/strings/str_cat.h"
@@ -93,7 +94,7 @@ void ModuleFilenameRule::Lint(const TextStructureView& text_structure,
 
   // Only report a violation on the last module declaration.
   const auto& last_module_id = GetModuleNameToken(*module_matches.back().match);
-  violations_.push_back(verible::LintViolation(
+  violations_.insert(verible::LintViolation(
       last_module_id, absl::StrCat(kMessage, "\"", unitname, "\"")));
 }
 

--- a/verilog/analysis/checkers/module_filename_rule.h
+++ b/verilog/analysis/checkers/module_filename_rule.h
@@ -16,7 +16,7 @@
 #define VERIBLE_VERILOG_ANALYSIS_CHECKERS_MODULE_FILENAME_RULE_H_
 
 #include <string>
-#include <vector>
+#include <set>
 
 #include "absl/strings/string_view.h"
 #include "common/analysis/lint_rule_status.h"
@@ -51,7 +51,7 @@ class ModuleFilenameRule : public verible::TextStructureLintRule {
   static const char kMessage[];
 
   // Collection of found violations.
-  std::vector<verible::LintViolation> violations_;
+  std::set<verible::LintViolation> violations_;
 };
 
 }  // namespace analysis

--- a/verilog/analysis/checkers/module_instantiation_rules.cc
+++ b/verilog/analysis/checkers/module_instantiation_rules.cc
@@ -17,7 +17,7 @@
 #include <algorithm>
 #include <memory>
 #include <string>
-#include <vector>
+#include <set>
 
 #include "absl/strings/str_cat.h"
 #include "common/analysis/citation.h"
@@ -112,7 +112,7 @@ void ModuleParameterRule::HandleSymbol(
       if (parameter_count > 1) {  // Determine the spanning location
         const auto leaf_ptr = verible::GetLeftmostLeaf(*list);
         const verible::TokenInfo token = ABSL_DIE_IF_NULL(leaf_ptr)->get();
-        violations_.push_back(verible::LintViolation(token, kMessage, context));
+        violations_.insert(verible::LintViolation(token, kMessage, context));
       }
     }
   }
@@ -145,7 +145,7 @@ void ModulePortRule::HandleSymbol(const verible::Symbol& symbol,
         // Determine the leftmost location
         const auto leaf_ptr = verible::GetLeftmostLeaf(*port_list_node);
         const verible::TokenInfo token = ABSL_DIE_IF_NULL(leaf_ptr)->get();
-        violations_.push_back(verible::LintViolation(token, kMessage, context));
+        violations_.insert(verible::LintViolation(token, kMessage, context));
       }
     }
   }

--- a/verilog/analysis/checkers/module_instantiation_rules.h
+++ b/verilog/analysis/checkers/module_instantiation_rules.h
@@ -16,7 +16,7 @@
 #define VERIBLE_VERILOG_ANALYSIS_CHECKERS_MODULE_INSTANTIATION_RULES_H_
 
 #include <string>
-#include <vector>
+#include <set>
 
 #include "common/analysis/lint_rule_status.h"
 #include "common/analysis/matcher/matcher.h"
@@ -60,7 +60,7 @@ class ModuleParameterRule : public verible::SyntaxTreeLintRule {
   // Diagnostic message.
   static const char kMessage[];
 
-  std::vector<verible::LintViolation> violations_;
+  std::set<verible::LintViolation> violations_;
 };
 
 // ModuleParamRule is an implementation of LintRule that handles incorrect
@@ -97,7 +97,7 @@ class ModulePortRule : public verible::SyntaxTreeLintRule {
   // true if it is not.
   bool IsPortListCompliant(const verible::SyntaxTreeNode& port_list_node) const;
 
-  std::vector<verible::LintViolation> violations_;
+  std::set<verible::LintViolation> violations_;
 };
 
 }  // namespace analysis

--- a/verilog/analysis/checkers/no_tabs_rule.cc
+++ b/verilog/analysis/checkers/no_tabs_rule.cc
@@ -16,7 +16,7 @@
 
 #include <cstddef>
 #include <string>
-#include <vector>
+#include <set>
 
 #include "absl/strings/str_cat.h"
 #include "absl/strings/string_view.h"
@@ -55,7 +55,7 @@ void NoTabsRule::HandleLine(absl::string_view line) {
   const auto tab_pos = line.find('\t');
   if (tab_pos != absl::string_view::npos) {
     TokenInfo token(TK_SPACE, line.substr(tab_pos, 1));
-    violations_.push_back(LintViolation(token, kMessage));
+    violations_.insert(LintViolation(token, kMessage));
   }
 }
 

--- a/verilog/analysis/checkers/no_tabs_rule.h
+++ b/verilog/analysis/checkers/no_tabs_rule.h
@@ -18,7 +18,7 @@
 #include <stddef.h>
 
 #include <string>
-#include <vector>
+#include <set>
 
 #include "absl/strings/string_view.h"
 #include "common/analysis/line_lint_rule.h"
@@ -52,7 +52,7 @@ class NoTabsRule : public verible::LineLintRule {
   static const char kMessage[];
 
   // Collection of found violations.
-  std::vector<verible::LintViolation> violations_;
+  std::set<verible::LintViolation> violations_;
 };
 
 }  // namespace analysis

--- a/verilog/analysis/checkers/no_trailing_spaces_rule.cc
+++ b/verilog/analysis/checkers/no_trailing_spaces_rule.cc
@@ -20,7 +20,7 @@
 #include <cctype>
 #include <iterator>
 #include <string>
-#include <vector>
+#include <set>
 
 #include "absl/strings/str_cat.h"
 #include "absl/strings/string_view.h"
@@ -65,7 +65,7 @@ void NoTrailingSpacesRule::HandleLine(absl::string_view line) {
     if (trailing != 0) {
       const int column = line.length() - trailing;
       const TokenInfo token(TK_SPACE, line.substr(column));
-      violations_.push_back(LintViolation(token, kMessage));
+      violations_.insert(LintViolation(token, kMessage));
     }
   }
 }

--- a/verilog/analysis/checkers/no_trailing_spaces_rule.h
+++ b/verilog/analysis/checkers/no_trailing_spaces_rule.h
@@ -18,7 +18,7 @@
 #include <stddef.h>
 
 #include <string>
-#include <vector>
+#include <set>
 
 #include "absl/strings/string_view.h"
 #include "common/analysis/line_lint_rule.h"
@@ -52,7 +52,7 @@ class NoTrailingSpacesRule : public verible::LineLintRule {
   static const char kMessage[];
 
   // Collection of found violations.
-  std::vector<verible::LintViolation> violations_;
+  std::set<verible::LintViolation> violations_;
 };
 
 }  // namespace analysis

--- a/verilog/analysis/checkers/package_filename_rule.cc
+++ b/verilog/analysis/checkers/package_filename_rule.cc
@@ -16,6 +16,7 @@
 
 #include <memory>
 #include <string>
+#include <set>
 #include <vector>
 
 #include "absl/strings/str_cat.h"
@@ -87,7 +88,7 @@ void PackageFilenameRule::Lint(const TextStructureView& text_structure,
     absl::string_view package_id = package_name_token.text;
     auto package_id_plus_suffix = absl::StrCat(package_id, optional_suffix);
     if ((package_id != unitname) && (package_id_plus_suffix != unitname)) {
-      violations_.push_back(verible::LintViolation(
+      violations_.insert(verible::LintViolation(
           package_name_token,
           absl::StrCat(kMessage, "declaration: \"", package_id,
                        "\" vs. basename(file): \"", unitname, "\"")));

--- a/verilog/analysis/checkers/package_filename_rule.h
+++ b/verilog/analysis/checkers/package_filename_rule.h
@@ -16,7 +16,7 @@
 #define VERIBLE_VERILOG_ANALYSIS_CHECKERS_PACKAGE_FILENAME_RULE_H_
 
 #include <string>
-#include <vector>
+#include <set>
 
 #include "absl/strings/string_view.h"
 #include "common/analysis/lint_rule_status.h"
@@ -52,7 +52,7 @@ class PackageFilenameRule : public verible::TextStructureLintRule {
   static const char kMessage[];
 
   // Collection of found violations.
-  std::vector<verible::LintViolation> violations_;
+  std::set<verible::LintViolation> violations_;
 };
 
 }  // namespace analysis

--- a/verilog/analysis/checkers/packed_dimensions_rule.cc
+++ b/verilog/analysis/checkers/packed_dimensions_rule.cc
@@ -16,7 +16,7 @@
 
 #include <algorithm>  // for std::distance
 #include <string>
-#include <vector>
+#include <set>
 
 #include "absl/strings/str_cat.h"
 #include "absl/strings/string_view.h"
@@ -82,7 +82,7 @@ void PackedDimensionsRule::HandleSymbol(
         (left_is_constant && right_is_constant && left_value < right_value)) {
       const verible::TokenInfo token(TK_OTHER,
                                      verible::StringSpanOfSymbol(left, right));
-      violations_.push_back(LintViolation(token, kMessage, context));
+      violations_.insert(LintViolation(token, kMessage, context));
     }
   }
 }

--- a/verilog/analysis/checkers/packed_dimensions_rule.h
+++ b/verilog/analysis/checkers/packed_dimensions_rule.h
@@ -16,7 +16,7 @@
 #define VERIBLE_VERILOG_ANALYSIS_CHECKERS_PACKED_DIMENSIONS_RULE_H_
 
 #include <string>
-#include <vector>
+#include <set>
 
 #include "common/analysis/lint_rule_status.h"
 #include "common/analysis/matcher/matcher.h"
@@ -54,7 +54,7 @@ class PackedDimensionsRule : public verible::SyntaxTreeLintRule {
   // Diagnostic message.
   static const char kMessage[];
 
-  std::vector<verible::LintViolation> violations_;
+  std::set<verible::LintViolation> violations_;
 };
 
 }  // namespace analysis

--- a/verilog/analysis/checkers/parameter_name_style_rule.cc
+++ b/verilog/analysis/checkers/parameter_name_style_rule.cc
@@ -15,7 +15,7 @@
 #include "verilog/analysis/checkers/parameter_name_style_rule.h"
 
 #include <string>
-#include <vector>
+#include <set>
 
 #include "absl/strings/str_cat.h"
 #include "absl/strings/string_view.h"
@@ -75,12 +75,12 @@ void ParameterNameStyleRule::HandleSymbol(const verible::Symbol& symbol,
     const auto param_name = param_name_token->text;
     if (param_decl_token == TK_localparam) {
       if (!verible::IsUpperCamelCaseWithDigits(param_name))
-        violations_.push_back(
+        violations_.insert(
             LintViolation(*param_name_token, kLocalParamMessage, context));
     } else if (param_decl_token == TK_parameter) {
       if (!verible::IsUpperCamelCaseWithDigits(param_name) &&
           !verible::IsNameAllCapsUnderscoresDigits(param_name))
-        violations_.push_back(
+        violations_.insert(
             LintViolation(*param_name_token, kParameterMessage, context));
     }
   }

--- a/verilog/analysis/checkers/parameter_name_style_rule.h
+++ b/verilog/analysis/checkers/parameter_name_style_rule.h
@@ -16,7 +16,7 @@
 #define VERIBLE_VERILOG_ANALYSIS_CHECKERS_PARAMETER_NAME_STYLE_RULE_H_
 
 #include <string>
-#include <vector>
+#include <set>
 
 #include "common/analysis/lint_rule_status.h"
 #include "common/analysis/matcher/matcher.h"
@@ -62,7 +62,7 @@ class ParameterNameStyleRule : public verible::SyntaxTreeLintRule {
 
   Matcher matcher_ = NodekParamDeclaration();
 
-  std::vector<verible::LintViolation> violations_;
+  std::set<verible::LintViolation> violations_;
 };
 
 }  // namespace analysis

--- a/verilog/analysis/checkers/plusarg_assignment_rule.cc
+++ b/verilog/analysis/checkers/plusarg_assignment_rule.cc
@@ -15,7 +15,7 @@
 #include "verilog/analysis/checkers/plusarg_assignment_rule.h"
 
 #include <string>
-#include <vector>
+#include <set>
 
 #include "absl/strings/str_cat.h"
 #include "absl/strings/string_view.h"
@@ -56,7 +56,7 @@ void PlusargAssignmentRule::HandleSymbol(
   if (matcher_.Matches(symbol, &manager)) {
     if (auto leaf = manager.GetAs<verible::SyntaxTreeLeaf>("name")) {
       if (kForbiddenFunctionName == leaf->get().text) {
-        violations_.push_back(
+        violations_.insert(
             verible::LintViolation(leaf->get(), FormatReason(), context));
       }
     }

--- a/verilog/analysis/checkers/plusarg_assignment_rule.h
+++ b/verilog/analysis/checkers/plusarg_assignment_rule.h
@@ -16,7 +16,7 @@
 #define VERIBLE_VERILOG_ANALYSIS_CHECKERS_PLUSARG_ASSIGNMENT_RULE_H_
 
 #include <string>
-#include <vector>
+#include <set>
 
 #include "common/analysis/lint_rule_status.h"
 #include "common/analysis/matcher/matcher.h"
@@ -67,7 +67,7 @@ class PlusargAssignmentRule : public verible::SyntaxTreeLintRule {
       SystemTFIdentifierLeaf().Bind("name");
 
  private:
-  std::vector<verible::LintViolation> violations_;
+  std::set<verible::LintViolation> violations_;
 };
 
 }  // namespace analysis

--- a/verilog/analysis/checkers/posix_eof_rule.cc
+++ b/verilog/analysis/checkers/posix_eof_rule.cc
@@ -15,7 +15,7 @@
 #include "verilog/analysis/checkers/posix_eof_rule.h"
 
 #include <string>
-#include <vector>
+#include <set>
 
 #include "absl/strings/str_cat.h"
 #include "absl/strings/string_view.h"
@@ -55,7 +55,7 @@ void PosixEOFRule::Lint(const TextStructureView& text_structure,
     if (!last_line.empty()) {
       // Point to the end of the line (also EOF).
       const TokenInfo token(TK_OTHER, last_line.substr(last_line.length(), 0));
-      violations_.push_back(LintViolation(token, kMessage));
+      violations_.insert(LintViolation(token, kMessage));
     }
   }
 }

--- a/verilog/analysis/checkers/posix_eof_rule.h
+++ b/verilog/analysis/checkers/posix_eof_rule.h
@@ -16,7 +16,7 @@
 #define VERIBLE_VERILOG_ANALYSIS_CHECKERS_POSIX_EOF_RULE_H_
 
 #include <string>
-#include <vector>
+#include <set>
 
 #include "absl/strings/string_view.h"
 #include "common/analysis/lint_rule_status.h"
@@ -58,7 +58,7 @@ class PosixEOFRule : public verible::TextStructureLintRule {
   static const char kMessage[];
 
   // Collection of found violations.
-  std::vector<verible::LintViolation> violations_;
+  std::set<verible::LintViolation> violations_;
 };
 
 }  // namespace analysis

--- a/verilog/analysis/checkers/proper_parameter_declaration_rule.cc
+++ b/verilog/analysis/checkers/proper_parameter_declaration_rule.cc
@@ -15,7 +15,7 @@
 #include "verilog/analysis/checkers/proper_parameter_declaration_rule.h"
 
 #include <string>
-#include <vector>
+#include <set>
 
 #include "absl/strings/str_cat.h"
 #include "common/analysis/citation.h"
@@ -73,17 +73,17 @@ void ProperParameterDeclarationRule::HandleSymbol(
       // kFormalParameterList.
       if (ContextIsInsideClass(context) &&
           !ContextIsInsideFormalParameterList(context)) {
-        violations_.push_back(
+        violations_.insert(
             LintViolation(symbol, kParameterMessage, context));
       } else if (ContextIsInsideModule(context) &&
                  !ContextIsInsideFormalParameterList(context)) {
-        violations_.push_back(
+        violations_.insert(
             LintViolation(symbol, kParameterMessage, context));
       }
     } else if (param_decl_token == TK_localparam) {
       // If the context is not inside a class or module, report violation.
       if (!ContextIsInsideClass(context) && !ContextIsInsideModule(context))
-        violations_.push_back(
+        violations_.insert(
             LintViolation(symbol, kLocalParamMessage, context));
     }
   }

--- a/verilog/analysis/checkers/proper_parameter_declaration_rule.h
+++ b/verilog/analysis/checkers/proper_parameter_declaration_rule.h
@@ -16,7 +16,7 @@
 #define VERIBLE_VERILOG_ANALYSIS_CHECKERS_PROPER_PARAMETER_DECLARATION_RULE_H_
 
 #include <string>
-#include <vector>
+#include <set>
 
 #include "common/analysis/lint_rule_status.h"
 #include "common/analysis/matcher/matcher.h"
@@ -61,7 +61,7 @@ class ProperParameterDeclarationRule : public verible::SyntaxTreeLintRule {
 
   Matcher matcher_ = NodekParamDeclaration();
 
-  std::vector<verible::LintViolation> violations_;
+  std::set<verible::LintViolation> violations_;
 };
 
 }  // namespace analysis

--- a/verilog/analysis/checkers/signal_name_style_rule.cc
+++ b/verilog/analysis/checkers/signal_name_style_rule.cc
@@ -15,7 +15,7 @@
 #include "verilog/analysis/checkers/signal_name_style_rule.h"
 
 #include <string>
-#include <vector>
+#include <set>
 
 #include "absl/strings/str_cat.h"
 #include "common/analysis/citation.h"
@@ -66,21 +66,21 @@ void SignalNameStyleRule::HandleSymbol(const verible::Symbol& symbol,
         GetIdentifierFromModulePortDeclaration(symbol);
     const auto name = ABSL_DIE_IF_NULL(identifier_leaf)->get().text;
     if (!verible::IsLowerSnakeCaseWithDigits(name))
-      violations_.push_back(
+      violations_.insert(
           LintViolation(identifier_leaf->get(), kMessage, context));
   } else if (matcher_net_.Matches(symbol, &manager)) {
     const auto identifier_leaves = GetIdentifiersFromNetDeclaration(symbol);
     for (auto& leaf : identifier_leaves) {
       const auto name = leaf->text;
       if (!verible::IsLowerSnakeCaseWithDigits(name))
-        violations_.push_back(LintViolation(*leaf, kMessage, context));
+        violations_.insert(LintViolation(*leaf, kMessage, context));
     }
   } else if (matcher_data_.Matches(symbol, &manager)) {
     const auto identifier_leaves = GetIdentifiersFromDataDeclaration(symbol);
     for (auto& leaf : identifier_leaves) {
       const auto name = leaf->text;
       if (!verible::IsLowerSnakeCaseWithDigits(name))
-        violations_.push_back(LintViolation(*leaf, kMessage, context));
+        violations_.insert(LintViolation(*leaf, kMessage, context));
     }
   }
 }

--- a/verilog/analysis/checkers/signal_name_style_rule.h
+++ b/verilog/analysis/checkers/signal_name_style_rule.h
@@ -16,7 +16,7 @@
 #define VERIBLE_VERILOG_ANALYSIS_CHECKERS_SIGNAL_NAME_STYLE_RULE_H_
 
 #include <string>
-#include <vector>
+#include <set>
 
 #include "common/analysis/lint_rule_status.h"
 #include "common/analysis/matcher/matcher.h"
@@ -60,7 +60,7 @@ class SignalNameStyleRule : public verible::SyntaxTreeLintRule {
   Matcher matcher_net_ = NodekNetDeclaration();
   Matcher matcher_data_ = NodekDataDeclaration();
 
-  std::vector<verible::LintViolation> violations_;
+  std::set<verible::LintViolation> violations_;
 };
 
 }  // namespace analysis

--- a/verilog/analysis/checkers/struct_union_name_style_rule.cc
+++ b/verilog/analysis/checkers/struct_union_name_style_rule.cc
@@ -15,7 +15,7 @@
 #include "verilog/analysis/checkers/struct_union_name_style_rule.h"
 
 #include <string>
-#include <vector>
+#include <set>
 
 #include "absl/strings/match.h"
 #include "absl/strings/str_cat.h"
@@ -75,7 +75,7 @@ void StructUnionNameStyleRule::HandleSymbol(const verible::Symbol& symbol,
     const auto name = ABSL_DIE_IF_NULL(identifier_leaf)->get().text;
     if (!verible::IsLowerSnakeCaseWithDigits(name) ||
         !absl::EndsWith(name, "_t")) {
-      violations_.push_back(
+      violations_.insert(
           LintViolation(identifier_leaf->get(), msg, context));
     }
   }

--- a/verilog/analysis/checkers/struct_union_name_style_rule.h
+++ b/verilog/analysis/checkers/struct_union_name_style_rule.h
@@ -16,7 +16,7 @@
 #define VERIBLE_VERILOG_ANALYSIS_CHECKERS_STRUCT_UNION_NAME_STYLE_RULE_H_
 
 #include <string>
-#include <vector>
+#include <set>
 
 #include "common/analysis/lint_rule_status.h"
 #include "common/analysis/matcher/matcher.h"
@@ -58,7 +58,7 @@ class StructUnionNameStyleRule : public verible::SyntaxTreeLintRule {
 
   Matcher matcher_typedef_ = NodekTypeDeclaration();
 
-  std::vector<verible::LintViolation> violations_;
+  std::set<verible::LintViolation> violations_;
 };
 
 }  // namespace analysis

--- a/verilog/analysis/checkers/undersized_binary_literal_rule.cc
+++ b/verilog/analysis/checkers/undersized_binary_literal_rule.cc
@@ -16,7 +16,7 @@
 
 #include <cstddef>
 #include <string>
-#include <vector>
+#include <set>
 
 #include "absl/strings/numbers.h"
 #include "absl/strings/str_cat.h"
@@ -81,7 +81,7 @@ void UndersizedBinaryLiteralRule::HandleSymbol(
             CHECK_EQ(number.base,
                      'b');  // guaranteed by matching TK_BinBase
             if (width > number.literal.length() && number.literal != "0") {
-              violations_.push_back(LintViolation(
+              violations_.insert(LintViolation(
                   digits_leaf->get(),
                   FormatReason(width_text, base_text, digits_text), context));
             }

--- a/verilog/analysis/checkers/undersized_binary_literal_rule.h
+++ b/verilog/analysis/checkers/undersized_binary_literal_rule.h
@@ -16,7 +16,7 @@
 #define VERIBLE_VERILOG_ANALYSIS_CHECKERS_UNDERSIZED_BINARY_LITERAL_RULE_H_
 
 #include <string>
-#include <vector>
+#include <set>
 
 #include "absl/strings/string_view.h"
 #include "common/analysis/lint_rule_status.h"
@@ -67,7 +67,7 @@ class UndersizedBinaryLiteralRule : public verible::SyntaxTreeLintRule {
       NumberHasBasedLiteral(NumberIsBinary().Bind("base"),
                             NumberHasBinaryDigits().Bind("digits")));
 
-  std::vector<verible::LintViolation> violations_;
+  std::set<verible::LintViolation> violations_;
 };
 
 }  // namespace analysis

--- a/verilog/analysis/checkers/unpacked_dimensions_rule.cc
+++ b/verilog/analysis/checkers/unpacked_dimensions_rule.cc
@@ -15,7 +15,7 @@
 #include "verilog/analysis/checkers/unpacked_dimensions_rule.h"
 
 #include <string>
-#include <vector>
+#include <set>
 
 #include "absl/strings/str_cat.h"
 #include "absl/strings/string_view.h"
@@ -89,14 +89,14 @@ void UnpackedDimensionsRule::HandleSymbol(
     const verible::TokenInfo token(TK_OTHER,
                                    verible::StringSpanOfSymbol(left, right));
     if (left_is_zero) {
-      violations_.push_back(
+      violations_.insert(
           LintViolation(token, kMessageScalarInOrder, context));
     } else if (right_is_zero) {
-      violations_.push_back(
+      violations_.insert(
           LintViolation(token, kMessageScalarReversed, context));
     } else if (left_is_constant && right_is_constant &&
                left_value > right_value) {
-      violations_.push_back(LintViolation(token, kMessageReorder, context));
+      violations_.insert(LintViolation(token, kMessageReorder, context));
     }
   }
 }

--- a/verilog/analysis/checkers/unpacked_dimensions_rule.h
+++ b/verilog/analysis/checkers/unpacked_dimensions_rule.h
@@ -16,7 +16,7 @@
 #define VERIBLE_VERILOG_ANALYSIS_CHECKERS_UNPACKED_DIMENSIONS_RULE_H_
 
 #include <string>
-#include <vector>
+#include <set>
 
 #include "common/analysis/lint_rule_status.h"
 #include "common/analysis/matcher/matcher.h"
@@ -52,7 +52,7 @@ class UnpackedDimensionsRule : public verible::SyntaxTreeLintRule {
   // Link to style guide rule.
   static const char kTopic[];
 
-  std::vector<verible::LintViolation> violations_;
+  std::set<verible::LintViolation> violations_;
 };
 
 }  // namespace analysis

--- a/verilog/analysis/checkers/v2001_generate_begin_rule.cc
+++ b/verilog/analysis/checkers/v2001_generate_begin_rule.cc
@@ -15,7 +15,7 @@
 #include "verilog/analysis/checkers/v2001_generate_begin_rule.h"
 
 #include <string>
-#include <vector>
+#include <set>
 
 #include "absl/strings/str_cat.h"
 #include "common/analysis/citation.h"
@@ -59,7 +59,7 @@ void V2001GenerateBeginRule::HandleSymbol(
   verible::matcher::BoundSymbolManager manager;
   if (matcher_.Matches(symbol, &manager)) {
     if (const auto* block = manager.GetAs<verible::SyntaxTreeNode>("block")) {
-      violations_.push_back(LintViolation(
+      violations_.insert(LintViolation(
           verible::GetLeftmostLeaf(*block)->get(), kMessage, context));
     }
   }

--- a/verilog/analysis/checkers/v2001_generate_begin_rule.h
+++ b/verilog/analysis/checkers/v2001_generate_begin_rule.h
@@ -16,7 +16,7 @@
 #define VERIBLE_VERILOG_ANALYSIS_CHECKERS_V2001_GENERATE_BEGIN_RULE_H_
 
 #include <string>
-#include <vector>
+#include <set>
 
 #include "common/analysis/lint_rule_status.h"
 #include "common/analysis/matcher/matcher.h"
@@ -66,7 +66,7 @@ class V2001GenerateBeginRule : public verible::SyntaxTreeLintRule {
   // Diagnostic message.
   static const char kMessage[];
 
-  std::vector<verible::LintViolation> violations_;
+  std::set<verible::LintViolation> violations_;
 };
 
 }  // namespace analysis

--- a/verilog/analysis/checkers/void_cast_rule.cc
+++ b/verilog/analysis/checkers/void_cast_rule.cc
@@ -16,7 +16,7 @@
 
 #include <set>
 #include <string>
-#include <vector>
+#include <set>
 
 #include "absl/strings/str_cat.h"
 #include "absl/strings/string_view.h"
@@ -69,7 +69,7 @@ void VoidCastRule::HandleSymbol(const verible::Symbol& symbol,
     if (auto function_id = manager.GetAs<verible::SyntaxTreeLeaf>("id")) {
       const auto& bfs = BlacklistedFunctionsSet();
       if (bfs.find(std::string(function_id->get().text)) != bfs.end()) {
-        violations_.push_back(LintViolation(
+        violations_.insert(LintViolation(
             function_id->get(), FormatReason(*function_id), context));
       }
     }
@@ -81,7 +81,7 @@ void VoidCastRule::HandleSymbol(const verible::Symbol& symbol,
     if (auto randomize_node = manager.GetAs<verible::SyntaxTreeNode>("id")) {
       auto leaf_ptr = verible::GetLeftmostLeaf(*randomize_node);
       const verible::TokenInfo token = ABSL_DIE_IF_NULL(leaf_ptr)->get();
-      violations_.push_back(LintViolation(
+      violations_.insert(LintViolation(
           token, "randomize() is forbidden within void casts", context));
     }
   }

--- a/verilog/analysis/checkers/void_cast_rule.h
+++ b/verilog/analysis/checkers/void_cast_rule.h
@@ -17,7 +17,7 @@
 
 #include <set>
 #include <string>
-#include <vector>
+#include <set>
 
 #include "common/analysis/lint_rule_status.h"
 #include "common/analysis/matcher/core_matchers.h"
@@ -82,7 +82,7 @@ class VoidCastRule : public verible::SyntaxTreeLintRule {
       verible::matcher::AnyOf(ExpressionHasRandomizeCallExtension().Bind("id"),
                               ExpressionHasRandomizeFunction().Bind("id"))));
 
-  std::vector<verible::LintViolation> violations_;
+  std::set<verible::LintViolation> violations_;
 };
 
 }  // namespace analysis

--- a/verilog/analysis/verilog_linter.cc
+++ b/verilog/analysis/verilog_linter.cc
@@ -238,10 +238,8 @@ verible::util::Status VerilogLintTextStructure(
     VLOG(1) << "Lint Violations (" << total_violations << "): " << std::endl;
     // Output results to stream using formatter.
     verible::LintStatusFormatter formatter(contents);
-    for (const auto& report_status : linter_statuses) {
-      formatter.FormatLintRuleStatus(stream, report_status, text_base,
+    formatter.FormatLintRuleStatuses(stream, linter_statuses, text_base,
                                      filename);
-    }
   }
   return verible::util::OkStatus();
 }


### PR DESCRIPTION
This PR addresses an issue described here: https://github.com/google/verible/pull/88#discussion_r357854849

Copy for reference:

> It may even be a good idea to sort the violations some time before they are eventually reported to stdout; it is reasonable for users to expect violations to be reported in location order. Multiple ways this could be done, e.g. overrideable virtual function hook in LintRule to perform arbitrary actions on-finish (which would address unit-testing), or collect all violations after all checks are run and do a one-time final sort before printing. I suggest filing this (total ordering) as a separate issue, to keep this PR focused.

There are two patches, one solves the issue which can be seen in the test cases (see #88).
The other sorts the lint violations before printing them, for example, for:
```
module top;
  wire UglyWire;

  initial begin : first_label
    for(int i=0; i<5; ++i)
    begin : second_label
    end : i_second_label
  end : i_first_label

  wire A_sfds_asda;
endmodule
```

We get:
```
top.sv:2:8: Signal names must use lower_snake_case naming convention. [Style: signal-conventions] [signal-name-style]
top.sv:7:11: Begin/end block labels must match. [Style: mismatched-labels] [mismatched-labels]
top.sv:8:9: Begin/end block labels must match. [Style: mismatched-labels] [mismatched-labels]
top.sv:10:8: Signal names must use lower_snake_case naming convention. [Style: signal-conventions] [signal-name-style]
```
Instead of:
```                 
top.sv:10:8: Signal names must use lower_snake_case naming convention. [Style: signal-conventions] [signal-name-style]
top.sv:2:8: Signal names must use lower_snake_case naming convention. [Style: signal-conventions] [signal-name-style]
top.sv:7:11: Begin/end block labels must match. [Style: mismatched-labels] [mismatched-labels]                       
top.sv:8:9: Begin/end block labels must match. [Style: mismatched-labels] [mismatched-labels
```

Note that the printed violations are no longer grouped by lint rules and correctly sorted.

The test cases are not added to this PR yet, as I think there may be a better way to approach the sorting. If so, please feel free to criticize and point me in the right directions. Thanks!