### PR TITLE
Start new partition when else clause doesn't follow end keyword

### DIFF
--- a/verilog/formatting/formatter_test.cc
+++ b/verilog/formatting/formatter_test.cc
@@ -2321,6 +2321,17 @@ static const std::initializer_list<FormatterTestCase>
          "      f.g(h);\n"
          "  end\n"
          "endmodule\n"},
+        {"module m;initial begin if(a==b)"
+         "a|=b;else\n"
+         "a&=~b;end endmodule",
+         "module m;\n"
+         "  initial begin\n"
+         "    if (a == b)\n"
+         "      a |= b;\n"
+         "    else\n"
+         "      a &= ~b;\n"
+         "  end\n"
+         "endmodule\n"},
         {"   module m;  always_comb    begin     \n"
          "        if      ( a   ) b =  16'hdead    ; \n"
          "  else if (   c     )  d= 16 'hbeef  ;   \n"

--- a/verilog/formatting/tree_unwrapper.cc
+++ b/verilog/formatting/tree_unwrapper.cc
@@ -650,6 +650,7 @@ void TreeUnwrapper::Visit(const verible::SyntaxTreeNode& node) {
     case NodeEnum::kBlockingAssignmentStatement:     // id=expr
     case NodeEnum::kNonblockingAssignmentStatement:  // dest <= src;
     case NodeEnum::kAssignmentStatement:             // id=expr
+    case NodeEnum::kAssignModifyStatement:           // e.g. id |= expr
     case NodeEnum::kProceduralTimingControlStatement: {
       if (IsTopLevelListItem(Context())) {
         VisitIndentedSection(node, 0,

--- a/verilog/formatting/tree_unwrapper_test.cc
+++ b/verilog/formatting/tree_unwrapper_test.cc
@@ -3216,6 +3216,23 @@ const TreeUnwrapperTestData kUnwrapFunctionTestCases[] = {
     },
 
     {
+        "function with if-else branches, single-assign-modify-statements",
+        "function foo;"
+        "if (zz) "
+        "a |= b;"
+        "else "
+        "a &= ~b;"
+        "endfunction",
+        FunctionHeader(0, L(0, {"function", "foo", ";"})),
+        StatementList(1,
+                      FlowControl(1,  //
+                                  L(1, {"if", "(", "zz", ")"}),
+                                  NL(2, {"a", "|=", "b", ";"}), L(1, {"else"}),
+                                  NL(2, {"a", "&=", "~", "b", ";"}))),
+        L(0, {"endfunction"}),
+    },
+
+    {
         "function with for loop",
         "function foo;"
         "for (x=0;x<N;++x) begin "


### PR DESCRIPTION
Fix #95 