### PR TITLE
Add depolyment to Travis builds

### DIFF
--- a/.github/kokoro/run.sh
+++ b/.github/kokoro/run.sh
@@ -1,4 +1,17 @@
 #!/bin/bash
+# Copyright 2020 The Verible Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 set -e
 

--- a/.github/kokoro/steps/compiler.sh
+++ b/.github/kokoro/steps/compiler.sh
@@ -1,4 +1,17 @@
 #!/bin/bash
+# Copyright 2020 The Verible Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 set -e
 

--- a/.github/kokoro/steps/convert-logs.sh
+++ b/.github/kokoro/steps/convert-logs.sh
@@ -1,4 +1,17 @@
 #!/bin/bash
+# Copyright 2020 The Verible Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 mkdir -p "$KOKORO_ARTIFACTS_DIR/bazel_test_logs"
 # rename all test.log to sponge_log.log and then copy them to the kokoro

--- a/.github/kokoro/steps/git.sh
+++ b/.github/kokoro/steps/git.sh
@@ -1,4 +1,17 @@
 #!/bin/bash
+# Copyright 2020 The Verible Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 set -e
 

--- a/.github/kokoro/steps/hostinfo.sh
+++ b/.github/kokoro/steps/hostinfo.sh
@@ -1,4 +1,17 @@
 #!/bin/bash
+# Copyright 2020 The Verible Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 set -e
 

--- a/.github/kokoro/steps/hostsetup.sh
+++ b/.github/kokoro/steps/hostsetup.sh
@@ -1,4 +1,17 @@
 #!/bin/bash
+# Copyright 2020 The Verible Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 set -e
 

--- a/.github/travis/github-pages-setup.sh
+++ b/.github/travis/github-pages-setup.sh
@@ -1,0 +1,164 @@
+#!/bin/bash
+# Copyright 2020 The Verible Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# GitHub Pages
+# ---------------
+# Generate the GitHub pages to deploy
+
+GIT_DATE=$(git show -s --format=%ci)
+GIT_VERSION=$(git describe --match=v*)
+GIT_HASH=$(git rev-parse HEAD)
+
+PAGES_DIR=/tmp/pages
+rm -rf $PAGES_DIR
+mkdir -p $PAGES_DIR
+
+# Copy across the current markdown files
+# --------------------------------
+cp -a *.md $PAGES_DIR/
+cp -a AUTHORS $PAGES_DIR/AUTHORS.md
+
+# Generate an index page
+# --------------------------------
+INDEX_DOC=$PAGES_DIR/index.md
+
+# Copy the top of the README.md
+sed -e '/## /,$d' README.md > $INDEX_DOC
+# Add links to other documents
+cat >> $INDEX_DOC <<EOF
+
+See the [README file for further information.](README.md)
+
+## Tools
+
+ * [verilog_lint Info](verilog_lint.md)
+ * [verilog_format Info](verilog_format.md)
+ * [verilog_syntax Info](verilog_syntax.md)
+
+## Information
+
+ * [Code - https://github.com/$TRAVIS_REPO_SLUG](https://github.com/$TRAVIS_REPO_SLUG)
+ * [Binaries - https://github.com/$TRAVIS_REPO_SLUG/releases](https://github.com/$TRAVIS_REPO_SLUG/releases)
+ * [Bug Reports - https://github.com/$TRAVIS_REPO_SLUG/issues/new](https://github.com/$TRAVIS_REPO_SLUG/issues/new)
+ * [Lint Rules](lint.md)
+ * [Further Information](README.md)
+
+## Authors
+
+ * [Contributing](CONTRIBUTING.md)
+ * [Authors](AUTHORS.md)
+ * [License Information](license.md)
+
+## Version
+
+Generated on $GIT_DATE from [$GIT_VERSION](https://github.com/$TRAVIS_REPO_SLUG/commit/$GIT_HASH)
+EOF
+
+# Add markdown version of Apache 2.0 license
+# --------------------------------
+wget https://raw.githubusercontent.com/IQAndreas/markdown-licenses/master/apache-v2.0.md -O $PAGES_DIR/license.md
+
+# Generate lint rules documentation
+# --------------------------------
+bazel-bin/verilog/tools/lint/verilog_lint -generate_markdown > $PAGES_DIR/lint.md
+cat >> $PAGES_DIR/lint.md <<EOF
+
+## Version
+
+Generated on $GIT_DATE from [$GIT_VERSION](https://github.com/$TRAVIS_REPO_SLUG/commit/$GIT_HASH)
+EOF
+
+# Generate docs for verilog_syntax
+# --------------------------------
+SYNTAX_DOC=$PAGES_DIR/verilog_syntax.md
+cat > $SYNTAX_DOC <<EOF
+# \`verilog_syntax\`
+
+Tool for looking at the syntax of Verilog and SystemVerilog code. Part of the
+verible tool suite.
+
+## Command line arguments
+\`\`\`
+EOF
+bazel-bin/verilog/tools/syntax/verilog_syntax -helpfull >> $SYNTAX_DOC
+cat >> $SYNTAX_DOC <<EOF
+\`\`\`
+
+## Version
+
+Generated on $GIT_DATE from [$GIT_VERSION](https://github.com/$TRAVIS_REPO_SLUG/commit/$GIT_HASH)
+EOF
+
+
+# Generate docs for verilog_lint
+# --------------------------------
+LINT_DOC=$PAGES_DIR/verilog_lint.md
+cat > $LINT_DOC <<EOF
+# \`verilog_lint\`
+
+Tool for formatting Verilog and SystemVerilog code. Part of the verible tool
+suite.
+
+## Command line arguments
+
+\`\`\`
+EOF
+bazel-bin/verilog/tools/lint/verilog_lint -helpfull >> $LINT_DOC
+cat >> $LINT_DOC <<'EOF'
+```
+
+## Lint Rules
+
+EOF
+bazel-bin/verilog/tools/lint/verilog_lint -generate_markdown >> $LINT_DOC
+cat >> $LINT_DOC <<EOF
+
+## Version
+
+Generated on $GIT_DATE from [$GIT_VERSION](https://github.com/$TRAVIS_REPO_SLUG/commit/$GIT_HASH)
+EOF
+
+# Generate docs for verilog_format
+# --------------------------------
+FORMAT_DOC=$PAGES_DIR/verilog_format.md
+cat > $FORMAT_DOC <<EOF
+# \`verilog_format\`
+
+Tool for formatting Verilog and SystemVerilog code. Part of the verible tool
+suite.
+
+## Command line arguments
+\`\`\`
+EOF
+bazel-bin/verilog/tools/formatter/verilog_format -helpfull >> $FORMAT_DOC
+cat >> $FORMAT_DOC <<EOF
+\`\`\`
+
+## Version
+
+Generated on $GIT_DATE from [$GIT_VERSION](https://github.com/$TRAVIS_REPO_SLUG/commit/$GIT_HASH)
+EOF
+
+# Add jekyll front matter to all markdown pages.
+# ----------------------------------------------
+for MD in $PAGES_DIR/*; do
+    cat > $MD.new <<EOF
+---
+---
+
+EOF
+    cat $MD >> $MD.new
+    mv $MD.new $MD
+done

--- a/.github/travis/github-releases-setup.sh
+++ b/.github/travis/github-releases-setup.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+# Copyright 2020 The Verible Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# GitHub Releases
+# ---------------
+# Generate the GitHub Releases to deploy
+
+RELEASE_DIR=/tmp/releases
+rm -rf $RELEASE_DIR
+
+PREFIX=$RELEASE_DIR/verible-$TRAVIS_TAG
+PREFIX_BIN=$PREFIX/bin
+PREFIX_DOC=$PREFIX/share/verible
+PREFIX_MAN=$PREFIX/share/man/man1
+mkdir -p $PREFIX
+mkdir -p $PREFIX_BIN
+mkdir -p $PREFIX_DOC
+mkdir -p $PREFIX_MAN
+
+# Binaries
+cp -a bazel-bin/verilog/tools/syntax/verilog_syntax     $PREFIX_BIN
+cp -a bazel-bin/verilog/tools/lint/verilog_lint         $PREFIX_BIN
+cp -a bazel-bin/verilog/tools/formatter/verilog_format  $PREFIX_BIN
+
+for BIN in $PREFIX_BIN/*; do
+    ls -l $BIN
+    file $BIN
+    ldd $BIN
+done
+
+# Documentation
+cp -a /tmp/pages/* $PREFIX_DOC
+# Man pages
+gflags2man --help_flag="--helpfull" --dest_dir $PREFIX_MAN bazel-bin/verilog/tools/syntax/verilog_syntax
+gzip $PREFIX_MAN/verilog_lint.1
+gflags2man --help_flag="--helpfull" --dest_dir $PREFIX_MAN bazel-bin/verilog/tools/lint/verilog_lint
+gzip $PREFIX_MAN/verilog_lint.1
+gflags2man  --help_flag="--helpfull" --dest_dir $PREFIX_MAN bazel-bin/verilog/tools/formatter/verilog_format
+gzip $PREFIX_MAN/verilog_format.1
+
+DISTRO=$(lsb_release --short --id)
+DISTRO_RELEASE=$(lsb_release --short --release)
+DISTRO_CODENAME=$(lsb_release --short --codename)
+TARBALL=$RELEASE_DIR/verible-$TRAVIS_TAG-$TRAVIS_OS_NAME-$TRAVIS_CPU_ARCH-$DISTRO-$DISTRO_RELEASE-$DISTRO_CODENAME.tar.gz
+(
+    cd $RELEASE_DIR
+    tar -zcvf $TARBALL verible-$TRAVIS_TAG
+)

--- a/.github/travis/install-bazel.sh
+++ b/.github/travis/install-bazel.sh
@@ -13,14 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-find -L -name \*.log
-for F in $(find -L -name \*.log); do
-    echo
-    export FOLD_NAME=$(echo $F | sed -e's/[^A-Za-z0-9]/_/g')
-    travis_fold start $FOLD_NAME
-    echo -e "\n\n$F\n--------------"
-    cat $F
-    echo "--------------"
-    travis_fold end $FOLD_NAME
-    echo
-done
+wget https://github.com/bazelbuild/bazel/releases/download/1.2.0/bazel_1.2.0-linux-x86_64.deb -O /tmp/bazel.deb
+sudo dpkg -i /tmp/bazel.deb || true
+sudo apt-get -f install
+bazel --version

--- a/.github/travis/set-compiler.sh
+++ b/.github/travis/set-compiler.sh
@@ -13,14 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-find -L -name \*.log
-for F in $(find -L -name \*.log); do
-    echo
-    export FOLD_NAME=$(echo $F | sed -e's/[^A-Za-z0-9]/_/g')
-    travis_fold start $FOLD_NAME
-    echo -e "\n\n$F\n--------------"
-    cat $F
-    echo "--------------"
-    travis_fold end $FOLD_NAME
-    echo
-done
+VERSION=$1
+
+sudo dpkg --list | grep gcc
+sudo ln -sf /usr/bin/gcc-$VERSION /usr/bin/gcc
+sudo ln -sf /usr/bin/g++-$VERSION /usr/bin/g++
+gcc --version || true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,57 @@
-dist: bionic
-
 language: cpp
 
-compiler:
-  - gcc
+# Don't build auto-generated tags
+if: NOT tag =~ /v[0-9.]*-.*/
 
-addons:
-  apt:
-    packages:
-      - g++-8
+git:
+  depth: false
+
+jobs:
+  include:
+   - stage: "Test"
+     name: "Ubuntu Trusty"
+     os: linux
+     dist: trusty
+     addons:
+       apt:
+         sources:
+         - ubuntu-toolchain-r-test
+         packages:
+         - g++-9
+         - gcc-9
+         - pandoc
+         - python-gflags
+   - stage: "Test"
+     name: "Ubuntu Xenial"
+     os: linux
+     dist: xenial
+     addons:
+       apt:
+         sources:
+         - ubuntu-toolchain-r-test
+         packages:
+         - g++-9
+         - gcc-9
+         - pandoc
+         - python-gflags
+#   - stage: "Test"
+#     name: "Ubuntu Bionic"
+#     os: linux
+#     dist: bionic
+#     addons:
+#       apt:
+#         sources:
+#         - ubuntu-toolchain-r-test
+#         packages:
+#         - g++-9
+#         - gcc-9
+#         - pandoc
+#         - python-gflags
 
 before_install:
-  - wget https://github.com/bazelbuild/bazel/releases/download/1.1.0/bazel_1.1.0-linux-x86_64.deb
-  - sudo dpkg -i bazel_1.1.0-linux-x86_64.deb
+  - ./.github/travis/set-compiler.sh 9
+  - ./.github/travis/install-bazel.sh 9
+  - git fetch --tags
 
 script:
   - bazel build --noshow_progress --cxxopt='-std=c++17' //...
@@ -20,3 +59,40 @@ script:
 
 after_failure:
   - source .github/travis/output-logs.sh
+
+after_success:
+  - git config --local user.name "Deployment Bot"
+  - git config --local user.email "verible-dev@googlegroups.com"
+  # Create a tag of form v0.0-183-gdf2b162-20191112132344
+  - export TRAVIS_TAG=${TRAVIS_TAG:-$(git describe --match=v*)}
+  - git tag $TRAVIS_TAG || true
+  # Set up things for GitHub Pages deployment
+  - ./.github/travis/github-pages-setup.sh
+  # Set up things for GitHub Releases deployment
+  - ./.github/travis/github-releases-setup.sh
+
+before_deploy:
+  - find /tmp/pages | sort
+  - find /tmp/releases | sort
+
+# For deploy to work, you must https://travis-ci.org/$USER/verible/settings and
+# add the following environment values;
+# OCTOKIT_ACCESS_TOKEN - Personal access token from https://github.com/settings/tokens
+# OCTOKIT_LOGIN - Your Github username
+# OCTOKIT_PASSWORD - Same as OCTOKIT_ACCESS_TOKEN above
+deploy:
+ - provider: pages
+   skip_cleanup: true
+   keep_history: true
+   github_token: $OCTOKIT_ACCESS_TOKEN
+   local_dir: /tmp/pages
+   on:
+     branch: master
+ - provider: releases
+   file_glob: true
+   username: $OCTOKIT_LOGIN
+   password: $OCTOKIT_PASSWORD
+   file:
+    - /tmp/releases/verible-*.tar.gz
+   overwrite: true
+   skip_cleanup: true


### PR DESCRIPTION
 * Deploy markdown pages to Github pages (including generated output from verilog_lint). See https://mithro.github.io/verible/ for example output.
 * Deploy precompiled binaries to Github releases. See https://github.com/mithro/verible/releases for example output.