### PR TITLE
Parameter type name rule

### DIFF
--- a/verilog/analysis/checkers/BUILD
+++ b/verilog/analysis/checkers/BUILD
@@ -1302,6 +1302,20 @@ cc_library(
     alwayslink = 1,
 )
 
+cc_test(
+    name = "parameter_type_name_style_rule_test",
+    srcs = ["parameter_type_name_style_rule_test.cc"],
+    deps = [
+        ":parameter_type_name_style_rule",
+        "//common/analysis:linter_test_utils",
+        "//common/analysis:syntax_tree_linter_test_utils",
+        "//common/text:symbol",
+        "//verilog/CST:verilog_nonterminals",
+        "//verilog/analysis:verilog_analyzer",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
 cc_library(
     name = "proper_parameter_declaration_rule",
     srcs = ["proper_parameter_declaration_rule.cc"],

--- a/verilog/analysis/checkers/BUILD
+++ b/verilog/analysis/checkers/BUILD
@@ -45,6 +45,7 @@ cc_library(
         ":package_filename_rule",
         ":packed_dimensions_rule",
         ":parameter_name_style_rule",
+        ":parameter_type_name_style_rule",
         ":plusarg_assignment_rule",
         ":posix_eof_rule",
         ":proper_parameter_declaration_rule",
@@ -1274,6 +1275,31 @@ cc_test(
         "//verilog/analysis:verilog_analyzer",
         "@com_google_googletest//:gtest_main",
     ],
+)
+
+cc_library(
+    name = "parameter_type_name_style_rule",
+    srcs = ["parameter_type_name_style_rule.cc"],
+    hdrs = ["parameter_type_name_style_rule.h"],
+    deps = [
+        "//common/analysis:citation",
+        "//common/analysis:lint_rule_status",
+        "//common/analysis:syntax_tree_lint_rule",
+        "//common/analysis/matcher",
+        "//common/analysis/matcher:bound_symbol_manager",
+        "//common/analysis/matcher:matcher_builders",
+        "//common/strings:naming_utils",
+        "//common/text:symbol",
+        "//common/text:syntax_tree_context",
+        "//common/text:token_info",
+        "//verilog/CST:parameters",
+        "//verilog/CST:verilog_matchers",
+        "//verilog/analysis:descriptions",
+        "//verilog/analysis:lint_rule_registry",
+        "//verilog/parser:verilog_token_enum",
+        "@com_google_absl//absl/strings",
+    ],
+    alwayslink = 1,
 )
 
 cc_library(

--- a/verilog/analysis/checkers/parameter_name_style_rule.cc
+++ b/verilog/analysis/checkers/parameter_name_style_rule.cc
@@ -47,16 +47,16 @@ absl::string_view ParameterNameStyleRule::Name() {
 }
 const char ParameterNameStyleRule::kTopic[] = "constants";
 const char ParameterNameStyleRule::kParameterMessage[] =
-    "Parameter names must be styled with UpperCamelCase or ALL_CAPS.";
+    "Non-type parameter names must be styled with UpperCamelCase or ALL_CAPS.";
 const char ParameterNameStyleRule::kLocalParamMessage[] =
-    "Localparam names must be styled with UpperCamelCase.";
+    "Non-type localparam names must be styled with UpperCamelCase.";
 
 std::string ParameterNameStyleRule::GetDescription(
     DescriptionType description_type) {
   return absl::StrCat(
-      "Checks that parameter names follow UpperCamelCase or ALL_CAPS naming "
-      "convention and that localparam names follow UpperCamelCase naming "
-      "convention. See ",
+      "Checks that non-type parameter names follow UpperCamelCase or ALL_CAPS "
+      "naming convention and that localparam names follow UpperCamelCase "
+      "naming convention. See ",
       GetStyleGuideCitation(kTopic), ".");
 }
 
@@ -68,9 +68,9 @@ void ParameterNameStyleRule::HandleSymbol(const verible::Symbol& symbol,
 
     const verible::TokenInfo* param_name_token = nullptr;
     if (IsParamTypeDeclaration(symbol))
-      param_name_token = &GetSymbolIdentifierFromParamDeclaration(symbol);
-    else
-      param_name_token = &GetParameterNameToken(symbol);
+      return;
+
+    param_name_token = &GetParameterNameToken(symbol);
 
     const auto param_name = param_name_token->text;
     if (param_decl_token == TK_localparam) {

--- a/verilog/analysis/checkers/parameter_name_style_rule.h
+++ b/verilog/analysis/checkers/parameter_name_style_rule.h
@@ -30,8 +30,8 @@
 namespace verilog {
 namespace analysis {
 
-// ParameterNameStyleRule checks that each parameter/localparam follows the
-// correct naming convention.
+// ParameterNameStyleRule checks that each non-type parameter/localparam
+// follows the correct naming convention.
 // parameter should follow UpperCamelCase (preferred) or ALL_CAPS.
 // localparam should follow UpperCamelCase.
 class ParameterNameStyleRule : public verible::SyntaxTreeLintRule {

--- a/verilog/analysis/checkers/parameter_name_style_rule_test.cc
+++ b/verilog/analysis/checkers/parameter_name_style_rule_test.cc
@@ -36,8 +36,8 @@ TEST(ParameterNameStyleRuleTest, AcceptTests) {
       {""},
       {"module foo; endmodule"},
       {"module foo (input bar); endmodule"},
-      {"module foo; localparam Bar = 1; endmodule"},
       {"module foo; localparam type Bar_1 = 1; endmodule"},
+      {"module foo; localparam Bar = 1; endmodule"},
       {"module foo; localparam int Bar = 1; endmodule"},
       {"module foo; parameter int HelloWorld = 1; endmodule"},
       {"module foo #(parameter int HelloWorld_1 = 1); endmodule"},
@@ -53,6 +53,11 @@ TEST(ParameterNameStyleRuleTest, AcceptTests) {
       {"parameter int Foo = 1;"},
       {"parameter type FooBar;"},
       {"parameter Foo = 1;"},
+
+      // Make sure parameter type triggers no violation
+      {"module foo; localparam type Bar_Hello_1 = 1; endmodule"},
+      {"module foo #(parameter type Bar_1_Hello__); endmodule"},
+      {"package foo; parameter type Hello_world; endpackage"},
   };
   RunLintTestCases<VerilogAnalyzer, ParameterNameStyleRule>(kTestCases);
 }
@@ -63,16 +68,10 @@ TEST(ParameterNameStyleRuleTest, RejectTests) {
   const std::initializer_list<LintTestCase> kTestCases = {
       {"module foo; localparam ", {kToken, "Bar_Hello"}, " = 1; endmodule"},
       {"module foo; localparam int ", {kToken, "Bar_Hello"}, " = 1; endmodule"},
-      {"module foo; localparam type ",
-       {kToken, "Bar_Hello_1"},
-       " = 1; endmodule"},
       {"module foo; parameter int ", {kToken, "__Bar"}, " = 1; endmodule"},
       {"module foo #(parameter int ",
        {kToken, "Bar_1_Hello"},
        " = 1); endmodule"},
-      {"module foo #(parameter type ",
-       {kToken, "Bar_1_Hello__"},
-       "); endmodule"},
       {"module foo #(int ", {kToken, "Bar_1_Two"}, "); endmodule"},
       {"module foo; localparam int ",
        {kToken, "bar"},
@@ -91,7 +90,6 @@ TEST(ParameterNameStyleRuleTest, RejectTests) {
       {"package foo; parameter ", {kToken, "hello__1"}, " = 1; endpackage"},
       {"package foo; parameter ", {kToken, "HELLO_WORLd"}, " = 1; endpackage"},
       {"package foo; parameter int ", {kToken, "_1Bar"}, " = 1; endpackage"},
-      {"package foo; parameter type ", {kToken, "Hello_world"}, "; endpackage"},
       {"package foo; parameter int ",
        {kToken, "HELLO_World"},
        " = 1; parameter int ",

--- a/verilog/analysis/checkers/parameter_type_name_style_rule.cc
+++ b/verilog/analysis/checkers/parameter_type_name_style_rule.cc
@@ -1,0 +1,88 @@
+// Copyright 2017-2020 The Verible Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "verilog/analysis/checkers/parameter_type_name_style_rule.h"
+
+#include <set>
+#include <string>
+
+#include "absl/strings/match.h"
+#include "absl/strings/str_cat.h"
+#include "absl/strings/string_view.h"
+#include "common/analysis/citation.h"
+#include "common/analysis/lint_rule_status.h"
+#include "common/analysis/matcher/bound_symbol_manager.h"
+#include "common/strings/naming_utils.h"
+#include "common/text/symbol.h"
+#include "common/text/syntax_tree_context.h"
+#include "common/text/token_info.h"
+#include "verilog/CST/parameters.h"
+#include "verilog/analysis/descriptions.h"
+#include "verilog/analysis/lint_rule_registry.h"
+#include "verilog/parser/verilog_token_enum.h"
+
+namespace verilog {
+namespace analysis {
+
+using verible::GetStyleGuideCitation;
+using verible::LintRuleStatus;
+using verible::LintViolation;
+using verible::SyntaxTreeContext;
+
+// Register ParameterTypeNameStyleRule.
+VERILOG_REGISTER_LINT_RULE(ParameterTypeNameStyleRule);
+
+absl::string_view ParameterTypeNameStyleRule::Name() {
+  return "parameter-type-name-style";
+}
+const char ParameterTypeNameStyleRule::kTopic[] = "parametrized-objects";
+
+const char ParameterTypeNameStyleRule::kMessage[] =
+    "Parameter type names must use the lower_snake_case naming convention"
+    " and end with _t.";
+
+std::string ParameterTypeNameStyleRule::GetDescription(
+    DescriptionType description_type) {
+  return absl::StrCat(
+      "Checks that parameter type names follow the lower_snake_case naming "
+      "convention and end with _t. See ",
+      GetStyleGuideCitation(kTopic), ".");
+}
+
+void ParameterTypeNameStyleRule::HandleSymbol(
+    const verible::Symbol& symbol, const SyntaxTreeContext& context) {
+  verible::matcher::BoundSymbolManager manager;
+  if (matcher_.Matches(symbol, &manager)) {
+
+    const verible::TokenInfo* param_name_token = nullptr;
+    if (!IsParamTypeDeclaration(symbol))
+      return;
+
+    param_name_token = &GetSymbolIdentifierFromParamDeclaration(symbol);
+    const auto param_name = param_name_token->text;
+
+    if (!verible::IsLowerSnakeCaseWithDigits(param_name) ||
+        !absl::EndsWith(param_name, "_t"))
+      violations_.insert(LintViolation(*param_name_token,
+                                       kMessage,
+                                       context));
+  }
+}
+
+LintRuleStatus ParameterTypeNameStyleRule::Report() const {
+  return LintRuleStatus(violations_, Name(), GetStyleGuideCitation(kTopic));
+}
+
+}  // namespace analysis
+}  // namespace verilog

--- a/verilog/analysis/checkers/parameter_type_name_style_rule.h
+++ b/verilog/analysis/checkers/parameter_type_name_style_rule.h
@@ -1,0 +1,66 @@
+// Copyright 2017-2020 The Verible Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef VERIBLE_VERILOG_ANALYSIS_CHECKERS_PARAMETER_TYPE_NAME_STYLE_RULE_H_
+#define VERIBLE_VERILOG_ANALYSIS_CHECKERS_PARAMETER_TYPE_NAME_STYLE_RULE_H_
+
+#include <set>
+#include <string>
+
+#include "common/analysis/lint_rule_status.h"
+#include "common/analysis/matcher/matcher.h"
+#include "common/analysis/matcher/matcher_builders.h"
+#include "common/analysis/syntax_tree_lint_rule.h"
+#include "common/text/symbol.h"
+#include "common/text/syntax_tree_context.h"
+#include "verilog/CST/verilog_matchers.h"  // IWYU pragma: keep
+#include "verilog/analysis/descriptions.h"
+
+namespace verilog {
+namespace analysis {
+
+// ParameterTypeNameStyleRule checks that each parameter type name follows the
+// correct naming convention.
+class ParameterTypeNameStyleRule : public verible::SyntaxTreeLintRule {
+ public:
+  using rule_type = verible::SyntaxTreeLintRule;
+  static absl::string_view Name();
+
+  // Returns the description of the rule implemented formatted for either the
+  // helper flag or markdown depending on the parameter type.
+  static std::string GetDescription(DescriptionType);
+
+  void HandleSymbol(const verible::Symbol& symbol,
+                    const verible::SyntaxTreeContext& context) override;
+
+  verible::LintRuleStatus Report() const override;
+
+ private:
+  // Link to style guide rule.
+  static const char kTopic[];
+
+  // Diagnostic message for type name violations.
+  static const char kMessage[];
+
+  using Matcher = verible::matcher::Matcher;
+
+  Matcher matcher_ = NodekParamDeclaration();
+
+  std::set<verible::LintViolation> violations_;
+};
+
+}  // namespace analysis
+}  // namespace verilog
+
+#endif  // VERIBLE_VERILOG_ANALYSIS_CHECKERS_PARAMETER_TYPE_NAME_STYLE_RULE_H_

--- a/verilog/analysis/checkers/parameter_type_name_style_rule_test.cc
+++ b/verilog/analysis/checkers/parameter_type_name_style_rule_test.cc
@@ -1,0 +1,109 @@
+// Copyright 2017-2020 The Verible Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "verilog/analysis/checkers/parameter_type_name_style_rule.h"
+
+#include <initializer_list>
+
+#include "gtest/gtest.h"
+#include "common/analysis/linter_test_utils.h"
+#include "common/analysis/syntax_tree_linter_test_utils.h"
+#include "common/text/symbol.h"
+#include "verilog/CST/verilog_nonterminals.h"
+#include "verilog/analysis/verilog_analyzer.h"
+
+namespace verilog {
+namespace analysis {
+namespace {
+
+using verible::LintTestCase;
+using verible::RunLintTestCases;
+
+// Tests that ParameterTypeNameStyleRule correctly accepts valid names.
+TEST(ParameterTypeNameStyleRuleTest, AcceptTests) {
+  const std::initializer_list<LintTestCase> kTestCases = {
+      {""},
+      {"module foo #(parameter type foo_bar_t); endmodule"},
+      {"module foo #(parameter type foo_bar_t = logic); endmodule"},
+      {"module foo; localparam type foo_bar_t; endmodule"},
+      {"module foo; localparam type foo_bar_t = logic; endmodule"},
+      {"parameter type foo_bar_t;"},
+      {"parameter type foo_bar_t = logic;"},
+
+      // Make sure non-type parameters trigger no violation
+      {"module foo; localparam Bar_Hello = 1; endmodule"},
+      {"module foo; localparam int Bar_Hello = 1; endmodule"},
+      {"module foo; parameter int __Bar = 1; endmodule"},
+      {"module foo #(parameter int Bar_1_Hello = 1); endmodule"},
+      {"module foo #(int Bar_1_Two); endmodule"},
+      {"module foo; localparam int bar = 1; "
+       "localparam int BarSecond = 2; endmodule"},
+      {"module foo; localparam int bar = 1; "
+       "localparam int Bar_Second = 2; endmodule"},
+      {"class foo; localparam int helloWorld = 1; endclass"},
+      {"class foo #(parameter int hello_world = 1); endclass"},
+      {"package foo; parameter hello__1 = 1; endpackage"},
+      {"package foo; parameter HELLO_WORLd = 1; endpackage"},
+      {"package foo; parameter int _1Bar = 1; endpackage"},
+      {"package foo; parameter int HELLO_World = 1; "
+       "parameter int bar = 2; endpackage"},
+      {"parameter int HelloWorld_ = 1;"},
+      {"parameter HelloWorld__ = 1;"},
+  };
+  RunLintTestCases<VerilogAnalyzer, ParameterTypeNameStyleRule>(kTestCases);
+}
+
+// Tests that ParameterTypeNameStyleRule rejects invalid names.
+TEST(ParameterTypeNameStyleRuleTest, RejectTests) {
+  constexpr int kToken = SymbolIdentifier;
+  const std::initializer_list<LintTestCase> kTestCases = {
+
+      {"module foo #(parameter type ",
+        {kToken, "FooBar"},
+        "); endmodule"},
+      {"module foo #(parameter type ",
+        {kToken, "FooBar"},
+        " = logic); endmodule"},
+      {"module foo #(parameter type ",
+        {kToken, "FooBar_t"},
+        " = logic); endmodule"},
+      {"module foo #(parameter type ",
+        {kToken, "foobar"},
+        "); endmodule"},
+      {"module foo #(parameter type ",
+        {kToken, "_t"},
+        "); endmodule"},
+
+      {"module foo; localparam type ",
+       {kToken, "FooBar"},
+       " = logic; endmodule"},
+      {"module foo; localparam type ",
+       {kToken, "foo_bar"},
+       " = logic; endmodule"},
+      {"module foo; localparam type ",
+       {kToken, "Foo_Bar_t"},
+       " = logic; endmodule"},
+
+      {"parameter type ", {kToken, "Foo_Bar_t"}, ";"},
+      {"parameter type ", {kToken, "FooBar_t"}, ";"},
+      {"parameter type ", {kToken, "Foobar_t"}, ";"},
+      {"parameter type ", {kToken, "foobar"}, ";"},
+      {"parameter type ", {kToken, "foo_bar"}, ";"},
+  };
+  RunLintTestCases<VerilogAnalyzer, ParameterTypeNameStyleRule>(kTestCases);
+}  // namespace
+
+}  // namespace
+}  // namespace analysis
+}  // namespace verilog

--- a/verilog/tools/lint/BUILD
+++ b/verilog/tools/lint/BUILD
@@ -42,6 +42,8 @@ _linter_test_configs = [
     ("packed-dimensions-range-ordering", "packed_dimensions", True),
     ("parameter-name-style", "localparam_name_style", True),
     ("parameter-name-style", "parameter_name_style", True),
+    ("parameter-type-name-style", "parameter_type_name_style", False),
+    ("parameter-type-name-style", "localparam_type_name_style", False),
     ("plusarg-assignment", "plusarg_assignment", True),
     ("proper-parameter-declaration", "proper_parameter_declaration", False),
     ("proper-parameter-declaration", "proper_localparam_declaration", False),

--- a/verilog/tools/lint/testdata/localparam_type_name_style.sv
+++ b/verilog/tools/lint/testdata/localparam_type_name_style.sv
@@ -1,0 +1,4 @@
+// Expected localparam type name, "Hello_World" to follow lower_snake_case naming convention and end with _t.
+class foo;
+  localparam type Hello_World = logic;
+endclass

--- a/verilog/tools/lint/testdata/parameter_type_name_style.sv
+++ b/verilog/tools/lint/testdata/parameter_type_name_style.sv
@@ -1,0 +1,2 @@
+// Expected parameter type name, "Hello_World" to follow lower_snake_case naming convention and end with _t.
+parameter type Hello_World = logic;


### PR DESCRIPTION
This PR adds a new rule discussed in #164 for checking parameter type names.

Add the same time this PR modifies the parameter name rule so it does not check parameter type name with contradicting rules.

Fixes #164 