### PR TITLE
Add build version based on git-hash. If that is not available, use

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,1 @@
+build --workspace_status_command=bazel/build-version.sh

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*~
 /bazel-*
 tags
 Docker/centos*

--- a/bazel/build-version.sh
+++ b/bazel/build-version.sh
@@ -15,5 +15,9 @@
 
 # Invoke bazel with --workspace_status_command=bazel/build-version.sh to
 # get this invoked and populate bazel-out/volatile-status.sh
-echo "GIT_HASH $(git log -n1 --date=short --format='"verible_%cd_%h"' || echo '"<unknown>"')"
+GIT_DATE="$(git log -n1 --format='"%cs"')"
+GIT_DESCRIBE="$(git describe)"
+
+test -z "$GIT_DATE" || echo "GIT_DATE $GIT_DATE"
+test -z "$GIT_DESCRIBE" || echo "GIT_DESCRIBE \"$GIT_DESCRIBE\""
 

--- a/bazel/build-version.sh
+++ b/bazel/build-version.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Copyright 2020 The Verible Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Invoke bazel with --workspace_status_command=bazel/build-version.sh to
+# get this invoked and populate bazel-out/volatile-status.sh
+echo "GIT_HASH $(git log -n1 --date=short --format='"verible_%cd_%h"' || echo '"<unknown>"')"
+

--- a/common/util/BUILD
+++ b/common/util/BUILD
@@ -42,9 +42,26 @@ cc_library(
     ],
 )
 
+# Due to the hermetic builds bazel offers, we can't just fill a header file
+# with a git hash. We have to use the workspace stamping features bazel
+# offers.
+# https://docs.bazel.build/versions/master/user-manual.html#workspace_status
+# to contain a proper git timestamp, bazel has to be invoked with
+#  bazel build --workspace_status_command=bazel/build-version.sh
+genrule(
+    name = "version_header",
+    outs = ["verible_build_version.h"],
+    cmd = "./$(location create_version_header.sh) > $@",
+    stamp = 1,  # Tell bazel that we really are interested in the status file
+    tools = ["create_version_header.sh"],
+)
+
 cc_library(
     name = "init_command_line",
-    srcs = ["init_command_line.cc"],
+    srcs = [
+        "init_command_line.cc",
+        "verible_build_version.h",
+    ],
     hdrs = ["init_command_line.h"],
     deps = [
         "@com_google_absl//absl/flags:flag",

--- a/common/util/create_version_header.sh
+++ b/common/util/create_version_header.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Copyright 2020 The Verible Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+GIT_HASH=$(grep GIT_HASH bazel-out/volatile-status.txt | cut -f2 -d' ')
+
+if [ ! -z "$GIT_HASH" ] ; then
+  echo "#define VERIBLE_GIT_HASH $GIT_HASH"
+fi
+
+TS_INT=$(grep BUILD_TIMESTAMP bazel-out/volatile-status.txt | cut -f2 -d' ')
+TS_STRING=$(date +"%Y-%m-%d %H:%M UTC" -u -d @$TS_INT)
+
+if [ ! -z "$TS_STRING" ] ; then
+  echo "#define VERIBLE_BUILD_TIMESTAMP \"$TS_STRING\""
+fi
+

--- a/common/util/create_version_header.sh
+++ b/common/util/create_version_header.sh
@@ -13,9 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-GIT_HASH="$(grep GIT_HASH bazel-out/volatile-status.txt | cut -f2 -d' ')"
-TS_INT=$(grep BUILD_TIMESTAMP bazel-out/volatile-status.txt | cut -f2 -d' ')
-TS_STRING="$(date +"%Y-%m-%d %H:%M UTC" -u -d @$TS_INT)"
+GIT_DATE="$(grep GIT_DATE bazel-out/volatile-status.txt | cut -f2 -d' ')"
+GIT_DESC="$(grep GIT_DESCRIBE bazel-out/volatile-status.txt | cut -f2 -d' ')"
 
-test -z "$GIT_HASH" || echo "#define VERIBLE_GIT_HASH $GIT_HASH"
+# Timestamp is always provided by bazel.
+TS_INT=$(grep BUILD_TIMESTAMP bazel-out/volatile-status.txt | cut -f2 -d' ')
+TS_STRING="$(date +"%Y-%m-%dT%H:%M:%SZ" -u -d @$TS_INT)"
+
+test -z "$GIT_DATE"  || echo "#define VERIBLE_GIT_DATE $GIT_DATE"
+test -z "$GIT_DESC"  || echo "#define VERIBLE_GIT_DESC $GIT_DESC"
 test -z "$TS_STRING" || echo "#define VERIBLE_BUILD_TIMESTAMP \"$TS_STRING\""

--- a/common/util/create_version_header.sh
+++ b/common/util/create_version_header.sh
@@ -14,15 +14,8 @@
 # limitations under the License.
 
 GIT_HASH=$(grep GIT_HASH bazel-out/volatile-status.txt | cut -f2 -d' ')
-
-if [ ! -z "$GIT_HASH" ] ; then
-  echo "#define VERIBLE_GIT_HASH $GIT_HASH"
-fi
-
 TS_INT=$(grep BUILD_TIMESTAMP bazel-out/volatile-status.txt | cut -f2 -d' ')
 TS_STRING=$(date +"%Y-%m-%d %H:%M UTC" -u -d @$TS_INT)
 
-if [ ! -z "$TS_STRING" ] ; then
-  echo "#define VERIBLE_BUILD_TIMESTAMP \"$TS_STRING\""
-fi
-
+test -z "$GIT_HASH" || echo "#define VERIBLE_GIT_HASH $GIT_HASH"
+test -z "$TS_STRING" || echo "#define VERIBLE_BUILD_TIMESTAMP \"$TS_STRING\""

--- a/common/util/create_version_header.sh
+++ b/common/util/create_version_header.sh
@@ -13,9 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-GIT_HASH=$(grep GIT_HASH bazel-out/volatile-status.txt | cut -f2 -d' ')
+GIT_HASH="$(grep GIT_HASH bazel-out/volatile-status.txt | cut -f2 -d' ')"
 TS_INT=$(grep BUILD_TIMESTAMP bazel-out/volatile-status.txt | cut -f2 -d' ')
-TS_STRING=$(date +"%Y-%m-%d %H:%M UTC" -u -d @$TS_INT)
+TS_STRING="$(date +"%Y-%m-%d %H:%M UTC" -u -d @$TS_INT)"
 
 test -z "$GIT_HASH" || echo "#define VERIBLE_GIT_HASH $GIT_HASH"
 test -z "$TS_STRING" || echo "#define VERIBLE_BUILD_TIMESTAMP \"$TS_STRING\""

--- a/common/util/init_command_line.cc
+++ b/common/util/init_command_line.cc
@@ -19,11 +19,26 @@
 #include "absl/flags/flag.h"
 #include "absl/flags/parse.h"
 #include "absl/flags/usage.h"
+#include "absl/flags/usage_config.h"
+#include "common/util/verible_build_version.h"
 
 namespace verible {
 
+std::string GetBuildVersion() {
+#ifdef VERIBLE_GIT_HASH
+  return VERIBLE_GIT_HASH "\n";
+#elif defined(VERIBLE_BUILD_TIMESTAMP)
+  return "Built: " VERIBLE_BUILD_TIMESTAMP "\n";
+#else
+  return "<unknown>\n";
+#endif
+}
+
 std::vector<char*> InitCommandLine(absl::string_view usage, int* argc,
                                    char*** argv) {
+  absl::FlagsUsageConfig usage_config;
+  usage_config.version_string = GetBuildVersion;
+  absl::SetFlagsUsageConfig(usage_config);
   absl::SetProgramUsageMessage(usage);  // copies usage string
   return absl::ParseCommandLine(*argc, *argv);
 }

--- a/common/util/init_command_line.cc
+++ b/common/util/init_command_line.cc
@@ -25,13 +25,18 @@
 namespace verible {
 
 static std::string GetBuildVersion() {
-#ifdef VERIBLE_GIT_HASH
-  return VERIBLE_GIT_HASH "\n";
-#elif defined(VERIBLE_BUILD_TIMESTAMP)
-  return "Built: " VERIBLE_BUILD_TIMESTAMP "\n";
-#else
-  return "<unknown>\n";
+  std::string result;
+  // Build a version string with as much as possible info.
+#ifdef VERIBLE_GIT_DESC
+  result.append(VERIBLE_GIT_DESC).append("\n");
 #endif
+#ifdef VERIBLE_GIT_DATE
+  result.append("Commit\t").append(VERIBLE_GIT_DATE).append("\n");
+#endif
+#ifdef VERIBLE_BUILD_TIMESTAMP
+  result.append("Built\t").append(VERIBLE_BUILD_TIMESTAMP).append("\n");
+#endif
+  return result;
 }
 
 std::vector<char*> InitCommandLine(absl::string_view usage, int* argc,

--- a/common/util/init_command_line.cc
+++ b/common/util/init_command_line.cc
@@ -24,7 +24,7 @@
 
 namespace verible {
 
-std::string GetBuildVersion() {
+static std::string GetBuildVersion() {
 #ifdef VERIBLE_GIT_HASH
   return VERIBLE_GIT_HASH "\n";
 #elif defined(VERIBLE_BUILD_TIMESTAMP)


### PR DESCRIPTION
just the timestamp that is always available in bazel.

Given that bazel does not allow to arbitrarily generate changing
code to guarantee hermetic builds, we have to use the workspace status
feature
 https://docs.bazel.build/versions/master/user-manual.html#workspace_status

In short, we create name-value pairs using the build-version.sh script, which
are then picked up in the version_header genrule.

To make sure the build-version.sh script is invoked, we add it to the
project .bazelrc.

This now creates outputs like these

$ bazel-bin/verilog/tools/syntax/verilog_syntax --version
verible_2020-02-13_27b5698

Fixes #173

Signed-off-by: Henner Zeller <h.zeller@acm.org>