### PR TITLE
Match multiple inline parameters in linter name style rule

### DIFF
--- a/verilog/CST/parameters.h
+++ b/verilog/CST/parameters.h
@@ -75,6 +75,18 @@ const verible::Symbol* GetParamTypeInfoSymbol(const verible::Symbol&);
 // Returns the token of the declared parameter.
 const verible::TokenInfo& GetParameterNameToken(const verible::Symbol&);
 
+// Returns all tokens for a parameter declaration.
+std::vector<const verible::TokenInfo*> GetAllParameterNameTokens(
+    const verible::Symbol&);
+
+// Get the token info for a given kParameterAssign node symbol
+const verible::TokenInfo& GetAssignedParameterNameToken(
+    const verible::Symbol& symbol);
+
+// Get the symbols for all kParameterAssign nodes
+std::vector<const verible::Symbol*> GetAllAssignedParameterSymbols(
+    const verible::Symbol& root);
+
 // Returns the token of the SymbolIdentifier from the node kParamDeclaration.
 // Used specifically for 'parameter type' declarations.
 const verible::TokenInfo& GetSymbolIdentifierFromParamDeclaration(

--- a/verilog/CST/parameters_test.cc
+++ b/verilog/CST/parameters_test.cc
@@ -199,6 +199,37 @@ TEST(GetParameterNameTokenTest, BasicTests) {
   }
 }
 
+// Test that GetAllParameterNameTokens correctly returns all tokens
+TEST(GetAllParameterNameTokensTest, BasicTests) {
+  const std::pair<std::string, int> kTestCases[] = {
+      {"module foo; parameter Bar = 1; endmodule", 1},
+      {"module foo; localparam Bar_1 = 1; endmodule", 1},
+      {"module foo; localparam int HelloWorld = 1; endmodule", 1},
+      {"module foo #(parameter int HelloWorld1 = 1); endmodule", 1},
+      {"class foo; parameter HelloWorld_1 = 1; endclass", 1},
+      {"class foo; localparam FooBar = 1; endclass", 1},
+      {"class foo; localparam int Bar_1_1 = 1; endclass", 1},
+      {"package foo; parameter BAR = 1; endpackage", 1},
+      {"package foo; parameter int HELLO_WORLD = 1; endpackage", 1},
+      {"parameter int Bar = 1;", 1},
+      {"parameter int Bar = 1, Foo = 1;", 2},
+      {"parameter int Bar = 1, Foo = 1, Baz = 1;", 3},
+      {"module foo; parameter int Bar = 1; endmodule;", 1},
+      {"module foo; parameter int Bar = 1, Foo = 1; endmodule;", 2},
+      {"module foo; parameter int Bar = 1, Foo = 1, Baz = 1; endmodule;", 3},
+  };
+
+  for (const auto& test : kTestCases) {
+    VerilogAnalyzer analyzer(test.first, "");
+    ASSERT_OK(analyzer.Analyze());
+    const auto& root = analyzer.Data().SyntaxTree();
+    const auto param_declarations = FindAllParamDeclarations(*root);
+    const auto name_tokens =
+        GetAllParameterNameTokens(*param_declarations.front().match);
+    EXPECT_EQ(name_tokens.size(), test.second);
+  }
+}
+
 // Tests that GetSymbolIdentifierFromParamDeclaration correctly returns the
 // token of the symbol identifier.
 TEST(GetSymbolIdentifierFromParamDeclarationTest, BasicTests) {

--- a/verilog/analysis/checkers/parameter_name_style_rule.cc
+++ b/verilog/analysis/checkers/parameter_name_style_rule.cc
@@ -64,23 +64,25 @@ void ParameterNameStyleRule::HandleSymbol(const verible::Symbol& symbol,
                                           const SyntaxTreeContext& context) {
   verible::matcher::BoundSymbolManager manager;
   if (matcher_.Matches(symbol, &manager)) {
-    const auto param_decl_token = GetParamKeyword(symbol);
-
-    const verible::TokenInfo* param_name_token = nullptr;
     if (IsParamTypeDeclaration(symbol)) return;
 
-    param_name_token = &GetParameterNameToken(symbol);
+    const auto param_decl_token = GetParamKeyword(symbol);
 
-    const auto param_name = param_name_token->text;
-    if (param_decl_token == TK_localparam) {
-      if (!verible::IsUpperCamelCaseWithDigits(param_name))
-        violations_.insert(
-            LintViolation(*param_name_token, kLocalParamMessage, context));
-    } else if (param_decl_token == TK_parameter) {
-      if (!verible::IsUpperCamelCaseWithDigits(param_name) &&
-          !verible::IsNameAllCapsUnderscoresDigits(param_name))
-        violations_.insert(
-            LintViolation(*param_name_token, kParameterMessage, context));
+    auto identifiers =
+      GetAllParameterNameTokens(symbol);
+
+    for (auto id: identifiers) {
+      const auto param_name = id->text;
+      if (param_decl_token == TK_localparam) {
+        if (!verible::IsUpperCamelCaseWithDigits(param_name))
+          violations_.insert(
+              LintViolation(*id, kLocalParamMessage, context));
+      } else if (param_decl_token == TK_parameter) {
+        if (!verible::IsUpperCamelCaseWithDigits(param_name) &&
+            !verible::IsNameAllCapsUnderscoresDigits(param_name))
+          violations_.insert(
+              LintViolation(*id, kParameterMessage, context));
+      }
     }
   }
 }

--- a/verilog/analysis/checkers/parameter_name_style_rule_test.cc
+++ b/verilog/analysis/checkers/parameter_name_style_rule_test.cc
@@ -69,6 +69,14 @@ TEST(ParameterNameStyleRuleTest, RejectTests) {
       {"module foo; localparam ", {kToken, "Bar_Hello"}, " = 1; endmodule"},
       {"module foo; localparam int ", {kToken, "Bar_Hello"}, " = 1; endmodule"},
       {"module foo; parameter int ", {kToken, "__Bar"}, " = 1; endmodule"},
+      {"module foo; parameter int ",
+       {kToken, "__Foo"}, " = 1, ",
+       {kToken, "__Bar"}, " = 1; "
+       "endmodule"},
+      {"module foo; localparam int ",
+       {kToken, "__Foo"}, " = 1, ",
+       {kToken, "__Bar"}, " = 1; "
+       "endmodule"},
       {"module foo #(parameter int ",
        {kToken, "Bar_1_Hello"},
        " = 1); endmodule"},


### PR DESCRIPTION
Fixes: #203