### PR TITLE
interface-name-style shouldn't apply to typedefs of virtual interfaces

### DIFF
--- a/verilog/analysis/checkers/interface_name_style_rule.cc
+++ b/verilog/analysis/checkers/interface_name_style_rule.cc
@@ -63,22 +63,11 @@ void InterfaceNameStyleRule::HandleSymbol(const verible::Symbol& symbol,
   if (matcher_interface_.Matches(symbol, &manager)) {
     identifier_token = &GetInterfaceNameToken(symbol);
     name = identifier_token->text;
-  } else if (matcher_typedef_.Matches(symbol, &manager)) {
-    // TODO: This can be changed to checking type of child (by index) when we
-    // have consistent shape for all kTypeDeclaration nodes.
-    if (!FindAllInterfaceTypes(symbol).empty()) {
-      identifier_token = &GetIdentifierFromTypeDeclaration(symbol)->get();
-      name = identifier_token->text;
-    } else {
-      return;  // not an interface typedef
-    }
-  } else {
-    return;  // not an interface symbol
-  }
 
-  if (!verible::IsLowerSnakeCaseWithDigits(name) ||
-      !absl::EndsWith(name, "_if")) {
-    violations_.insert(LintViolation(*identifier_token, kMessage, context));
+    if (!verible::IsLowerSnakeCaseWithDigits(name) ||
+        !absl::EndsWith(name, "_if")) {
+      violations_.insert(LintViolation(*identifier_token, kMessage, context));
+    }
   }
 }
 

--- a/verilog/analysis/checkers/interface_name_style_rule_test.cc
+++ b/verilog/analysis/checkers/interface_name_style_rule_test.cc
@@ -36,6 +36,38 @@ TEST(InterfaceNameStyleRuleTest, ValidInterfaceDeclarationNames) {
       {"interface foo_if; endinterface"},
       {"interface good_name_if; endinterface"},
       {"interface b_a_z_if; endinterface"},
+
+      // Should not apply to typedefs of virtual interfaces
+      {"typedef virtual interface foo foo_if;"},
+      {"typedef virtual interface foo good_name_if;"},
+      {"typedef virtual interface foo b_a_z_if;"},
+      {"typedef virtual foo foo_if;"},
+      {"typedef virtual foo good_name_if;"},
+      {"typedef virtual foo b_a_z_if;"},
+      {"typedef virtual interface foo HelloWorld;"},
+      {"typedef virtual interface foo _baz;"},
+      {"typedef virtual interface foo Bad_name;"},
+      {"typedef virtual interface foo bad_Name;"},
+      {"typedef virtual interface foo Bad2;"},
+      {"typedef virtual interface foo very_Bad_name;"},
+      {"typedef virtual interface foo wrong_ending;"},
+      {"typedef virtual interface foo _if;"},
+      {"typedef virtual interface foo _i_f;"},
+      {"typedef virtual interface foo i_f;"},
+      {"typedef virtual interface foo _;"},
+      {"typedef virtual interface foo foo_;"},
+      {"typedef virtual foo HelloWorld;"},
+      {"typedef virtual foo _baz;"},
+      {"typedef virtual foo Bad_name;"},
+      {"typedef virtual foo bad_Name;"},
+      {"typedef virtual foo Bad2;"},
+      {"typedef virtual foo very_Bad_name;"},
+      {"typedef virtual foo wrong_ending;"},
+      {"typedef virtual foo _if;"},
+      {"typedef virtual foo _i_f;"},
+      {"typedef virtual foo i_f;"},
+      {"typedef virtual foo _;"},
+      {"typedef virtual foo foo_;"},
   };
   RunLintTestCases<VerilogAnalyzer, InterfaceNameStyleRule>(kTestCases);
 }
@@ -55,50 +87,6 @@ TEST(InterfaceNameStyleRuleTest, InvalidInterfaceDeclarationNames) {
       {"interface ", {kToken, "i_f"}, "; endinterface"},
       {"interface ", {kToken, "_"}, "; endinterface"},
       {"interface ", {kToken, "foo_"}, "; endinterface"},
-  };
-  RunLintTestCases<VerilogAnalyzer, InterfaceNameStyleRule>(kTestCases);
-}
-
-TEST(InterfaceNameStyleRuleTest, ValidInterfaceTypeNames) {
-  const std::initializer_list<LintTestCase> kTestCases = {
-      {""},
-      {"typedef virtual interface foo foo_if;"},
-      {"typedef virtual interface foo good_name_if;"},
-      {"typedef virtual interface foo b_a_z_if;"},
-      {"typedef virtual foo foo_if;"},
-      {"typedef virtual foo good_name_if;"},
-      {"typedef virtual foo b_a_z_if;"},
-  };
-  RunLintTestCases<VerilogAnalyzer, InterfaceNameStyleRule>(kTestCases);
-}
-
-TEST(InterfaceNameStyleRuleTest, InvalidInterfaceTypeNames) {
-  constexpr int kToken = SymbolIdentifier;
-  const std::initializer_list<LintTestCase> kTestCases = {
-      {"typedef virtual interface foo ", {kToken, "HelloWorld"}, ";"},
-      {"typedef virtual interface foo ", {kToken, "_baz"}, ";"},
-      {"typedef virtual interface foo ", {kToken, "Bad_name"}, ";"},
-      {"typedef virtual interface foo ", {kToken, "bad_Name"}, ";"},
-      {"typedef virtual interface foo ", {kToken, "Bad2"}, ";"},
-      {"typedef virtual interface foo ", {kToken, "very_Bad_name"}, ";"},
-      {"typedef virtual interface foo ", {kToken, "wrong_ending"}, ";"},
-      {"typedef virtual interface foo ", {kToken, "_if"}, ";"},
-      {"typedef virtual interface foo ", {kToken, "_i_f"}, ";"},
-      {"typedef virtual interface foo ", {kToken, "i_f"}, ";"},
-      {"typedef virtual interface foo ", {kToken, "_"}, ";"},
-      {"typedef virtual interface foo ", {kToken, "foo_"}, ";"},
-      {"typedef virtual foo ", {kToken, "HelloWorld"}, ";"},
-      {"typedef virtual foo ", {kToken, "_baz"}, ";"},
-      {"typedef virtual foo ", {kToken, "Bad_name"}, ";"},
-      {"typedef virtual foo ", {kToken, "bad_Name"}, ";"},
-      {"typedef virtual foo ", {kToken, "Bad2"}, ";"},
-      {"typedef virtual foo ", {kToken, "very_Bad_name"}, ";"},
-      {"typedef virtual foo ", {kToken, "wrong_ending"}, ";"},
-      {"typedef virtual foo ", {kToken, "_if"}, ";"},
-      {"typedef virtual foo ", {kToken, "_i_f"}, ";"},
-      {"typedef virtual foo ", {kToken, "i_f"}, ";"},
-      {"typedef virtual foo ", {kToken, "_"}, ";"},
-      {"typedef virtual foo ", {kToken, "foo_"}, ";"},
   };
   RunLintTestCases<VerilogAnalyzer, InterfaceNameStyleRule>(kTestCases);
 }

--- a/verilog/tools/lint/BUILD
+++ b/verilog/tools/lint/BUILD
@@ -32,9 +32,7 @@ _linter_test_configs = [
     ("generate-label", "generate_label_module", True),
     ("generate-label", "generate-label-module-body", True),  # uses parse directive
     ("invalid-system-task-function", "psprintf", True),
-    ("interface-name-style", "interface_decl_name_style", False),
     ("interface-name-style", "interface_type_name_style", False),
-    ("interface-name-style", "interface_virtual_name_style", False),
     ("macro-name-style", "macro_name_style", True),
     ("mismatched-labels", "mismatched_labels", False),
     ("module-begin-block", "module_begin_block", True),

--- a/verilog/tools/lint/testdata/interface_decl_name_style.sv
+++ b/verilog/tools/lint/testdata/interface_decl_name_style.sv
@@ -1,2 +1,0 @@
-// Interface names should be lower_snake_case and end with _if
-typedef virtual interface foo barBaz;

--- a/verilog/tools/lint/testdata/interface_virtual_name_style.sv
+++ b/verilog/tools/lint/testdata/interface_virtual_name_style.sv
@@ -1,2 +1,0 @@
-// Interface names should be lower_snake_case and end with _if
-typedef virtual foo barBaz;


### PR DESCRIPTION
Fixes #210 

It completely removes the check for typedefs of virtual interfaces.

All the relevant tests have been moved to the passing tests to make sure these are ignored.