### PR TITLE
Apply kAppendFittingSubpartition to macro calls

### DIFF
--- a/verilog/formatting/formatter.cc
+++ b/verilog/formatting/formatter.cc
@@ -234,18 +234,15 @@ static void DeterminePartitionExpansion(partition_node_type* node,
   const auto partition_policy = uwline.PartitionPolicy();
   VLOG(3) << "partition policy: " << partition_policy;
   switch (partition_policy) {
-    // Expand kAppendFittingSubPartitions partition and let us see it's
-    // grouped and (mostly) fitted childrens
-    case PartitionPolicyEnum::kAppendFittingSubPartitions: {
-      node_view.Expand();
-      break;
-    }
     case PartitionPolicyEnum::kAlwaysExpand: {
       if (children.size() > 1) {
         node_view.Expand();
       }
       break;
     }
+    // Try to fit kAppendFittingSubPartitions partition into single line.
+    // If it doesn't fit expand to grouped nodes.
+    case PartitionPolicyEnum::kAppendFittingSubPartitions:
     case PartitionPolicyEnum::kFitOnLineElseExpand: {
       if (verible::FitsOnLine(uwline, style).fits) {
         VLOG(3) << "Fits, un-expanding.";

--- a/verilog/formatting/formatter_test.cc
+++ b/verilog/formatting/formatter_test.cc
@@ -2706,8 +2706,7 @@ static const std::initializer_list<FormatterTestCase> kFormatterTestCases = {
         "      if (cfg.enable) begin\n"
         "        count = 1;\n"
         "      end,\n"
-        "      utils_pkg::decrement()\n"
-        "  )\n"
+        "      utils_pkg::decrement())\n"
         "endclass\n",
     },
 

--- a/verilog/formatting/formatter_test.cc
+++ b/verilog/formatting/formatter_test.cc
@@ -224,6 +224,133 @@ static const std::initializer_list<FormatterTestCase> kFormatterTestCases = {
         "`define FOO \\\n"
         " 1\n"  // TODO(b/141517267): Reflowing macro definitions
     },
+    {// macro with MacroArg tokens as arguments
+     "`FOOOOOO(\nbar1...\n,\nbar2...\n,\nbar3...\n,\nbar4\n)\n",
+     "`FOOOOOO(bar1..., bar2..., bar3...,\n"
+     "         bar4)\n"},
+    {// macro declaration exceeds line length limit
+     "`F_MACRO(looooooong_type if_it_fits_I_sits)\n",
+     "`F_MACRO(\n"
+     "    looooooong_type if_it_fits_I_sits)\n"},
+    {// macro call with not fitting arguments
+     "`MACRO_FFFFFFFFFFF("
+            "type_a_aaaa,type_b_bbbbb,"
+            "type_c_cccccc,type_d_dddddddd,"
+            "type_e_eeeeeeee,type_f_ffff)\n",
+     "`MACRO_FFFFFFFFFFF(\n"
+     "    type_a_aaaa, type_b_bbbbb,\n"
+     "    type_c_cccccc, type_d_dddddddd,\n"
+     "    type_e_eeeeeeee, type_f_ffff)\n"},
+    {// nested macro call
+     "`MACRO_FFFFFFFFFFF( "
+     "`A(type_a_aaaa), `B(type_b_bbbbb), "
+     "`C(type_c_cccccc), `D(type_d_dddddddd), "
+     "`E(type_e_eeeeeeee), `F(type_f_ffff))\n",
+     "`MACRO_FFFFFFFFFFF(`A(type_a_aaaa),\n"
+     "                   `B(type_b_bbbbb),\n"
+     "                   `C(type_c_cccccc),\n"
+     "                   `D(type_d_dddddddd),\n"
+     "                   `E(type_e_eeeeeeee),\n"
+     "                   `F(type_f_ffff))\n"},
+    {// two-level nested macro call
+     "`MACRO_FFFFFFFFFFF( "
+     "`A(type_a_aaaa, `B(type_b_bbbbb)), "
+     "`C(type_c_cccccc, `D(type_d_dddddddd)), "
+     "`E(type_e_eeeeeeee, `F(type_f_ffff)))\n",
+     "`MACRO_FFFFFFFFFFF(\n"
+     "    `A(type_a_aaaa, `B(type_b_bbbbb)),\n"
+     "    `C(type_c_cccccc,\n"
+     "       `D(type_d_dddddddd)),\n"
+     "    `E(type_e_eeeeeeee,\n"
+     "       `F(type_f_ffff)))\n"},
+    {// three-level nested macro call
+     "`MACRO_FFFFFFFFFFF(`A(type_a_aaaa,"
+     "`B(type_b_bbbbb,`C(type_c_cccccc))),"
+     "`D(type_d_dddddddd,`E(type_e_eeeeeeee,"
+     "`F(type_f_ffff))))\n",
+     "`MACRO_FFFFFFFFFFF(\n"
+     "    `A(type_a_aaaa,\n"
+     "        `B(type_b_bbbbb,\n"
+     "           `C(type_c_cccccc))),\n"
+     "    `D(type_d_dddddddd,\n"
+     "        `E(type_e_eeeeeeee,\n"
+     "           `F(type_f_ffff))))\n"},
+    {// macro call with MacroArg tokens as arugments and with semicolon
+     "`FOOOOOO(\nbar1...\n,\nbar2...\n,\nbar3...\n,\nbar4\n);\n",
+     "`FOOOOOO(bar1..., bar2..., bar3...,\n"
+     "         bar4);\n"},
+    {// macro declaration exceeds line length limit and contains semicolon
+     "`F_MACRO(looooooong_type if_it_fits_I_sits);\n",
+     "`F_MACRO(\n"
+     "    looooooong_type if_it_fits_I_sits);\n"},
+    {// macro call with not fitting arguments and semicolon
+     "`MACRO_FFFFFFFFFFF("
+            "type_a_aaaa,type_b_bbbbb,"
+            "type_c_cccccc,type_d_dddddddd,"
+            "type_e_eeeeeeee,type_f_ffff);\n",
+     "`MACRO_FFFFFFFFFFF(\n"
+     "    type_a_aaaa, type_b_bbbbb,\n"
+     "    type_c_cccccc, type_d_dddddddd,\n"
+     "    type_e_eeeeeeee, type_f_ffff);\n"},
+    {// nested macro call with semicolon
+     "`MACRO_FFFFFFFFFFF( "
+     "`A(type_a_aaaa), `B(type_b_bbbbb), "
+     "`C(type_c_cccccc), `D(type_d_dddddddd), "
+     "`E(type_e_eeeeeeee), `F(type_f_ffff));\n",
+     "`MACRO_FFFFFFFFFFF(`A(type_a_aaaa),\n"
+     "                   `B(type_b_bbbbb),\n"
+     "                   `C(type_c_cccccc),\n"
+     "                   `D(type_d_dddddddd),\n"
+     "                   `E(type_e_eeeeeeee),\n"
+     "                   `F(type_f_ffff));\n"},
+    {// two-level nested macro call with semicolon
+     "`MACRO_FFFFFFFFFFF( "
+     "`A(type_a_aaaa, `B(type_b_bbbbb)), "
+     "`C(type_c_cccccc, `D(type_d_dddddddd)), "
+     "`E(type_e_eeeeeeee, `F(type_f_ffff)));\n",
+     "`MACRO_FFFFFFFFFFF(\n"
+     "    `A(type_a_aaaa, `B(type_b_bbbbb)),\n"
+     "    `C(type_c_cccccc,\n"
+     "       `D(type_d_dddddddd)),\n"
+     "    `E(type_e_eeeeeeee,\n"
+     "       `F(type_f_ffff)));\n"},
+    {// three-level nested macro call with semicolon
+     "`MACRO_FFFFFFFFFFF(`A(type_a_aaaa,"
+     "`B(type_b_bbbbb,`C(type_c_cccccc))),"
+     "`D(type_d_dddddddd,`E(type_e_eeeeeeee,"
+     "`F(type_f_ffff))));\n",
+     "`MACRO_FFFFFFFFFFF(\n"
+     "    `A(type_a_aaaa,\n"
+     "        `B(type_b_bbbbb,\n"
+     "           `C(type_c_cccccc))),\n"
+     "    `D(type_d_dddddddd,\n"
+     "        `E(type_e_eeeeeeee,\n"
+     "           `F(type_f_ffff))));\n"},
+    {// macro call with no args
+     "`FOOOOOO()\n",
+     "`FOOOOOO()\n"},
+    {// macro call with no args and semicolon
+     "`FOOOOOO();\n",
+     "`FOOOOOO();\n"},
+    {// macro call with no args and semicolon separated by space
+     "`FOOOOOO() ;\n",
+     "`FOOOOOO();\n"},
+    {// macro call with comments in argument list
+     "`FOO(aa, //aa\nbb , // bb\ncc)\n",
+     "`FOO(aa,  //aa\n"
+     "     bb,  // bb\n"
+     "     cc)\n"},
+    {// macro call with comment before first argument
+     "`FOO(//aa\naa, //bb\nbb , // cc\ncc)\n",
+     "`FOO(  //aa\n"
+     "    aa,  //bb\n"
+     "    bb,  // cc\n"
+     "    cc)\n"},
+    {// macro call with argument including comment
+     "`FOO(aa, bb//cc\ndd)\n",
+     "`FOO(aa, bb//cc\n"
+     "dd)\n"
+    }, // TODO(fangism): Improve formatting arguments with comments
     {"  // leading comment\n"
      "  `define   FOO    \\\n"  // multiline macro definition
      "1\n"

--- a/verilog/formatting/tree_unwrapper.cc
+++ b/verilog/formatting/tree_unwrapper.cc
@@ -757,8 +757,7 @@ void TreeUnwrapper::SetIndentationsAndCreatePartitions(
     case NodeEnum::kNonblockingAssignmentStatement:  // dest <= src;
     case NodeEnum::kAssignModifyStatement:           // id+=expr
     case NodeEnum::kIncrementDecrementExpression:    // --y
-    case NodeEnum::kProceduralTimingControlStatement:
-    case NodeEnum::kMacroCall: {
+    case NodeEnum::kProceduralTimingControlStatement: {
       // Single statements directly inside a flow-control construct
       // should be properly indented one level.
       const int indent = DirectParentIsFlowControlConstruct(Context())
@@ -766,6 +765,17 @@ void TreeUnwrapper::SetIndentationsAndCreatePartitions(
                              : 0;
       VisitIndentedSection(node, indent,
                            PartitionPolicyEnum::kFitOnLineElseExpand);
+      break;
+    }
+
+    case NodeEnum::kMacroCall: {
+      // Single statements directly inside a flow-control construct
+      // should be properly indented one level.
+      const int indent = DirectParentIsFlowControlConstruct(Context())
+                             ? style_.indentation_spaces
+                             : 0;
+      VisitIndentedSection(node, indent,
+                           PartitionPolicyEnum::kAppendFittingSubPartitions);
       break;
     }
 

--- a/verilog/formatting/tree_unwrapper.cc
+++ b/verilog/formatting/tree_unwrapper.cc
@@ -499,8 +499,12 @@ void TreeUnwrapper::InterChildNodeHook(const SyntaxTreeNode& node) {
     case NodeEnum::kBlockItemStatementList:
       LookAheadBeyondCurrentNode();
       break;
-    default:
+    default: {
+      if (Context().DirectParentIs(NodeEnum::kMacroArgList)) {
+        StartNewUnwrappedLine(PartitionPolicyEnum::kFitOnLineElseExpand);
+      }
       break;
+    }
   }
   VLOG(4) << "end of " << __FUNCTION__ << " node type: " << tag;
 }

--- a/verilog/formatting/tree_unwrapper_test.cc
+++ b/verilog/formatting/tree_unwrapper_test.cc
@@ -3262,6 +3262,64 @@ const TreeUnwrapperTestData kUnwrapPreprocessorTestCases[] = {
     },
 
     {
+        "lone macro call, with space before semicolon",
+        "`FOO() ;\n",
+        L(0, {"`FOO", "(", ")", ";"}),
+    },
+
+    {
+        "macro call with one argument and with semicolon",
+        "`FOO(arg);\n",
+        N(0,
+          L(0, {"`FOO", "("}),
+          L(2, {"arg", ")", ";"})),
+    },
+
+    {
+        "macro call with one argument and with space before semicolon",
+        "`FOO(arg) ;\n",
+        N(0,
+          L(0, {"`FOO", "("}),
+          L(2, {"arg", ")", ";"})),
+    },
+
+    {
+        "macro call with comments in argument list",
+        "`FOO(aa, //aa\nbb , // bb\ncc)\n",
+        N(0,
+          L(0, {"`FOO", "("}),
+          N(2,
+            L(2, {"aa"}),
+            L(2, {",", "//aa"}),
+            L(2, {"bb"}),
+            L(2, {",", "// bb"}),
+            L(2, {"cc", ")"}))),
+    },
+
+    {
+        "macro call with comment before first argument",
+        "`FOO(// aa\naa, // bb\nbb, // cc\ncc)\n",
+        N(0,
+          L(0, {"`FOO", "(", "// aa"}),
+          N(2,
+            L(2, {"aa"}),
+            L(2, {",", "// bb"}),
+            L(2, {"bb"}),
+            L(2, {",", "// cc"}),
+            L(2, {"cc", ")"}))),
+    },
+
+    {   // TODO(fangism): Improve formatting arguments with comments
+        "macro call with argument including comment",
+        "`FOO(aa, bb // cc\ndd)\n",
+        N(0,
+          L(0, {"`FOO", "("}),
+          N(2,
+            L(2, {"aa", ","}),
+            L(2, {"bb // cc\ndd", ")"}))),
+    },
+
+    {
         "lone macro item",
         "`FOO\n",
         L(0, {"`FOO"}),

--- a/verilog/formatting/tree_unwrapper_test.cc
+++ b/verilog/formatting/tree_unwrapper_test.cc
@@ -942,7 +942,7 @@ const TreeUnwrapperTestData kUnwrapModuleTestCases[] = {
         ModuleDeclaration(
             0, L(0, {"module", "foob", ";"}),
             N(1, L(1, {"assign", "`BIT_ASSIGN_MACRO", "("}),
-              MacroArgList(3, L(3, {"l1", ","}), L(3, {"r1"})), L(1, {")"})),
+              MacroArgList(3, L(3, {"l1", ","}), L(3, {"r1", ")"}))),
             L(0, {"endmodule"})),
     },
 
@@ -953,8 +953,7 @@ const TreeUnwrapperTestData kUnwrapModuleTestCases[] = {
         "endmodule",
         ModuleDeclaration(0, L(0, {"module", "foob", ";"}),
                           N(1, L(1, {"assign", "`BIT_ASSIGN_MACRO", "("}),
-                            MacroArgList(3, L(3, {"l1", ","}), L(3, {"r1"})),
-                            L(1, {")", ";"})),
+                            MacroArgList(3, L(3, {"l1", ","}), L(3, {"r1", ")", ";"}))),
                           L(0, {"endmodule"})),
     },
 
@@ -970,8 +969,7 @@ const TreeUnwrapperTestData kUnwrapModuleTestCases[] = {
             ModuleItemList(
                 1, L(1, {"initial", "begin"}),
                 StatementList(2, L(2, {"assign", "`BIT_ASSIGN_MACRO", "("}),
-                              MacroArgList(4, L(4, {"l1", ","}), L(4, {"r1"})),
-                              L(2, {")"})),
+                              MacroArgList(4, L(4, {"l1", ","}), L(4, {"r1", ")"}))),
                 L(1, {"end"})),
             L(0, {"endmodule"})),
     },
@@ -1167,7 +1165,7 @@ const TreeUnwrapperTestData kUnwrapModuleTestCases[] = {
             ModuleItemList(
                 1,
                 N(1,  //
-                  L(1, {"`ASSERT", "("}), L(3, {"blah"}), L(1, {")"})),
+                  L(1, {"`ASSERT", "("}), L(3, {"blah", ")"})),
                 N(1,  //
                   L(1, {"generate"}), L(1, {"endgenerate"}))),
             L(0, {"endmodule"})),
@@ -2156,11 +2154,11 @@ const TreeUnwrapperTestData kUnwrapUvmTestCases[] = {
         "`uvm_field_int(l1a, UVM_DEFAULT)\n"
         "`uvm_field_int(l1b, UVM_DEFAULT)\n"
         "`uvm_object_utils_end\n",
-        N(0, L(0, {"`uvm_object_utils_begin", "("}), L(2, {"l0"}), L(0, {")"})),
+        N(0, L(0, {"`uvm_object_utils_begin", "("}), L(2, {"l0", ")"})),
         N(1, L(1, {"`uvm_field_int", "("}),
-          N(3, L(3, {"l1a", ","}), L(3, {"UVM_DEFAULT"})), L(1, {")"})),
+          N(3, L(3, {"l1a", ","}), L(3, {"UVM_DEFAULT", ")"}))),
         N(1, L(1, {"`uvm_field_int", "("}),
-          N(3, L(3, {"l1b", ","}), L(3, {"UVM_DEFAULT"})), L(1, {")"})),
+          N(3, L(3, {"l1b", ","}), L(3, {"UVM_DEFAULT", ")"}))),
         L(0, {"`uvm_object_utils_end"}),
     },
 
@@ -2170,11 +2168,11 @@ const TreeUnwrapperTestData kUnwrapUvmTestCases[] = {
         "`uvm_field_int(l1a, UVM_DEFAULT)\n"
         "`uvm_field_int(l1b, UVM_DEFAULT)\n"
         "`uvm_field_utils_end\n",
-        N(0, L(0, {"`uvm_field_utils_begin", "("}), L(2, {"l0"}), L(0, {")"})),
+        N(0, L(0, {"`uvm_field_utils_begin", "("}), L(2, {"l0", ")"})),
         N(1, L(1, {"`uvm_field_int", "("}),
-          N(3, L(3, {"l1a", ","}), L(3, {"UVM_DEFAULT"})), L(1, {")"})),
+          N(3, L(3, {"l1a", ","}), L(3, {"UVM_DEFAULT", ")"}))),
         N(1, L(1, {"`uvm_field_int", "("}),
-          N(3, L(3, {"l1b", ","}), L(3, {"UVM_DEFAULT"})), L(1, {")"})),
+          N(3, L(3, {"l1b", ","}), L(3, {"UVM_DEFAULT", ")"}))),
         L(0, {"`uvm_field_utils_end"}),
     },
 
@@ -2190,19 +2188,19 @@ const TreeUnwrapperTestData kUnwrapUvmTestCases[] = {
         "`uvm_object_utils_end\n"
         "`uvm_field_int(l1b, UVM_DEFAULT)\n"
         "`uvm_object_utils_end\n",
-        N(0, L(0, {"`uvm_object_utils_begin", "("}), L(2, {"l0"}), L(0, {")"})),
+        N(0, L(0, {"`uvm_object_utils_begin", "("}), L(2, {"l0", ")"})),
         N(1, L(1, {"`uvm_field_int", "("}),
-          N(3, L(3, {"l1a", ","}), L(3, {"UVM_DEFAULT"})), L(1, {")"})),
-        N(1, L(1, {"`uvm_object_utils_begin", "("}), L(3, {"l1"}), L(1, {")"})),
+          N(3, L(3, {"l1a", ","}), L(3, {"UVM_DEFAULT", ")"}))),
+        N(1, L(1, {"`uvm_object_utils_begin", "("}), L(3, {"l1", ")"})),
         N(2, L(2, {"`uvm_field_int", "("}),
-          N(4, L(4, {"l2a", ","}), L(4, {"UVM_DEFAULT"})), L(2, {")"})),
-        N(2, L(2, {"`uvm_object_utils_begin", "("}), L(4, {"l2"}), L(2, {")"})),
+          N(4, L(4, {"l2a", ","}), L(4, {"UVM_DEFAULT", ")"}))),
+        N(2, L(2, {"`uvm_object_utils_begin", "("}), L(4, {"l2", ")"})),
         N(3, L(3, {"`uvm_field_int", "("}),
-          N(5, L(5, {"l3a", ","}), L(5, {"UVM_DEFAULT"})), L(3, {")"})),
+          N(5, L(5, {"l3a", ","}), L(5, {"UVM_DEFAULT", ")"}))),
         L(2, {"`uvm_object_utils_end"}),
         L(1, {"`uvm_object_utils_end"}),
         N(1, L(1, {"`uvm_field_int", "("}),
-          N(3, L(3, {"l1b", ","}), L(3, {"UVM_DEFAULT"})), L(1, {")"})),
+          N(3, L(3, {"l1b", ","}), L(3, {"UVM_DEFAULT", ")"}))),
         L(0, {"`uvm_object_utils_end"}),
     },
 
@@ -2211,11 +2209,11 @@ const TreeUnwrapperTestData kUnwrapUvmTestCases[] = {
         "`uvm_field_utils_begin(l0)\n"
         "`uvm_field_int(l1a, UVM_DEFAULT)\n"
         "`uvm_field_int(l1b, UVM_DEFAULT)\n",
-        N(0, L(0, {"`uvm_field_utils_begin", "("}), L(2, {"l0"}), L(0, {")"})),
+        N(0, L(0, {"`uvm_field_utils_begin", "("}), L(2, {"l0", ")"})),
         N(0, L(0, {"`uvm_field_int", "("}),
-          N(2, L(2, {"l1a", ","}), L(2, {"UVM_DEFAULT"})), L(0, {")"})),
+          N(2, L(2, {"l1a", ","}), L(2, {"UVM_DEFAULT", ")"}))),
         N(0, L(0, {"`uvm_field_int", "("}),
-          N(2, L(2, {"l1b", ","}), L(2, {"UVM_DEFAULT"})), L(0, {")"})),
+          N(2, L(2, {"l1b", ","}), L(2, {"UVM_DEFAULT", ")"}))),
     },
 
     {
@@ -2224,9 +2222,9 @@ const TreeUnwrapperTestData kUnwrapUvmTestCases[] = {
         "`uvm_field_int(l1b, UVM_DEFAULT)\n"
         "`uvm_field_utils_end\n",
         N(0, L(0, {"`uvm_field_int", "("}),
-          N(2, L(2, {"l1a", ","}), L(2, {"UVM_DEFAULT"})), L(0, {")"})),
+          N(2, L(2, {"l1a", ","}), L(2, {"UVM_DEFAULT", ")"}))),
         N(0, L(0, {"`uvm_field_int", "("}),
-          N(2, L(2, {"l1b", ","}), L(2, {"UVM_DEFAULT"})), L(0, {")"})),
+          N(2, L(2, {"l1b", ","}), L(2, {"UVM_DEFAULT", ")"}))),
         L(0, {"`uvm_field_utils_end"}),
     },
 };
@@ -2378,8 +2376,7 @@ const TreeUnwrapperTestData kClassTestCases[] = {
               N(3, L(3, {"// verilog_syntax: parse-as-statements"}),
                 L(3, {"int", "count", ";"}),
                 FlowControl(3, L(3, {"if", "(", "cfg", ")", "begin"}),
-                            L(4, {"count", "=", "1", ";"}), L(3, {"end"}))),
-              L(1, {")"})),
+                            L(4, {"count", "=", "1", ";"}), L(3, {"end", ")"})))),
             L(0, {"endclass"})),
     },
     {
@@ -2401,8 +2398,7 @@ const TreeUnwrapperTestData kClassTestCases[] = {
                 FlowControl(3, L(3, {"if", "(", "cfg", ")", "begin"}),
                             N(4, L(4, {"// parsed comment"}),
                               L(4, {"count", "=", "1", ";"})),
-                            L(3, {"end"}))),
-              L(1, {")"})),
+                            L(3, {"end", ")"})))),
             L(0, {"endclass"})),
     },
 
@@ -3105,7 +3101,7 @@ const TreeUnwrapperTestData kUnwrapPreprocessorTestCases[] = {
         "`define FOO BAR\n"
         "`FOO(baz)\n",
         L(0, {"`define", "FOO", "BAR"}),
-        N(0, L(0, {"`FOO", "("}), L(2, {"baz"}), L(0, {")"})),
+        N(0, L(0, {"`FOO", "("}), L(2, {"baz", ")"})),
     },
 
     {
@@ -3305,8 +3301,7 @@ const TreeUnwrapperTestData kUnwrapPreprocessorTestCases[] = {
                                             ":",          "2",
                                             "]",          ")",
                                             ","}),
-            L(2, {"clk_i", ","}), L(2, {"!", "rst_ni"})),
-          L(0, {")"})),
+            L(2, {"clk_i", ","}), L(2, {"!", "rst_ni", ")"}))),
     },
 
     {
@@ -3343,8 +3338,7 @@ const TreeUnwrapperTestData kUnwrapPreprocessorTestCases[] = {
                       ":",          "2",
                       "]",          ")",
                       ","}),
-                L(3, {"clk_i", ","}), L(3, {"!", "rst_ni"})),
-              L(1, {")"})),
+                L(3, {"clk_i", ","}), L(3, {"!", "rst_ni", ")"}))),
             L(0, {"endmodule"})),
     },
 
@@ -3386,8 +3380,7 @@ const TreeUnwrapperTestData kUnwrapPreprocessorTestCases[] = {
                         ":",          "2",
                         "]",          ")",
                         ","}),
-                  L(4, {"clk_i", ","}), L(4, {"!", "rst_ni"})),
-                L(2, {")"})),
+                  L(4, {"clk_i", ","}), L(4, {"!", "rst_ni", ")"}))),
               L(1, {"end"})),
             L(0, {"endmodule"})),
     },
@@ -4465,7 +4458,7 @@ const TreeUnwrapperTestData kUnwrapFunctionTestCases[] = {
         FunctionDeclaration(
             0, FunctionHeader(0, {"function", "foo", ";"}),
             N(1, L(1, {"y", "=", "`TWISTER", "("}),
-              MacroArgList(3, L(3, {"x", ","}), L(3, {"y"})), L(1, {")", ";"})),
+              MacroArgList(3, L(3, {"x", ","}), L(3, {"y", ")", ";"}))),
             L(0, {"endfunction"})),
     },
 


### PR DESCRIPTION
Going to fix #225 

First attempt to apply kAppendFittingSubpartitions:
Input:
```
`FOOOOOO(bar1...,bar2...,bar3...,bar4)
```
Output:
```
`FOOOOOO(bar1..., bar2..., bar3..., bar4)
```
`-show_token_partition_tree`:
```
  { ([<auto>]) @{0}, policy: append-fitting-sub-partitions
    { ([`FOOOOOO (]) }
    { (>>>>[<auto>]) @{0,1}, policy: fit-else-expand
      { (>>>>[bar1... ,]) }
      { (>>>>[bar2... ,]) }
      { (>>>>[bar3... ,]) }
      { (>>>>[bar4 )]) }
    }
  }
```
After applying `kAppendFittingSubpartitions`:
```
  { ([<auto>]) @{0}, policy: append-fitting-sub-partitions
    { ([<auto>]) @{0,0}, policy: fit-else-expand
      { ([`FOOOOOO (]) }
      { (>>>>[bar1... ,]) }
      { (>>>>[bar2... ,]) }
      { (>>>>[bar3... ,]) }
      { (>>>>[bar4 )]) }
    }
  }
```

And more compilcated input:
```
`MY_MACRO(
// verilog_syntax: parse-as-statements
// EOL comment
int count;
if(cfg.enable) begin
count = 1;
end,
utils_pkg::decrement())
endclass
```
output:
```
class foo;
  `MY_MACRO(  // verilog_syntax: parse-as-statements
            // EOL comment
            int count;
      if (cfg.enable) begin
        count = 1;
      end,
            utils_pkg::decrement())
endclass
```
`-show_token_partition_tree`:
```
  { (>>[<auto>]) @{2}, policy: always-expand
    { (>>[<auto>]) @{2,0}, policy: append-fitting-sub-partitions
      { (>>[`MY_MACRO (]) }
      { (>>>>>>[<auto>]) @{2,0,1}, policy: fit-else-expand
        { (>>>>>>[// verilog_syntax: parse-as-statements]) }
        { (>>>>>>[// EOL comment]) }
        { (>>>>>>[<auto>]) @{2,0,1,2}, policy: fit-else-expand
          { (>>>>>>[int count ;]) }
        }
        { (>>>>>>[<auto>]) @{2,0,1,3}, policy: fit-else-expand
          { (>>>>>>[if ( cfg . enable ) begin]) }
          { (>>>>>>>>[<auto>]) @{2,0,1,3,1}, policy: always-expand
            { (>>>>>>>>[<auto>]) @{2,0,1,3,1,0}, policy: fit-else-expand
              { (>>>>>>>>[count = 1 ;]) }
            }
          }
          { (>>>>>>[end ,]) }
        }
        { (>>>>>>[utils_pkg :: decrement ( ) )]) }
      }
    }
  }
```
After applying `kAppendFittingSubpartitions`:
```
  { (>>[<auto>]) @{2}, policy: always-expand
    { (>>[<auto>]) @{2,0}, policy: append-fitting-sub-partitions
      { (>>[<auto>]) @{2,0,0}, policy: fit-else-expand
        { (>>[`MY_MACRO (]) }
        { (>>>>>>[// verilog_syntax: parse-as-statements]) }
      }
      { (>>>>>>>>>>>>[<auto>]) @{2,0,1}, policy: fit-else-expand
        { (>>>>>>[// EOL comment]) }
      }
      { (>>>>>>>>>>>>[<auto>]) @{2,0,2}, policy: fit-else-expand
        { (>>>>>>[<auto>]) @{2,0,2,0}, policy: fit-else-expand
          { (>>>>>>[int count ;]) }
        }
      }
      { (>>>>>>>>>>>>[<auto>]) @{2,0,3}, policy: fit-else-expand
        { (>>>>>>[<auto>]) @{2,0,3,0}, policy: fit-else-expand
          { (>>>>>>[if ( cfg . enable ) begin]) }
          { (>>>>>>>>[<auto>]) @{2,0,3,0,1}, policy: always-expand
            { (>>>>>>>>[<auto>]) @{2,0,3,0,1,0}, policy: fit-else-expand
              { (>>>>>>>>[count = 1 ;]) }
            }
          }
          { (>>>>>>[end ,]) }
        }
      }
      { (>>>>>>>>>>>>[<auto>]) @{2,0,4}, policy: fit-else-expand
        { (>>>>>>[utils_pkg :: decrement ( ) )]) }
      }
    }
  }
```