### PR TITLE
Add missing macro definitions to fix CI failures

### DIFF
--- a/verilog/CST/DPI_test.cc
+++ b/verilog/CST/DPI_test.cc
@@ -23,6 +23,9 @@
 #include "common/util/range.h"
 #include "verilog/analysis/verilog_analyzer.h"
 
+#undef ASSERT_OK
+#define ASSERT_OK(value) ASSERT_TRUE((value).ok())
+
 namespace verilog {
 namespace {
 

--- a/verilog/CST/declaration_test.cc
+++ b/verilog/CST/declaration_test.cc
@@ -23,6 +23,9 @@
 #include "common/util/range.h"
 #include "verilog/analysis/verilog_analyzer.h"
 
+#undef ASSERT_OK
+#define ASSERT_OK(value) ASSERT_TRUE((value).ok())
+
 namespace verilog {
 namespace {
 


### PR DESCRIPTION
Without this the CI fails. Both with current master and for all new PRs (e.g. #229)