### PR TITLE
Fix dynamic_cast failure on [create-object-name-match] rule

### DIFF
--- a/verilog/analysis/checkers/create_object_name_match_rule.cc
+++ b/verilog/analysis/checkers/create_object_name_match_rule.cc
@@ -121,6 +121,12 @@ static absl::string_view StripOuterQuotes(absl::string_view text) {
 static const TokenInfo* ExtractStringLiteralToken(
     const SyntaxTreeNode& expr_node) {
   if (!expr_node.MatchesTag(NodeEnum::kExpression)) return nullptr;
+
+  // this check is limited to only checking string literal leaf tokens
+  if (expr_node.children().front().get()->Kind() != verible::SymbolKind::kLeaf) {
+    return nullptr;
+  }
+
   const auto* leaf_ptr =
       down_cast<const SyntaxTreeLeaf*>(expr_node.children().front().get());
   if (leaf_ptr != nullptr) {

--- a/verilog/analysis/checkers/create_object_name_match_rule_test.cc
+++ b/verilog/analysis/checkers/create_object_name_match_rule_test.cc
@@ -110,6 +110,16 @@ TEST(CreateObjectNameMatchTest, FunctionFailures) {
        "for (int i = 0; i<N; ++i)\n"
        "  foo_h[i] = foo::type_id::create($sformat(\"asdf_%d\", i)); "
        "endfunction endclass"},  // array assignments are not checked
+      {"class crash2;\n"
+       "  virtual function void a();\n"
+       "    abc = foo::type_id::create(xyz);\n"
+       "  endfunction\n"
+       "endclass\n"}, // non string literal - not verified
+      {"class c;\n"
+       "  virtual function void g();\n"
+       "    foo = s::type_id::create(l(\"bar\"));\n"
+       "  endfunction\n"
+       "endclass\n"}, // non string literal - not verified
   };
 
   RunLintTestCases<VerilogAnalyzer, CreateObjectNameMatchRule>(kTestCases);


### PR DESCRIPTION
Closes #222
Closes #172 

The comment in the file actually says:

```
// Returns token information for a single string literal expression, or nullptr                                                                                                                                                                                                                                                                                              
// if the expression is not a string literal.                                                                                                                                                                                                                                                                                                                                
// `expr_node` should be a SyntaxTreeNode tagged as an expression. 
```

So this extra check in fact verifies if the given token can even be a string literal.

The problem in #222 was that the argument was in fact an expression (called as `l("name")` instead of just `"name"`) and the present checks failed to fully verify that.