### PR TITLE
Implement basic file-based waivers

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,6 +372,20 @@ All lines in between will be waived for rule-X
 // verilog_lint: waive-stop rule-X
 ```
 
+Another option is to use a configuration file with the  `--waivers_file` flag.
+The format of this file is as follows:
+```
+waive --rule=rule-name-1 --line=10
+waive --rule=rule-name-2 --line=5:10
+waive --rule=rule-name-3 --regex="^\s*abc$"
+```
+
+The `--line` flag can be used to specify a single line to apply the waiver to
+or a line range (separated with the `:` character).
+Additionally the `--regex` flag can be used to dynamically match lines on which
+a given rule has to be waived. This is especially useful for projects where
+some of the files are auto-generated.
+
 The name of the rule to waive is at the end of each diagnostic message in `[]`.
 
 Syntax errors cannot be waived. A common source of syntax errors is if the file

--- a/common/analysis/BUILD
+++ b/common/analysis/BUILD
@@ -1,6 +1,7 @@
 # This package contains functions and classes for analyzing text structures.
 
 licenses(["notice"])
+load("//bazel:flex.bzl", "genlex")
 
 package(
     default_visibility = [
@@ -43,18 +44,47 @@ cc_library(
     ],
 )
 
+genlex(
+    name = "config_file_lex",
+    src = "config_file.lex",
+    out = "config_file.yy.cc",
+)
+
+cc_library(
+    name = "config_file_lexer",
+    srcs = [
+        "config_file.yy.cc",
+        "config_file_lexer.cc",
+    ],
+    hdrs = [
+        "config_file_lexer.h",
+        "lint_waiver.h",
+    ],
+    deps = [
+        "//bazel:flex",
+        "//common/lexer:flex_lexer_adapter",
+        "//common/lexer:token_stream_adapter",
+        "//common/text:text_structure",
+        "//common/util:container_util",
+        "//common/util:interval_set",
+    ],
+)
+
 cc_library(
     name = "lint_waiver",
     srcs = ["lint_waiver.cc"],
     hdrs = ["lint_waiver.h"],
     deps = [
+        ":config_file_lexer",
         "//common/strings:comment_utils",
         "//common/text:text_structure",
         "//common/text:token_info",
         "//common/text:token_stream_view",
         "//common/util:container_util",
+        "//common/util:file_util",
         "//common/util:interval_set",
         "//common/util:iterator_range",
+        "//common/util:container_iterator_range",
         "//common/util:logging",
         "@com_google_absl//absl/strings",
     ],

--- a/common/analysis/config_file.lex
+++ b/common/analysis/config_file.lex
@@ -1,0 +1,119 @@
+%{
+#define _WAIVER_FLEXLEXER_H_
+#include "common/analysis/config_file_lexer.h"
+
+#define yy_set_top_state(state)  { yy_pop_state(); yy_push_state(state); }
+%}
+
+%option nodefault
+%option noyywrap
+%option prefix="verible"
+%option c++
+%option yylineno
+%option yyclass="verible::ConfigFileLexer"
+
+LineTerminator \r|\n|\r\n
+InputCharacter [^\r\n\0]
+Space [ \t\f\b]
+
+DecimalDigits [0-9]+
+Alpha [a-zA-Z]
+
+AnyChar ({Alpha}|{DecimalDigits}|-|_|:)
+
+Name {Alpha}({Alpha}|-|_)*
+Value ({AnyChar})*
+QuotedValue ([^\\\"\n]|\\.)*
+
+Quote \"
+
+Command {Name}
+
+ParamPrefix --
+
+Flag {ParamPrefix}{Name}
+FlagWithArg {ParamPrefix}{Name}=
+Arg {Value}
+Param {Value}
+
+
+%x COMMAND
+%x ARG
+%x QUOTED_ARG
+
+%%
+
+{Command} {
+  UpdateLocation();
+  yy_push_state(COMMAND);
+  return CFG_TK_COMMAND;
+}
+
+<COMMAND>{Param} {
+  UpdateLocation();
+  return CFG_TK_PARAM;
+}
+
+<COMMAND>{Flag} {
+  UpdateLocation();
+  return CFG_TK_FLAG;
+}
+
+<COMMAND>{FlagWithArg} {
+  UpdateLocation();
+  yy_push_state(ARG);
+  return CFG_TK_FLAG_WITH_ARG;
+}
+
+<ARG>{Quote} {
+  UpdateLocation();
+  yy_set_top_state(QUOTED_ARG);
+}
+
+<QUOTED_ARG>{QuotedValue} {
+  UpdateLocation();
+  return CFG_TK_ARG;
+}
+
+<QUOTED_ARG>{Quote} {
+  UpdateLocation();
+  yy_pop_state();
+}
+
+<ARG>{Value} {
+  UpdateLocation();
+  yy_pop_state();
+  return CFG_TK_ARG;
+}
+
+<COMMAND>{LineTerminator} {
+  UpdateLocation();
+  yy_pop_state();
+  return CFG_TK_NEWLINE;
+}
+
+<COMMAND><<EOF>> {
+  UpdateLocation();
+  yy_pop_state();
+  return CFG_TK_NEWLINE;
+}
+
+<INITIAL>{LineTerminator} {
+  UpdateLocation();
+}
+
+<*>{LineTerminator} {
+  UpdateLocation();
+  return CFG_TK_ERROR;
+}
+
+<*>{Space} {
+  UpdateLocation();
+}
+
+<*>. {
+  UpdateLocation();
+  return CFG_TK_ERROR;
+}
+
+%%

--- a/common/analysis/config_file_lexer.cc
+++ b/common/analysis/config_file_lexer.cc
@@ -1,0 +1,83 @@
+// Copyright 2017-2020 The Verible Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "common/analysis/config_file_lexer.h"
+
+#include "absl/strings/string_view.h"
+#include "common/analysis/lint_waiver.h"
+#include "common/text/token_info.h"
+#include "common/util/logging.h"
+#include "common/lexer/token_stream_adapter.h"
+
+namespace verible {
+
+ConfigFileLexer::ConfigFileLexer(absl::string_view config)
+    : parent_lexer_type(config) {
+  const auto lex_status = MakeTokenSequence(this,
+                                            config,
+                                            &tokens_,
+                                            [&](const TokenInfo& error_token) {
+                                              LOG(ERROR) << "erroneous token: "
+                                                         << error_token;
+                                            });
+
+  // Pre-process all tokens where its needed
+  for (auto& t: tokens_) {
+    switch (t.token_enum) {
+      case CFG_TK_FLAG:
+        // Skip -- prefix
+        t.text = t.text.substr(2, t.text.length() - 2);
+        break;
+      case CFG_TK_FLAG_WITH_ARG:
+        // Skip -- prefix and = suffix
+        t.text = t.text.substr(2, t.text.length() - 3);
+        break;
+    }
+  }
+
+};
+
+bool ConfigFileLexer::TokenIsError(
+    const verible::TokenInfo& token) const {
+  return false;
+}
+
+std::vector<TokenRange> ConfigFileLexer::GetCommandsTokenRanges() {
+  std::vector<TokenRange> commands;
+
+  auto i = tokens_.cbegin();
+  auto j = i;
+
+  while (1) {
+    // Note that empty lines or lines with whitespace only are skipped
+    // by the lexer and do not have to be handled here
+    j = std::find_if(i + 1, tokens_.cend(),
+                     [](TokenInfo t) {
+                       return t.token_enum == CFG_TK_NEWLINE;
+                     });
+
+    if (j == tokens_.cend()) {
+      break;
+    }
+
+    // Use const iterators, increment j to include last element
+    commands.push_back(make_range(i, ++j));
+
+    i = j;
+  }
+
+  return commands;
+}
+
+}  // namespace verible

--- a/common/analysis/config_file_lexer.h
+++ b/common/analysis/config_file_lexer.h
@@ -1,0 +1,76 @@
+// Copyright 2017-2020 The Verible Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef VERIBLE_CONFIG_FILE_LEXER_H__
+#define VERIBLE_CONFIG_FILE_LEXER_H__
+
+// lint_waiver_config.lex has "%prefix=verible", meaning the class flex
+// creates is veribleFlexLexer. Unfortunately, FlexLexer.h doesn't have proper
+// ifdefs around its inclusion, so we have to put a bar around it here.
+#include "common/analysis/lint_waiver.h"
+#include "common/lexer/flex_lexer_adapter.h"
+#include "common/text/token_info.h"
+#ifndef _WAIVER_FLEXLEXER_H_
+#undef yyFlexLexer  // this is how FlexLexer.h says to do things
+#define yyFlexLexer veribleFlexLexer
+#include <FlexLexer.h>
+#endif
+
+#include "absl/strings/string_view.h"
+
+namespace verible {
+
+// Acceptable syntax:
+//
+// CFG_TK_COMMAND [--CFG_TK_FLAG] [--CFG_TK_FLAG_WITH_ARG=CFG_TK_ARG] [CFG_TK_PARAM]
+enum ConfigTokenEnum {
+  CFG_TK_COMMAND = 1,
+  CFG_TK_FLAG,
+  CFG_TK_FLAG_WITH_ARG,
+  CFG_TK_ARG,
+  CFG_TK_PARAM,
+  CFG_TK_NEWLINE,
+  CFG_TK_ERROR,
+};
+
+enum ConfigParserStateEnum {
+  PARSER_INIT,
+  PARSER_COMMAND,
+};
+
+
+class ConfigFileLexer :
+    public verible::FlexLexerAdapter<veribleFlexLexer> {
+  using parent_lexer_type = verible::FlexLexerAdapter<veribleFlexLexer>;
+  using parent_lexer_type::Restart;
+
+ public:
+  explicit ConfigFileLexer(absl::string_view config);
+
+  // Main lexing function. Will be defined by Flex.
+  int yylex() override;
+
+  // Returns true if token is invalid.
+  bool TokenIsError(const verible::TokenInfo&) const override;
+
+  // Runs the Lexer and attached command handlers
+  std::vector<TokenRange> GetCommandsTokenRanges();
+
+ private:
+  TokenSequence tokens_;
+};
+
+}  // namespace verible
+
+#endif  // VERIBLE_CONFIG_FILE_LEXER_H__

--- a/common/analysis/lint_waiver.cc
+++ b/common/analysis/lint_waiver.cc
@@ -23,6 +23,7 @@
 #include <set>
 #include <utility>
 #include <vector>
+#include <regex>
 
 #include "absl/strings/str_split.h"
 #include "absl/strings/string_view.h"
@@ -30,8 +31,12 @@
 #include "common/text/text_structure.h"
 #include "common/text/token_info.h"
 #include "common/text/token_stream_view.h"
+#include "common/util/file_util.h"
 #include "common/util/iterator_range.h"
+#include "common/util/container_iterator_range.h"
 #include "common/util/logging.h"
+
+#include "common/analysis/config_file_lexer.h"
 
 namespace verible {
 
@@ -43,6 +48,32 @@ void LintWaiver::WaiveLineRange(absl::string_view rule_name, size_t line_begin,
                                 size_t line_end) {
   LineSet& line_set = waiver_map_[rule_name];
   line_set.Add({line_begin, line_end});
+}
+
+void LintWaiver::WaiveWithRegex(absl::string_view rule_name,
+                                std::string regex_str) {
+  RegexVector& regex_vector = waiver_re_map_[rule_name];
+  auto regex_iter = regex_cache_.find(regex_str);
+
+  if (regex_iter == regex_cache_.end()) {
+    regex_cache_[regex_str] = std::regex(regex_str);
+  }
+
+  regex_vector.push_back(&regex_cache_[regex_str]);
+}
+
+void LintWaiver::RegexToLines(absl::string_view contents,
+                              const LineColumnMap& line_map) {
+  for (const auto& rule: waiver_re_map_) {
+    for (const auto* re: rule.second) {
+      for (std::cregex_iterator i(contents.begin(), contents.end(), *re);
+           i != std::cregex_iterator(); i++) {
+        std::cmatch match = *i;
+        WaiveOneLine(rule.first, line_map(match.position()).line);
+      }
+    }
+  }
+
 }
 
 bool LintWaiver::RuleIsWaivedOnLine(absl::string_view rule_name,
@@ -170,6 +201,10 @@ void LintWaiverBuilder::ProcessTokenRangesByLine(
     ProcessLine(token_range, i);
   }
 
+  // Apply regex waivers
+  lint_waiver_.RegexToLines(text_structure.Contents(),
+                            text_structure.GetLineColumnMap());
+
   // Flush out any remaining open-ranges, so that those waivers take effect
   // until the end-of-file.
   // TODO(b/78064145): Detect these as suspiciously unbalanced waiver uses.
@@ -178,6 +213,249 @@ void LintWaiverBuilder::ProcessTokenRangesByLine(
                                 total_lines);
   }
   waiver_open_ranges_.clear();
+}
+
+template <typename... T>
+static std::string WaiveCommandErrorFmt(LineColumn pos,
+                                                 absl::string_view filename,
+                                                 absl::string_view msg,
+                                                 T&... args) {
+  return absl::StrCat(filename, ":", pos.line + 1, ":", pos.column + 1,
+                      ": command error: ", msg, args...);
+}
+
+template <typename... T>
+static absl::Status WaiveCommandError(LineColumn pos,
+                                      absl::string_view filename,
+                                      absl::string_view msg,
+                                      T&... args) {
+
+  return absl::InvalidArgumentError(
+      WaiveCommandErrorFmt(pos, filename, msg, args...));
+}
+
+absl::Status WaiveCommandHandler(
+    const TokenRange& tokens,
+    absl::string_view filename,
+    absl::string_view config_base,
+    const LineColumnMap& line_map,
+    LintWaiver* waiver,
+    const std::set<absl::string_view> &active_rules) {
+  absl::string_view rule;
+
+  absl::string_view arg;
+  absl::string_view val;
+
+  int line_start = -1;
+  int line_end = -1;
+  std::string regex;
+
+  bool can_use_regex = false;
+  bool can_use_lineno = false;
+
+  LineColumn token_pos;
+  LineColumn regex_token_pos = {};
+
+  for (const auto& token : tokens) {
+    token_pos = line_map(token.left(config_base));
+
+    switch (token.token_enum) {
+    case CFG_TK_COMMAND:
+      // Verify that this command is supported by this handler
+      if (token.text != "waive") {
+        return absl::InvalidArgumentError("Invalid command handler called");
+      }
+      break;
+    case CFG_TK_ERROR:
+      return WaiveCommandError(token_pos, filename, "Configuration error");
+    case CFG_TK_PARAM:
+    case CFG_TK_FLAG:
+      return WaiveCommandError(token_pos, filename, "Unsupported argument: ",
+                               token.text);
+    case CFG_TK_FLAG_WITH_ARG:
+      arg = token.text;
+      break;
+    case CFG_TK_ARG:
+
+      val = token.text;
+
+      if (arg == "rule") {
+        for (auto r : active_rules) {
+          if (val == r) {
+            rule = r;
+            break;
+          }
+        }
+
+        if (rule == nullptr) {
+          return WaiveCommandError(token_pos, filename, "Invalid rule: ", val);
+        }
+
+        break;
+      }
+
+      if (arg == "line") {
+        size_t range = val.find(":");
+        if (range != absl::string_view::npos) {
+          // line range
+          if (!absl::SimpleAtoi(val.substr(0, range), &line_start) ||
+              !absl::SimpleAtoi(val.substr(range + 1, val.length() - range),
+                                &line_end)){
+            return WaiveCommandError(token_pos, filename,
+                                     "Unable to parse range: ", val);
+          }
+        } else {
+          // single line
+          if (!absl::SimpleAtoi(val, &line_start)) {
+            return WaiveCommandError(token_pos, filename,
+                                     "Unable to parse line number: ", val);
+          }
+          line_end = line_start;
+        }
+
+        if (line_start < 1) {
+          return WaiveCommandError(token_pos, filename,
+                                   "Invalid line number: ", val);
+        } else if (line_start > line_end) {
+          return WaiveCommandError(token_pos, filename,
+                                   "Invalid line range: ", val);
+        }
+
+        can_use_lineno = true;
+        continue;
+      }
+
+      if (arg == "regex") {
+        // Pre-compile regex to see if it's valid
+        regex = std::string(val);
+        can_use_regex = true;
+
+        // Save a copy to token pos in case the regex is invalid
+        regex_token_pos = token_pos;
+        continue;
+      }
+
+      return WaiveCommandError(token_pos, filename, "Unsupported flag: ", arg);
+
+    case CFG_TK_NEWLINE:
+      // Check if everything required has been set
+      if (rule == nullptr || (!can_use_regex && !can_use_lineno)) {
+        return WaiveCommandError(token_pos, filename,
+                                "Insufficient waiver configuration");
+      }
+
+      if (can_use_regex && can_use_lineno) {
+        return WaiveCommandError(
+            token_pos, filename,
+            "Regex and line flags are mutually exclusive");
+      }
+
+      if (can_use_regex) {
+        try {
+          waiver->WaiveWithRegex(rule, regex);
+        } catch (std::regex_error& e) {
+          auto *reason = e.what();
+
+          return WaiveCommandError(regex_token_pos, filename,
+                                   "Invalid regex: ", reason);
+        }
+      }
+
+      if (can_use_lineno) {
+        waiver->WaiveLineRange(rule, line_start - 1, line_end);
+      }
+
+      return absl::OkStatus();
+    default:
+      return WaiveCommandError(token_pos, filename, "Expecting arguments");
+    }
+  }
+
+  return absl::OkStatus();
+}
+
+static const std::map<absl::string_view,
+                      std::function<absl::Status(
+                          const TokenRange&,
+                          absl::string_view,
+                          absl::string_view,
+                          const LineColumnMap&,
+                          LintWaiver*,
+                          const std::set<absl::string_view>&)>>&
+    GetCommandHandlers() {
+  // allocated once, never freed
+  static const auto* handlers =
+    new std::map<absl::string_view,
+                 std::function<absl::Status(
+                     const TokenRange&,
+                     absl::string_view,
+                     absl::string_view,
+                     const LineColumnMap&,
+                     LintWaiver*,
+                     const std::set<absl::string_view>&)>> {
+    {"waive", WaiveCommandHandler},
+  };
+  return *handlers;
+}
+
+absl::Status LintWaiverBuilder::ApplyExternalWaivers(
+    const std::set<absl::string_view> &active_rules,
+    absl::string_view filename,
+    absl::string_view waivers_config_content) {
+
+  if (waivers_config_content == nullptr) {
+    return absl::Status(absl::StatusCode::kInternal,
+                        "Broken waiver config handle");
+  }
+
+  ConfigFileLexer lexer{waivers_config_content};
+  const LineColumnMap line_map(waivers_config_content);
+  LineColumn command_pos;
+
+  const auto& handlers = GetCommandHandlers();
+
+  std::vector<TokenRange> commands = lexer.GetCommandsTokenRanges();
+
+  bool all_commands_ok = true;
+  for (const auto c_range: commands) {
+    const auto command = make_container_range(c_range.begin(), c_range.end());
+
+    command_pos = line_map(command.begin()->left(waivers_config_content));
+
+    // The very first Token in 'command' should be an actual command
+    if (command.empty() || command[0].token_enum != CFG_TK_COMMAND) {
+      LOG(ERROR) << WaiveCommandErrorFmt(command_pos, filename,
+                                         "Not a command: ", command[0].text);
+      all_commands_ok = false;
+      continue;
+    }
+
+    // Check if command is supported
+    auto handler_iter = handlers.find(command[0].text);
+    if (handler_iter == handlers.end()) {
+      LOG(ERROR) << WaiveCommandErrorFmt(command_pos, filename,
+                                         "Command not supported: ",
+                                         command[0].text);
+      all_commands_ok = false;
+      continue;
+    }
+
+    auto status = handler_iter->second(command, filename,
+                                       waivers_config_content, line_map,
+                                       &lint_waiver_, active_rules);
+    if (!status.ok()) {
+      // Mark the return value to be false, but continue parsing the config
+      // file anyway
+      all_commands_ok = false;
+      LOG(ERROR) << status.message();
+    }
+  }
+
+  if (all_commands_ok) {
+    return absl::OkStatus();
+  } else {
+    return absl::InvalidArgumentError("Errors applying external waivers.");
+  }
 }
 
 }  // namespace verible

--- a/common/analysis/lint_waiver.h
+++ b/common/analysis/lint_waiver.h
@@ -19,6 +19,7 @@
 #include <map>
 #include <set>
 #include <vector>
+#include <regex>
 
 #include "absl/strings/string_view.h"
 #include "common/text/text_structure.h"
@@ -33,6 +34,7 @@ namespace verible {
 class LintWaiver {
   // Compact set of line numbers.
   using LineSet = IntervalSet<size_t>;
+  using RegexVector = std::vector<const std::regex*>;
 
  public:
   LintWaiver() {}
@@ -54,6 +56,15 @@ class LintWaiver {
   void WaiveLineRange(absl::string_view rule_name, size_t line_begin,
                       size_t line_end);
 
+  // Adds a regular expression which will be used to apply a waiver.
+  void WaiveWithRegex(absl::string_view rule_name,
+                      std::string regex);
+
+  // Converts the prepared regular expressions to line numbers and applies the
+  // waivers.
+  void RegexToLines(absl::string_view content,
+                    const LineColumnMap& line_map);
+
   // Returns true if `line_number` should be waived for a particular rule.
   bool RuleIsWaivedOnLine(absl::string_view rule_name,
                           size_t line_number) const;
@@ -73,9 +84,14 @@ class LintWaiver {
   }
 
  private:
-  // Key can be string_view because the static strings for each lint rule
-  // class exist, and will outlive all LintWaiver objects.
+  // Keys in the maps below are the names of the waived rules. They can be
+  // string_view because the static strings for each lint rule class exist,
+  // and will outlive all LintWaiver objects. This applies to both waiver_map_
+  // and waiver_re_map_.
   std::map<absl::string_view, LineSet> waiver_map_;
+  std::map<absl::string_view, RegexVector> waiver_re_map_;
+
+  std::map<std::string, std::regex> regex_cache_;
 };
 
 // LintWaiverBuilder is a language-agnostic helper class for constructing
@@ -123,6 +139,13 @@ class LintWaiverBuilder {
   // waived lines.  This can be more easily unit-tested using
   // TextStructureTokenized from text_structure_test_utils.h.
   void ProcessTokenRangesByLine(const TextStructureView&);
+
+  // Takes a set of active linter rules and the filename and the content of
+  // a waiver configuration file
+  absl::Status ApplyExternalWaivers(
+      const std::set<absl::string_view> &active_rules,
+      absl::string_view filename,
+      absl::string_view waivers_config_content);
 
   const LintWaiver& GetLintWaiver() const { return lint_waiver_; }
 

--- a/common/analysis/lint_waiver_test.cc
+++ b/common/analysis/lint_waiver_test.cc
@@ -620,5 +620,179 @@ TEST_F(LintWaiverBuilderTest, FromTextStructureOneWaiverRangeOpened) {
   EXPECT_TRUE(lint_waiver.RuleIsWaivedOnLine("qq-rule", 3));
 }
 
+TEST_F(LintWaiverBuilderTest, ApplyExternalWaiversInvalidCases) {
+  std::set<absl::string_view> active_rules;
+  const absl::string_view filename = "filename";
+
+  // Completely invalid config
+  const absl::string_view cfg_inv =
+    "inv config";
+  EXPECT_FALSE(ApplyExternalWaivers(active_rules, filename, cfg_inv).ok());
+
+  const absl::string_view cfg_inv_2 =
+    "--line=1";
+  EXPECT_FALSE(ApplyExternalWaivers(active_rules, filename, cfg_inv_2).ok());
+
+  // Valid command, invalid parameters
+  const absl::string_view cfg_inv_params =
+    "waive --something";
+  EXPECT_FALSE(ApplyExternalWaivers(active_rules, filename, cfg_inv_params).ok());
+
+  // Non-registered rule name
+  const absl::string_view cfg_inv_rule =
+    "waive --rule=abc --line=1";
+  EXPECT_FALSE(ApplyExternalWaivers(active_rules, filename, cfg_inv_rule).ok());
+
+  // register rule
+  const absl::string_view abc_rule = "abc";
+  active_rules.insert(abc_rule);
+
+  // Valid rule, missing params
+  const absl::string_view cfg_no_param =
+    "waive --rule=abc";
+  EXPECT_FALSE(ApplyExternalWaivers(active_rules, filename, cfg_no_param).ok());
+
+  // Valid rule, invalid line number
+  const absl::string_view cfg_inv_lineno =
+    "waive --rule=abc --line=0";
+  EXPECT_FALSE(ApplyExternalWaivers(active_rules, filename, cfg_inv_lineno).ok());
+
+  // Valid rule, invalid line range
+  const absl::string_view cfg_inv_range =
+    "waive --rule=abc --line=1:0";
+  EXPECT_FALSE(ApplyExternalWaivers(active_rules, filename, cfg_inv_range).ok());
+
+  // Valid rule, invalid regex
+  const absl::string_view cfg_inv_regex =
+    "waive --rule=abc --regex=\"(\"";
+  EXPECT_FALSE(ApplyExternalWaivers(active_rules, filename, cfg_inv_regex).ok());
+
+  // Valid rule, both regex and lines specified
+  const absl::string_view cfg_conflict =
+    "waive --rule=abc --regex=\".*\" --line=1";
+  EXPECT_FALSE(ApplyExternalWaivers(active_rules, filename, cfg_conflict).ok());
+
+  // Missing rulename
+  const absl::string_view cfg_no_rule =
+    "waive --line=1";
+  EXPECT_FALSE(ApplyExternalWaivers(active_rules, filename, cfg_no_rule).ok());
+
+  // Check that even though some rules are invalid, the consecutive ones
+  // are still parsed and applied
+  const absl::string_view cfg_mixed =
+    "waive --line=1\ndasdasda\nwaive --rule=abc --line=10";
+  EXPECT_FALSE(ApplyExternalWaivers(active_rules, filename, cfg_mixed).ok());
+  EXPECT_FALSE(lint_waiver_.RuleIsWaivedOnLine("abc", 8));
+  EXPECT_TRUE(lint_waiver_.RuleIsWaivedOnLine("abc", 9));
+  EXPECT_FALSE(lint_waiver_.RuleIsWaivedOnLine("abc", 10));
+}
+
+TEST_F(LintWaiverBuilderTest, ApplyExternalWaiversValidCases) {
+  const std::set<absl::string_view> active_rules{"abc"};
+  const absl::string_view filename = "filename";
+
+  // Completely invalid config
+  const absl::string_view cfg_line =
+    "waive --rule=abc --line=1";
+  EXPECT_TRUE(ApplyExternalWaivers(active_rules, filename, cfg_line).ok());
+  EXPECT_TRUE(lint_waiver_.RuleIsWaivedOnLine("abc", 0));
+  EXPECT_FALSE(lint_waiver_.RuleIsWaivedOnLine("abc", 1));
+
+  const absl::string_view cfg_line_inv_ord =
+    "waive --line=3 --rule=abc";
+  EXPECT_TRUE(ApplyExternalWaivers(active_rules, filename, cfg_line_inv_ord).ok());
+  EXPECT_FALSE(lint_waiver_.RuleIsWaivedOnLine("abc", 1));
+  EXPECT_TRUE(lint_waiver_.RuleIsWaivedOnLine("abc", 2));
+  EXPECT_FALSE(lint_waiver_.RuleIsWaivedOnLine("abc", 3));
+
+  const absl::string_view cfg_quotes =
+    "waive --rule=\"abc\" --line=5";
+  EXPECT_TRUE(ApplyExternalWaivers(active_rules, filename, cfg_quotes).ok());
+  EXPECT_FALSE(lint_waiver_.RuleIsWaivedOnLine("abc", 3));
+  EXPECT_TRUE(lint_waiver_.RuleIsWaivedOnLine("abc", 4));
+  EXPECT_FALSE(lint_waiver_.RuleIsWaivedOnLine("abc", 5));
+
+  const absl::string_view cfg_line_range =
+    "waive --rule=abc --line=7:9";
+  EXPECT_TRUE(ApplyExternalWaivers(active_rules, filename, cfg_line_range).ok());
+  EXPECT_FALSE(lint_waiver_.RuleIsWaivedOnLine("abc", 5));
+  EXPECT_TRUE(lint_waiver_.RuleIsWaivedOnLine("abc", 6));
+  EXPECT_TRUE(lint_waiver_.RuleIsWaivedOnLine("abc", 7));
+  EXPECT_TRUE(lint_waiver_.RuleIsWaivedOnLine("abc", 8));
+  EXPECT_FALSE(lint_waiver_.RuleIsWaivedOnLine("abc", 9));
+
+  const absl::string_view cfg_line_range_i =
+    "waive --rule=abc --line=11:11";
+  EXPECT_TRUE(ApplyExternalWaivers(active_rules, filename, cfg_line_range_i).ok());
+  EXPECT_FALSE(lint_waiver_.RuleIsWaivedOnLine("abc", 9));
+  EXPECT_TRUE(lint_waiver_.RuleIsWaivedOnLine("abc", 10));
+  EXPECT_FALSE(lint_waiver_.RuleIsWaivedOnLine("abc", 11));
+
+  const absl::string_view cfg_regex =
+    "waive --rule=abc --regex=abc";
+  EXPECT_TRUE(ApplyExternalWaivers(active_rules, filename, cfg_regex).ok());
+
+  const absl::string_view cfg_regex_complex =
+    "waive --rule=abc --regex=\"abc .*\"";
+  EXPECT_TRUE(ApplyExternalWaivers(active_rules, filename, cfg_regex_complex).ok());
+}
+
+TEST_F(LintWaiverBuilderTest, RegexToLinesSimple) {
+  const std::set<absl::string_view> active_rules{"rule-1"};
+  const absl::string_view filename = "filename";
+
+  const absl::string_view cfg_regex =
+    "waive --rule=rule-1 --regex=def";
+  EXPECT_TRUE(ApplyExternalWaivers(active_rules, filename, cfg_regex).ok());
+
+  const absl::string_view file = "abc\ndef\nghi\n";
+  const LineColumnMap line_map(file);
+
+  lint_waiver_.RegexToLines(file, line_map);
+
+  // The rule should be waived on the second line only (0-based indexing)
+  EXPECT_FALSE(lint_waiver_.RuleIsWaivedOnLine("rule-1", 0));
+  EXPECT_TRUE(lint_waiver_.RuleIsWaivedOnLine("rule-1", 1));
+  EXPECT_FALSE(lint_waiver_.RuleIsWaivedOnLine("rule-1", 2));
+}
+
+TEST_F(LintWaiverBuilderTest, RegexToLinesCatchAll) {
+  const std::set<absl::string_view> active_rules{"rule-1"};
+  const absl::string_view filename = "filename";
+
+  const absl::string_view cfg_regex =
+    "waive --rule=rule-1 --regex=\".*\"";
+  EXPECT_TRUE(ApplyExternalWaivers(active_rules, filename, cfg_regex).ok());
+
+  const absl::string_view file = "abc\ndef\nghi\n";
+  const LineColumnMap line_map(file);
+
+  lint_waiver_.RegexToLines(file, line_map);
+
+  // The rule should be waived on all lines
+  EXPECT_TRUE(lint_waiver_.RuleIsWaivedOnLine("rule-1", 0));
+  EXPECT_TRUE(lint_waiver_.RuleIsWaivedOnLine("rule-1", 1));
+  EXPECT_TRUE(lint_waiver_.RuleIsWaivedOnLine("rule-1", 2));
+}
+
+TEST_F(LintWaiverBuilderTest, RegexToLinesMultipleMatches) {
+  const std::set<absl::string_view> active_rules{"rule-1"};
+  const absl::string_view filename = "filename";
+
+  const absl::string_view cfg_regex =
+    "waive --rule=rule-1 --regex=\"[0-9]\"";
+  EXPECT_TRUE(ApplyExternalWaivers(active_rules, filename, cfg_regex).ok());
+
+  const absl::string_view file = "abc1\ndef\ng2hi\n";
+  const LineColumnMap line_map(file);
+
+  lint_waiver_.RegexToLines(file, line_map);
+
+  // The rule should be waived on all lines that contain any digits
+  EXPECT_TRUE(lint_waiver_.RuleIsWaivedOnLine("rule-1", 0));
+  EXPECT_FALSE(lint_waiver_.RuleIsWaivedOnLine("rule-1", 1));
+  EXPECT_TRUE(lint_waiver_.RuleIsWaivedOnLine("rule-1", 2));
+}
+
 }  // namespace
 }  // namespace verible

--- a/verilog/analysis/verilog_linter.cc
+++ b/verilog/analysis/verilog_linter.cc
@@ -60,6 +60,9 @@ ABSL_FLAG(std::string, rules_config, ".rules.verible_lint",
           "Path to lint rules configuration file.");
 ABSL_FLAG(verilog::RuleSet, ruleset, verilog::RuleSet::kDefault,
           "[default|all|none], the base set of rules used by linter");
+ABSL_FLAG(std::string, waivers_file, "",
+          "Path to waivers file. Please refer to the README file for "
+          " information about its format.");
 
 namespace verilog {
 
@@ -120,7 +123,8 @@ VerilogLinter::VerilogLinter()
           kLinterTrigger, kLinterWaiveLineCommand, kLinterWaiveStartCommand,
           kLinterWaiveStopCommand) {}
 
-void VerilogLinter::Configure(const LinterConfiguration& configuration) {
+absl::Status VerilogLinter::Configure(
+    const LinterConfiguration& configuration) {
   if (VLOG_IS_ON(1)) {
     for (const auto& name : configuration.ActiveRuleIds()) {
       LOG(INFO) << "active rule: '" << name << '\'';
@@ -142,6 +146,21 @@ void VerilogLinter::Configure(const LinterConfiguration& configuration) {
   for (auto& rule : syntax_rules) {
     syntax_tree_linter_.AddRule(std::move(rule));
   }
+
+  if (!configuration.external_waivers.empty()) {
+    std::string content;
+    if (verible::file::GetContents(configuration.external_waivers, &content)) {
+      return lint_waiver_.ApplyExternalWaivers(configuration.ActiveRuleIds(),
+                                               configuration.external_waivers,
+                                               content);
+    } else {
+      return absl::UnavailableError(absl::StrCat(
+          "Unable to read waivers configuration - ",
+          configuration.external_waivers));
+    }
+  }
+
+  return absl::OkStatus();
 }
 
 void VerilogLinter::Lint(const TextStructureView& text_structure,
@@ -209,6 +228,8 @@ std::vector<LintRuleStatus> VerilogLinter::ReportStatus(
 LinterConfiguration LinterConfigurationFromFlags() {
   LinterConfiguration config;
 
+  // TODO move all of these calls to GetFlag outside of this function
+
   // Turn on default ruleset.
   const auto& ruleset = absl::GetFlag(FLAGS_ruleset);
   config.UseRuleSet(ruleset);
@@ -234,6 +255,9 @@ LinterConfiguration LinterConfigurationFromFlags() {
   const auto& rules = absl::GetFlag(FLAGS_rules);
   config.UseRuleBundle(rules);
 
+  // Apply external waivers
+  config.external_waivers = absl::GetFlag(FLAGS_waivers_file);
+
   return config;
 }
 
@@ -244,7 +268,11 @@ absl::Status VerilogLintTextStructure(std::ostream* stream,
                                       const TextStructureView& text_structure) {
   // Create the linter, add rules, and run it.
   VerilogLinter linter;
-  linter.Configure(config);
+  const absl::Status configuration_status = linter.Configure(config);
+  if (!configuration_status.ok()) {
+    return configuration_status;
+  }
+
   linter.Lint(text_structure, filename);
 
   const absl::string_view text_base = text_structure.Contents();

--- a/verilog/analysis/verilog_linter.h
+++ b/verilog/analysis/verilog_linter.h
@@ -55,7 +55,7 @@ class VerilogLinter {
   VerilogLinter();
 
   // Configures the internal linters, enabling select rules.
-  void Configure(const LinterConfiguration& configuration);
+  absl::Status Configure(const LinterConfiguration& configuration);
 
   // Analyzes text structure.
   void Lint(const verible::TextStructureView& text_structure,

--- a/verilog/analysis/verilog_linter_configuration.h
+++ b/verilog/analysis/verilog_linter_configuration.h
@@ -196,6 +196,9 @@ class LinterConfiguration {
   std::vector<std::unique_ptr<verible::TextStructureLintRule>>
   CreateTextStructureRules() const;
 
+  // Path to external lint waivers configuration file
+  std::string external_waivers;
+
   // Returns true if configurations are equivalent.
   bool operator==(const LinterConfiguration&) const;
 

--- a/verilog/analysis/verilog_linter_configuration_test.cc
+++ b/verilog/analysis/verilog_linter_configuration_test.cc
@@ -258,7 +258,7 @@ TEST(VerilogSyntaxTreeLinterConfigurationTest, AddsExpectedNumber) {
   EXPECT_THAT(config.ActiveRuleIds(), SizeIs(2));
 
   VerilogLinter linter;
-  linter.Configure(config);
+  EXPECT_TRUE(linter.Configure(config).ok());
   FakeTextStructureView text_structure;
   linter.Lint(text_structure, filename);
 
@@ -275,7 +275,7 @@ TEST(VerilogTokenStreamLinterConfigurationTest, AddsExpectedNumber) {
   EXPECT_THAT(config.ActiveRuleIds(), SizeIs(1));
 
   VerilogLinter linter;
-  linter.Configure(config);
+  EXPECT_TRUE(linter.Configure(config).ok());
   FakeTextStructureView text_structure;
   linter.Lint(text_structure, filename);
 
@@ -292,7 +292,7 @@ TEST(VerilogLineLinterConfigurationTest, AddsExpectedNumber) {
   EXPECT_THAT(config.ActiveRuleIds(), SizeIs(1));
 
   VerilogLinter linter;
-  linter.Configure(config);
+  EXPECT_TRUE(linter.Configure(config).ok());
   FakeTextStructureView text_structure;
   linter.Lint(text_structure, filename);
 
@@ -309,7 +309,7 @@ TEST(VerilogTextStructureLinterConfigurationTest, AddsExpectedNumber) {
   EXPECT_THAT(config.ActiveRuleIds(), SizeIs(1));
 
   VerilogLinter linter;
-  linter.Configure(config);
+  EXPECT_TRUE(linter.Configure(config).ok());
   FakeTextStructureView text_structure;
   linter.Lint(text_structure, filename);
 
@@ -328,7 +328,7 @@ TEST(VerilogSyntaxTreeLinterConfigurationTest, TurnOnTurnOff) {
   EXPECT_THAT(config.ActiveRuleIds(), IsEmpty());
 
   VerilogLinter linter;
-  linter.Configure(config);
+  EXPECT_TRUE(linter.Configure(config).ok());
   FakeTextStructureView text_structure;
   linter.Lint(text_structure, filename);
 
@@ -399,7 +399,7 @@ TEST(VerilogSyntaxTreeLinterConfigurationTest, DefaultEmpty) {
   EXPECT_THAT(config.ActiveRuleIds(), IsEmpty());
 
   VerilogLinter linter;
-  linter.Configure(config);
+  EXPECT_TRUE(linter.Configure(config).ok());
   FakeTextStructureView text_structure;
   linter.Lint(text_structure, filename);
 
@@ -418,7 +418,7 @@ TEST(VerilogSyntaxTreeLinterConfigurationTest, UseRuleSetAll) {
   EXPECT_THAT(config.ActiveRuleIds(), SizeIs(expected_size));
 
   VerilogLinter linter;
-  linter.Configure(config);
+  EXPECT_TRUE(linter.Configure(config).ok());
   FakeTextStructureView text_structure;
   linter.Lint(text_structure, filename);
 
@@ -432,7 +432,7 @@ TEST(VerilogSyntaxTreeLinterConfigurationTest, UseRuleSetNone) {
   EXPECT_THAT(config.ActiveRuleIds(), IsEmpty());
 
   VerilogLinter linter;
-  linter.Configure(config);
+  EXPECT_TRUE(linter.Configure(config).ok());
   FakeTextStructureView text_structure;
   linter.Lint(text_structure, filename);
 
@@ -450,7 +450,7 @@ TEST(VerilogSyntaxTreeLinterConfigurationTest, NoneResets) {
   EXPECT_THAT(config.ActiveRuleIds(), IsEmpty());
 
   VerilogLinter linter;
-  linter.Configure(config);
+  EXPECT_TRUE(linter.Configure(config).ok());
   FakeTextStructureView text_structure;
   linter.Lint(text_structure, filename);
 
@@ -463,7 +463,7 @@ TEST(VerilogSyntaxTreeLinterConfigurationTest, UseRuleSetDefault) {
   config.UseRuleSet(RuleSet::kDefault);
 
   VerilogLinter linter;
-  linter.Configure(config);
+  EXPECT_TRUE(linter.Configure(config).ok());
   FakeTextStructureView text_structure;
   linter.Lint(text_structure, filename);
 


### PR DESCRIPTION
This is an initial implementation of what could serve as an answer to #105.

The waiver file can be specified with a flag. The syntax of the file is:
```
waive <rule name> <line_begin> [line_end]
```

I am going to continue working on this to make it more sophisticated (e.g. add filename matching, maybe matching lines with regex as suggested in #105), but as usually I am opening this early in case there are some comments that are fundamentally against what I am doing here.