### PR TITLE
In create-version-header: use less system-specific features.

### DIFF
--- a/common/util/BUILD
+++ b/common/util/BUILD
@@ -64,6 +64,7 @@ cc_library(
         "@com_google_absl//absl/flags:flag",
         "@com_google_absl//absl/flags:parse",
         "@com_google_absl//absl/flags:usage",
+        "@com_google_absl//absl/time:time",
         "@com_google_absl//absl/strings",
     ],
 )

--- a/common/util/create_version_header.sh
+++ b/common/util/create_version_header.sh
@@ -16,13 +16,9 @@
 # The file where bazel stores name/value pairs
 BAZEL_VOLATILE=bazel-out/volatile-status.txt
 
-GIT_DATE="$(grep -s GIT_DATE $BAZEL_VOLATILE | cut -f2- -d' ')"
-GIT_DESC="$(grep -s GIT_DESCRIBE $BAZEL_VOLATILE | cut -f2- -d' ')"
-
-# Timestamp is always provided by bazel.
-TS_INT="$(grep -s BUILD_TIMESTAMP $BAZEL_VOLATILE | cut -f2 -d' ')"
-test -z "$TS_INT" || TS_STRING="$(date +"%Y-%m-%dT%H:%M:%SZ" -u -d @$TS_INT)"
-
-test -z "$GIT_DATE"  || echo "#define VERIBLE_GIT_DATE $GIT_DATE"
-test -z "$GIT_DESC"  || echo "#define VERIBLE_GIT_DESC $GIT_DESC"
-test -z "$TS_STRING" || echo "#define VERIBLE_BUILD_TIMESTAMP \"$TS_STRING\""
+(while read NAME VALUE ; do
+   case $NAME in
+     # Only select the ones we're interested in.
+     GIT_* | BUILD_TIMESTAMP) echo "#define VERIBLE_${NAME} ${VALUE}"
+   esac
+ done) < "$BAZEL_VOLATILE"

--- a/common/util/create_version_header.sh
+++ b/common/util/create_version_header.sh
@@ -19,6 +19,8 @@ BAZEL_VOLATILE=bazel-out/volatile-status.txt
 (while read NAME VALUE ; do
    case $NAME in
      # Only select the ones we're interested in.
-     GIT_* | BUILD_TIMESTAMP) echo "#define VERIBLE_${NAME} ${VALUE}"
+     GIT_* | BUILD_TIMESTAMP)
+       echo "#define VERIBLE_${NAME} ${VALUE}"
+       ;;
    esac
  done) < "$BAZEL_VOLATILE"

--- a/common/util/init_command_line.cc
+++ b/common/util/init_command_line.cc
@@ -20,6 +20,7 @@
 #include "absl/flags/parse.h"
 #include "absl/flags/usage.h"
 #include "absl/flags/usage_config.h"
+#include "absl/time/time.h"
 #include "common/util/verible_build_version.h"
 
 namespace verible {
@@ -27,14 +28,18 @@ namespace verible {
 static std::string GetBuildVersion() {
   std::string result;
   // Build a version string with as much as possible info.
-#ifdef VERIBLE_GIT_DESC
-  result.append(VERIBLE_GIT_DESC).append("\n");
+#ifdef VERIBLE_GIT_DESCRIBE
+  result.append(VERIBLE_GIT_DESCRIBE).append("\n");
 #endif
 #ifdef VERIBLE_GIT_DATE
   result.append("Commit\t").append(VERIBLE_GIT_DATE).append("\n");
 #endif
 #ifdef VERIBLE_BUILD_TIMESTAMP
-  result.append("Built\t").append(VERIBLE_BUILD_TIMESTAMP).append("\n");
+  result.append("Built\t").append(
+      absl::FormatTime("%Y-%m-%dT%H:%M:%SZ",
+                       absl::FromTimeT(VERIBLE_BUILD_TIMESTAMP),
+                       absl::UTCTimeZone()))
+      .append("\n");
 #endif
   return result;
 }


### PR DESCRIPTION
Using 'date' to format some date only really works with
GNU date, so just use the raw time_t timestamp and format
that in code.

While at it, remove dependency on 'grep'.

This will remove one of the problems compiling on
Mac, found in #260.

Signed-off-by: Henner Zeller <h.zeller@acm.org>