### PR TITLE
[git] Source diff awk file with absolute path

### DIFF
--- a/verilog/tools/formatter/git-verilog_format.sh
+++ b/verilog/tools/formatter/git-verilog_format.sh
@@ -16,7 +16,7 @@
 # limitations under the License.
 
 script_name="$(basename $0)"
-script_dir="$(dirname $0)"
+script_dir="$(realpath $(dirname $0))"
 
 formatter="$(which verilog_format)" || \
   formatter="$script_dir"/verilog_format


### PR DESCRIPTION
git-verilog_format.sh uses the script directory to source diff awk file.
If the script is called with relative path it cannot source the file
correctly as the tool change the directory to the repository top.

This commit is to change the path to absolute path so that wherever the
script is called inside repo top, it can source the awk file.