### PR TITLE
verilog_format: accept multiple files to all process.

### DIFF
--- a/verilog/tools/formatter/verilog_format.cc
+++ b/verilog/tools/formatter/verilog_format.cc
@@ -30,6 +30,7 @@
 #include <vector>
 
 #include "absl/flags/flag.h"
+#include "absl/flags/usage.h"
 #include "absl/status/status.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_join.h"
@@ -120,45 +121,22 @@ ABSL_FLAG(bool, format_module_instantiations, false,
           "If true, format module instantiations (data declarations), "
           "else leave them unformatted.  This is a short-term workaround.");
 
-int main(int argc, char** argv) {
-  const auto usage = absl::StrCat("usage: ", argv[0],
-                                  " [options] <file>\n"
-                                  "To pipe from stdin, use '-' as <file>.");
-  const auto file_args = verible::InitCommandLine(usage, &argc, &argv);
-
-  // Currently accepts only one file positional argument.
-  // TODO(fangism): Support multiple file names.
-  QCHECK_GT(file_args.size(), 1)
-      << "Missing required positional argument (filename).";
-  const absl::string_view filename = file_args[1];
-
+bool formatOneFile(absl::string_view filename,
+                   const verilog::formatter::LineNumberSet &lines_to_format) {
   const bool inplace = absl::GetFlag(FLAGS_inplace);
   const bool is_stdin = filename == "-";
   const auto& stdin_name = absl::GetFlag(FLAGS_stdin_name);
 
   if (inplace && is_stdin) {
     std::cerr << "--inplace is incompatible with stdin.  Ignoring --inplace "
-                 "and writing to stdout."
-              << std::endl;
-  }
-  absl::string_view diagnostic_filename = filename;
-  if (is_stdin) {
-    diagnostic_filename = stdin_name;
+        "and writing to stdout." << std::endl;
   }
 
-  // Parse LineRanges into a line set, to validate the --lines flag(s)
-  verilog::formatter::LineNumberSet lines_to_format;
-  if (!verible::ParseInclusiveRanges(
-          &lines_to_format, LineRanges::values.begin(),
-          LineRanges::values.end(), &std::cerr, '-')) {
-    std::cerr << "Error parsing --lines." << std::endl;
-    std::cerr << "Got: --lines=" << AbslUnparseFlag(LineRanges()) << std::endl;
-    return 1;
-  }
+  const auto diagnostic_filename = is_stdin ? stdin_name : filename;
 
   // Read contents into memory first.
   std::string content;
-  if (!verible::file::GetContents(filename, &content)) return 1;
+  if (!verible::file::GetContents(filename, &content)) return false;
 
   // TODO(fangism): When requesting --inplace, verify that file
   // is write-able, and fail-early if it is not.
@@ -216,22 +194,61 @@ int main(int argc, char** argv) {
     }
     if (absl::GetFlag(FLAGS_failsafe_success)) {
       // original text was preserved, and --inplace modification is skipped.
-      return 0;
+      return true;
     }
-    return 1;
+    return false;
   }
 
   // Safe to write out result, having passed above verification.
   if (inplace && !is_stdin) {
-    if (!verible::file::SetContents(filename, formatted_output)) {
-      std::cerr << "Error writing to file: " << filename << std::endl;
-      std::cerr << "Printing to stdout instead." << std::endl;
-      std::cout << formatted_output;
-      return 1;
+    // Don't write if the output is exactly as the input, so that we don't mess
+    // with tools that look for timestamp changes (such as make).
+    if (content != formatted_output) {
+      if (!verible::file::SetContents(filename, formatted_output)) {
+        std::cerr << "Error writing to file: " << filename << std::endl;
+        std::cerr << "Printing to stdout instead." << std::endl;
+        std::cout << formatted_output;
+        return false;
+      }
     }
   } else {
     std::cout << formatted_output;
   }
 
-  return 0;
+  return true;
+}
+
+int main(int argc, char** argv) {
+  const auto usage = absl::StrCat("usage: ", argv[0],
+                                  " [options] <file>\n"
+                                  "To pipe from stdin, use '-' as <file>.");
+  const auto file_args = verible::InitCommandLine(usage, &argc, &argv);
+
+  if (file_args.size() == 1) {
+    std::cerr << absl::ProgramUsageMessage() << std::endl;
+    // TODO(hzeller): how can we append the output of --help here ?
+  }
+
+  // Parse LineRanges into a line set, to validate the --lines flag(s)
+  verilog::formatter::LineNumberSet lines_to_format;
+  if (!verible::ParseInclusiveRanges(
+          &lines_to_format, LineRanges::values.begin(),
+          LineRanges::values.end(), &std::cerr, '-')) {
+    std::cerr << "Error parsing --lines." << std::endl;
+    std::cerr << "Got: --lines=" << AbslUnparseFlag(LineRanges()) << std::endl;
+    return 1;
+  }
+
+  if (!lines_to_format.empty() && file_args.size() > 2) {
+    std::cerr << "Note, applying --lines rules to all files" << std::endl;
+  }
+
+  bool all_success = true;
+  // All positional arguments are file names.  Exclude program name.
+  for (const absl::string_view filename :
+           verible::make_range(file_args.begin() + 1, file_args.end())) {
+    all_success &= formatOneFile(filename, lines_to_format);
+  }
+
+  return all_success ? 0 : 1;
 }

--- a/verilog/tools/formatter/verilog_format.cc
+++ b/verilog/tools/formatter/verilog_format.cc
@@ -227,6 +227,7 @@ int main(int argc, char** argv) {
   if (file_args.size() == 1) {
     std::cerr << absl::ProgramUsageMessage() << std::endl;
     // TODO(hzeller): how can we append the output of --help here ?
+    return 1;
   }
 
   // Parse LineRanges into a line set, to validate the --lines flag(s)

--- a/verilog/tools/formatter/verilog_format.cc
+++ b/verilog/tools/formatter/verilog_format.cc
@@ -121,7 +121,7 @@ ABSL_FLAG(bool, format_module_instantiations, false,
           "If true, format module instantiations (data declarations), "
           "else leave them unformatted.  This is a short-term workaround.");
 
-std::ostream &FileMsg(absl::string_view filename) {
+std::ostream& FileMsg(absl::string_view filename) {
   std::cerr << filename << ": ";
   return std::cerr;
 }

--- a/verilog/tools/formatter/verilog_format.cc
+++ b/verilog/tools/formatter/verilog_format.cc
@@ -182,7 +182,7 @@ bool formatOneFile(absl::string_view filename,
       std::cout << content;
     }
     // Print the error message last so it shows up in user's console.
-    std::cerr << filename << format_status.message() << " ";
+    std::cerr << filename << ": " << format_status.message() << " ";
     switch (format_status.code()) {
       case StatusCode::kCancelled:
       case StatusCode::kInvalidArgument:

--- a/verilog/tools/formatter/verilog_format.cc
+++ b/verilog/tools/formatter/verilog_format.cc
@@ -210,7 +210,7 @@ bool formatOneFile(absl::string_view filename,
         return false;
       }
     } else {
-      std::cerr << filename << ": no change." << std::endl;
+      std::cerr << filename << ": Already formatted, no change." << std::endl;
     }
   } else {
     std::cout << formatted_output;
@@ -244,15 +244,13 @@ int main(int argc, char** argv) {
   // Some sanity checks if multiple files are given.
   if (file_args.size() > 2) {
     if (!lines_to_format.empty()) {
-      std::cerr << "Providing --lines but gave multiple different files."
-                << std::endl;
+      std::cerr << "--lines only works for single files." << std::endl;
       return 1;
     }
 
     if (!absl::GetFlag(FLAGS_inplace)) {
       // Dumping all to stdout doesn't really make sense.
-      std::cerr << "Multiple files given. Use --inplace "
-          "for a meaningful handling of these." << std::endl;
+      std::cerr << "--inplace required for multiple files." << std::endl;
       return 1;
     }
   }

--- a/verilog/tools/formatter/verilog_format.cc
+++ b/verilog/tools/formatter/verilog_format.cc
@@ -244,7 +244,7 @@ int main(int argc, char** argv) {
   // Some sanity checks if multiple files are given.
   if (file_args.size() > 2) {
     if (!lines_to_format.empty()) {
-      std::cerr << "Porviding --lines but gave multiple different files"
+      std::cerr << "Providing --lines but gave multiple different files."
                 << std::endl;
       return 1;
     }


### PR DESCRIPTION
  * Don't CHECK()-fail when no argument is given, but print usage instead.
  * Allow for arbitrary number of filename arguments.
  * Don't --inplace overwrite a file if the formatting did not
    generate any change (this is crucial to use in build-systems where
    typically the timestamp indicates if something needs to be
    re-built).

Signed-off-by: Henner Zeller <h.zeller@acm.org>