### PR TITLE
Fix indentation after applying kAppendFittingPartitions algorithm

### DIFF
--- a/common/formatting/token_partition_tree.cc
+++ b/common/formatting/token_partition_tree.cc
@@ -520,6 +520,13 @@ void ReshapeFittingSubpartitions(TokenPartitionTree* node,
     }
   }
 
+  // Update grouped childrens indentation in case of expanding grouping partitions
+  for (auto& group : temporary_tree.Children()) {
+    for (auto& subpart : group.Children()) {
+      AdjustIndentationAbsolute(&subpart, group.Value().IndentationSpaces());
+    }
+  }
+
   // Remove moved nodes
   node->Children().clear();
 

--- a/common/formatting/token_partition_tree_test.cc
+++ b/common/formatting/token_partition_tree_test.cc
@@ -1346,17 +1346,15 @@ TEST_F(ReshapeFittingSubpartitionsTest, IndentationTwoPartitions) {
 
   EXPECT_EQ(saved_tree.Children()[0].Value().IndentationSpaces(),
             tree.Children()[0].Children()[0].Value().IndentationSpaces());
-  EXPECT_EQ(saved_tree.Children()[1].Children()[0].Value().IndentationSpaces(),
-            tree.Children()[0].Children()[1].Value().IndentationSpaces());
-  EXPECT_EQ(saved_tree.Children()[1].Children()[1].Value().IndentationSpaces(),
-            tree.Children()[0].Children()[2].Value().IndentationSpaces());
+  EXPECT_EQ(tree.Children()[0].Children()[1].Value().IndentationSpaces(), 7);
+  EXPECT_EQ(tree.Children()[0].Children()[2].Value().IndentationSpaces(), 7);
 
-  EXPECT_EQ(saved_tree.Children()[1].Children()[2].Value().IndentationSpaces(),
-            tree.Children()[1].Children()[0].Value().IndentationSpaces());
-  EXPECT_EQ(saved_tree.Children()[1].Children()[3].Value().IndentationSpaces(),
-            tree.Children()[1].Children()[1].Value().IndentationSpaces());
-  EXPECT_EQ(saved_tree.Children()[1].Children()[4].Value().IndentationSpaces(),
-            tree.Children()[1].Children()[2].Value().IndentationSpaces());
+  EXPECT_EQ(tree.Children()[1].Children()[0].Value().IndentationSpaces(),
+            header.TokensRange()[0].Length() + 7); // appended
+  EXPECT_EQ(tree.Children()[1].Children()[1].Value().IndentationSpaces(),
+            header.TokensRange()[0].Length() + 7); // appended
+  EXPECT_EQ(tree.Children()[1].Children()[2].Value().IndentationSpaces(),
+            header.TokensRange()[0].Length() + 7); // appended
 }
 
 // Tests with real-world example

--- a/verilog/formatting/formatter_test.cc
+++ b/verilog/formatting/formatter_test.cc
@@ -273,11 +273,11 @@ static const std::initializer_list<FormatterTestCase> kFormatterTestCases = {
      "`F(type_f_ffff))))\n",
      "`MACRO_FFFFFFFFFFF(\n"
      "    `A(type_a_aaaa,\n"
-     "        `B(type_b_bbbbb,\n"
-     "           `C(type_c_cccccc))),\n"
+     "       `B(type_b_bbbbb,\n"
+     "          `C(type_c_cccccc))),\n"
      "    `D(type_d_dddddddd,\n"
-     "        `E(type_e_eeeeeeee,\n"
-     "           `F(type_f_ffff))))\n"},
+     "       `E(type_e_eeeeeeee,\n"
+     "          `F(type_f_ffff))))\n"},
     {// macro call with MacroArg tokens as arugments and with semicolon
      "`FOOOOOO(\nbar1...\n,\nbar2...\n,\nbar3...\n,\nbar4\n);\n",
      "`FOOOOOO(bar1..., bar2..., bar3...,\n"
@@ -324,11 +324,11 @@ static const std::initializer_list<FormatterTestCase> kFormatterTestCases = {
      "`F(type_f_ffff))));\n",
      "`MACRO_FFFFFFFFFFF(\n"
      "    `A(type_a_aaaa,\n"
-     "        `B(type_b_bbbbb,\n"
-     "           `C(type_c_cccccc))),\n"
+     "       `B(type_b_bbbbb,\n"
+     "          `C(type_c_cccccc))),\n"
      "    `D(type_d_dddddddd,\n"
-     "        `E(type_e_eeeeeeee,\n"
-     "           `F(type_f_ffff))));\n"},
+     "       `E(type_e_eeeeeeee,\n"
+     "          `F(type_f_ffff))));\n"},
     {// macro call with no args
      "`FOOOOOO()\n", "`FOOOOOO()\n"},
     {// macro call with no args and semicolon


### PR DESCRIPTION
This pull request is related to #240 and #277 
This PR updates indentation of grouped subpartitions after applying reshaping algorithm