### PR TITLE
Add Travis build for Ubuntu 20.04 LTS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,6 +54,9 @@ jobs:
    - name: "Ubuntu Eoan (19.10 latest)"
      env:
       - MODE=bin OS=ubuntu OS_VERSION=eoan
+   - name: "Ubuntu Focal (20.04 LTS)"
+     env:
+      - MODE=bin OS=ubuntu OS_VERSION=focal
    - name: "Centos 6"
      env:
       - MODE=bin OS=centos OS_VERSION=6


### PR DESCRIPTION
Add a deployment target for Ubuntu 20.04 "Focal Fossa", following the
same format as older releases.

Affects #300 