### PR TITLE
Include comma as a valid trailing delimiter for enum lists.

### DIFF
--- a/verilog/formatting/formatter_test.cc
+++ b/verilog/formatting/formatter_test.cc
@@ -2990,6 +2990,15 @@ static const std::initializer_list<FormatterTestCase> kFormatterTestCases = {
      "  A = 0,\n"
      "  B = 1\n"
      "} foo_t;\n"},
+    {"typedef enum logic\t{ A=0, // foo\n"
+     "B,// bar\n"
+     "C=3    // baz\n"
+     "}foo_t;",
+     "typedef enum logic {\n"
+     "  A = 0,  // foo\n"
+     "  B,  // bar\n"
+     "  C = 3  // baz\n"
+     "} foo_t;\n"},
     {// with scalar dimensions
      "typedef enum logic[2]\t{ A=0, B=1 }foo_t;",
      "typedef enum logic [2] {\n"

--- a/verilog/formatting/formatter_test.cc
+++ b/verilog/formatting/formatter_test.cc
@@ -2990,14 +2990,21 @@ static const std::initializer_list<FormatterTestCase> kFormatterTestCases = {
      "  A = 0,\n"
      "  B = 1\n"
      "} foo_t;\n"},
-    {"typedef enum logic\t{ A=0, // foo\n"
+    { // With comments on same line as enum value
+     "typedef enum logic\t{ A=0, // foo\n"
      "B,// bar\n"
-     "C=3    // baz\n"
+     "`ifndef DO_PANIC\n"
+     "C=42,// answer\n"
+     "`endif\n"
+     "D=3    // baz\n"
      "}foo_t;",
      "typedef enum logic {\n"
      "  A = 0,  // foo\n"
      "  B,  // bar\n"
-     "  C = 3  // baz\n"
+     "`ifndef DO_PANIC\n"
+     "  C = 42,  // answer\n"
+     "`endif\n"
+     "  D = 3  // baz\n"
      "} foo_t;\n"},
     {// with scalar dimensions
      "typedef enum logic[2]\t{ A=0, B=1 }foo_t;",
@@ -5580,7 +5587,7 @@ TEST(FormatterEndToEndTest, VerilogFormatTest) {
         FormatVerilog(test_case.input, "<filename>", style, stream);
     // Require these test cases to be valid.
     EXPECT_OK(status) << status.message();
-    EXPECT_EQ(stream.str(), test_case.expected) << "code:\n" << test_case.input;
+    EXPECT_EQ(stream.str(), std::string(test_case.expected)) << "code:\n" << test_case.input;
   }
 }
 

--- a/verilog/formatting/tree_unwrapper.cc
+++ b/verilog/formatting/tree_unwrapper.cc
@@ -1770,6 +1770,7 @@ void TreeUnwrapper::Visit(const verible::SyntaxTreeLeaf& leaf) {
               // NodeEnum:xxxx                             // due to element:
               NodeEnum::kMacroArgList,               // MacroArg
               NodeEnum::kFormalParameterList,        // kParamDeclaration
+              NodeEnum::kEnumNameList,
               NodeEnum::kActualParameterByNameList,  // kParamByName
               NodeEnum::kPortDeclarationList,        // kPort, kPortDeclaration
               NodeEnum::kPortActualList,             // kActualNamedPort,

--- a/verilog/formatting/tree_unwrapper.cc
+++ b/verilog/formatting/tree_unwrapper.cc
@@ -1770,7 +1770,7 @@ void TreeUnwrapper::Visit(const verible::SyntaxTreeLeaf& leaf) {
               // NodeEnum:xxxx                             // due to element:
               NodeEnum::kMacroArgList,               // MacroArg
               NodeEnum::kFormalParameterList,        // kParamDeclaration
-              NodeEnum::kEnumNameList,
+              NodeEnum::kEnumNameList,               // kEnumName
               NodeEnum::kActualParameterByNameList,  // kParamByName
               NodeEnum::kPortDeclarationList,        // kPort, kPortDeclaration
               NodeEnum::kPortActualList,             // kActualNamedPort,

--- a/verilog/formatting/tree_unwrapper_test.cc
+++ b/verilog/formatting/tree_unwrapper_test.cc
@@ -7107,6 +7107,21 @@ const TreeUnwrapperTestData kUnwrapEnumTestCases[] = {
                        L(1, {"two", "=", "2"})),
           L(0, {"}", "foo_e", ";"})),
     },
+
+    {
+        "Comment after enum member should attach",
+        "typedef enum logic {\n"
+        "one=1,   // foo\n"
+        "two,     // bar\n"
+        "three=3  // baz\n"
+        "} foo_e;",
+        N(0, L(0, {"typedef", "enum", "logic", "{"}),
+          EnumItemList(1,
+                       L(1, {"one", "=", "1", ",",  "// foo"}),
+                       L(1, {"two",           ",",  "// bar"}),
+                       L(1, {"three", "=", "3",     "// baz"})),
+          L(0, {"}", "foo_e", ";"})),
+    },
 };
 
 // Test that TreeUnwrapper produces correct UnwrappedLines from structs


### PR DESCRIPTION
Fixes #336

Signed-off-by: Henner Zeller <h.zeller@acm.org>