### PR TITLE
Package Extractor

### DIFF
--- a/verilog/CST/BUILD
+++ b/verilog/CST/BUILD
@@ -568,6 +568,7 @@ cc_test(
         "//common/text:symbol",
         "//common/text:text_structure",
         "//common/text:token_info",
+        ":match_test_utils",
         "//common/util:casts",
         "//common/util:logging",
         "//verilog/analysis:verilog_analyzer",

--- a/verilog/CST/module.cc
+++ b/verilog/CST/module.cc
@@ -82,7 +82,7 @@ const SyntaxTreeNode* GetModulePortDeclarationList(
 }
 
 const TokenInfo* GetModuleEndLabel(const verible::Symbol& s) {
-  const auto& label_node =
+  const auto* label_node =
       verible::GetSubtreeAsSymbol(s, NodeEnum::kModuleDeclaration, 3);
   if (label_node == nullptr) {
     return nullptr;

--- a/verilog/CST/package.cc
+++ b/verilog/CST/package.cc
@@ -33,6 +33,11 @@ std::vector<verible::TreeSearchMatch> FindAllPackageDeclarations(
   return SearchSyntaxTree(root, NodekPackageDeclaration());
 }
 
+std::vector<verible::TreeSearchMatch> FindAllPackageImportItems(
+    const verible::Symbol& root) {
+  return SearchSyntaxTree(root, NodekPackageImportItem());
+}
+
 const verible::TokenInfo& GetPackageNameToken(const verible::Symbol& s) {
   const auto& name_node = GetPackageNameLeaf(s);
   return name_node.get();
@@ -40,6 +45,50 @@ const verible::TokenInfo& GetPackageNameToken(const verible::Symbol& s) {
 
 const verible::SyntaxTreeLeaf& GetPackageNameLeaf(const verible::Symbol& s) {
   return verible::GetSubtreeAsLeaf(s, NodeEnum::kPackageDeclaration, 2);
+}
+
+const verible::SyntaxTreeLeaf* GetPackageNameEndLabel(
+    const verible::Symbol& package_declaration) {
+  const auto* label_node = verible::GetSubtreeAsSymbol(
+      package_declaration, NodeEnum::kPackageDeclaration, 6);
+  if (label_node == nullptr) {
+    return nullptr;
+  }
+  const auto& package_name = verible::GetSubtreeAsLeaf(
+      verible::SymbolCastToNode(*label_node), NodeEnum::kLabel, 1);
+  return &package_name;
+}
+
+const verible::Symbol* GetPackageItemList(
+    const verible::Symbol& package_declaration) {
+  return verible::GetSubtreeAsSymbol(package_declaration,
+                                     NodeEnum::kPackageDeclaration, 4);
+}
+
+const verible::SyntaxTreeNode& GetScopePrefixFromPackageImportItem(
+    const verible::Symbol& package_import_item) {
+  return verible::GetSubtreeAsNode(package_import_item,
+                                   NodeEnum::kPackageImportItem, 0,
+                                   NodeEnum::kScopePrefix);
+}
+
+const verible::SyntaxTreeLeaf& GetImportedPackageName(
+    const verible::Symbol& package_import_item) {
+  return verible::GetSubtreeAsLeaf(
+      GetScopePrefixFromPackageImportItem(package_import_item),
+      NodeEnum::kScopePrefix, 0);
+}
+
+const verible::SyntaxTreeLeaf* GeImportedItemNameFromPackageImportItem(
+    const verible::Symbol& package_import_item) {
+  const auto& imported_item = verible::GetSubtreeAsLeaf(
+      package_import_item, NodeEnum::kPackageImportItem, 1);
+
+  if (imported_item.get().token_enum() != verilog_tokentype::SymbolIdentifier) {
+    return nullptr;
+  }
+
+  return &imported_item;
 }
 
 }  // namespace verilog

--- a/verilog/CST/package.h
+++ b/verilog/CST/package.h
@@ -30,10 +30,42 @@ namespace verilog {
 std::vector<verible::TreeSearchMatch> FindAllPackageDeclarations(
     const verible::Symbol&);
 
+// Find all package imports items.
+std::vector<verible::TreeSearchMatch> FindAllPackageImportItems(
+    const verible::Symbol& root);
+
 // Extract the subnode of a package declaration that is the package name.
 const verible::TokenInfo& GetPackageNameToken(const verible::Symbol&);
 
+// Return the node spanning the name of the package.
 const verible::SyntaxTreeLeaf& GetPackageNameLeaf(const verible::Symbol& s);
+
+// Extracts the node that spans the name of the package after endpackage if
+// exists.
+const verible::SyntaxTreeLeaf* GetPackageNameEndLabel(
+    const verible::Symbol& package_declaration);
+
+// Extracts the node that spans the body of the package.
+const verible::Symbol* GetPackageItemList(
+    const verible::Symbol& package_declaration);
+
+// Extracts the node spanning the ScopePrefix node within PackageImportItem
+// node.
+const verible::SyntaxTreeNode& GetScopePrefixFromPackageImportItem(
+    const verible::Symbol& package_import_item);
+
+// Extracts package name for package import (node tagged with
+// kPackageImportItem).
+// e.g import pkg::my_integer return the node spanning "pkg".
+const verible::SyntaxTreeLeaf& GetImportedPackageName(
+    const verible::Symbol& package_import_item);
+
+// Extracts the symbol identifier from PackageImportItem if exits.
+// e.g import pkg::my_integer return the node spanning "my_integer".
+// return nullptr in case of import pkg::*.
+const verible::SyntaxTreeLeaf* GeImportedItemNameFromPackageImportItem(
+    const verible::Symbol& package_import_item);
+
 }  // namespace verilog
 
 #endif  // VERIBLE_VERILOG_CST_PACKAGE_H_

--- a/verilog/CST/package_test.cc
+++ b/verilog/CST/package_test.cc
@@ -25,8 +25,6 @@
 #include <memory>
 #include <vector>
 
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
 #include "absl/status/status.h"
 #include "common/analysis/syntax_tree_search.h"
 #include "common/analysis/syntax_tree_search_test_utils.h"
@@ -36,6 +34,9 @@
 #include "common/text/token_info.h"
 #include "common/util/casts.h"
 #include "common/util/logging.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "verilog/CST/match_test_utils.h"
 #include "verilog/analysis/verilog_analyzer.h"
 
 #undef EXPECT_OK
@@ -50,6 +51,7 @@ namespace {
 using verible::down_cast;
 using verible::SyntaxTreeNode;
 using verible::SyntaxTreeSearchTestCase;
+using verible::TextStructureView;
 using verible::TreeSearchMatch;
 
 TEST(FindAllPackageDeclarationsTest, VariousTests) {
@@ -343,6 +345,156 @@ TEST(GetPackageNameTokenTest, ValidPackage) {
   // Root node is a description list, not a package.
   const auto& token = GetPackageNameToken(package_node);
   EXPECT_EQ(token.text(), "foo");
+}
+
+TEST(GetPackageNameTest, GetPackageEndLabelName) {
+  constexpr int kTag = 1;
+  const SyntaxTreeSearchTestCase testcases[] = {
+      {""},
+      {"package foo;\n endpackage"},
+      {"package foo;\n endpackage: ", {kTag, "foo"}},
+      {"package foo;\n function int f();\n return 10;\n endfunction: f\n class "
+       "c; endclass: c\n "
+       "endpackage: ",
+       {kTag, "foo"}},
+  };
+
+  for (const auto& test : testcases) {
+    const absl::string_view code(test.code);
+    VerilogAnalyzer analyzer(code, "test-file");
+    const auto code_copy = analyzer.Data().Contents();
+    ASSERT_OK(analyzer.Analyze()) << "failed on:\n" << code;
+    const auto& root = analyzer.Data().SyntaxTree();
+
+    const auto declarations =
+        FindAllPackageDeclarations(*ABSL_DIE_IF_NULL(root));
+
+    std::vector<TreeSearchMatch> names;
+    for (const auto& decl : declarations) {
+      const auto* package_name = GetPackageNameEndLabel(*decl.match);
+      if (package_name == nullptr) continue;
+      names.push_back(TreeSearchMatch{package_name, {}});
+    }
+
+    std::ostringstream diffs;
+    EXPECT_TRUE(test.ExactMatchFindings(names, code_copy, &diffs))
+        << "failed on:\n"
+        << code << "\ndiffs:\n"
+        << diffs.str();
+  }
+}
+
+TEST(GetPackageBodyTest, GetPackageItemList) {
+  constexpr int kTag = 1;
+  const SyntaxTreeSearchTestCase testcases[] = {
+      {""},
+      {"package foo;\n endpackage"},
+      {"package foo;\n endpackage: foo"},
+      {"package foo;\n",
+       {kTag,
+        "function int f();\n return 10;\n endfunction: f\n class "
+        "c; endclass: c"},
+       "\n ",
+       "endpackage: foo"},
+  };
+
+  for (const auto& test : testcases) {
+    const absl::string_view code(test.code);
+    VerilogAnalyzer analyzer(code, "test-file");
+    const auto code_copy = analyzer.Data().Contents();
+    ASSERT_OK(analyzer.Analyze()) << "failed on:\n" << code;
+    const auto& root = analyzer.Data().SyntaxTree();
+
+    const auto declarations =
+        FindAllPackageDeclarations(*ABSL_DIE_IF_NULL(root));
+
+    std::vector<TreeSearchMatch> lists;
+    for (const auto& decl : declarations) {
+      const auto* package_item_list = GetPackageItemList(*decl.match);
+      if (package_item_list == nullptr) continue;
+      lists.push_back(TreeSearchMatch{package_item_list, {}});
+    }
+
+    std::ostringstream diffs;
+    EXPECT_TRUE(test.ExactMatchFindings(lists, code_copy, &diffs))
+        << "failed on:\n"
+        << code << "\ndiffs:\n"
+        << diffs.str();
+  }
+}
+
+TEST(PackageImportTest, GetImportedPackageName) {
+  constexpr int kTag = 1;  // value doesn't matter
+  const SyntaxTreeSearchTestCase kTestCases[] = {
+      {""},
+      {"module m; endmodule\n"},
+      {"package pkg; endpackage\nmodule m();\n import ",
+       {kTag, "pkg"},
+       "::*;\nendmodule"},
+      {"package pkg;\n int my_int;\nendpackage\nmodule m\nimport ",
+       {kTag, "pkg"},
+       "::*;\nimport ",
+       {kTag, "pkg"},
+       "::my_int;\n();\nendmodule"},
+  };
+  for (const auto& test : kTestCases) {
+    TestVerilogSyntaxRangeMatches(
+        __FUNCTION__, test, [](const TextStructureView& text_structure) {
+          const auto& root = text_structure.SyntaxTree();
+          const auto decls = FindAllPackageImportItems(*ABSL_DIE_IF_NULL(root));
+
+          std::vector<TreeSearchMatch> names;
+          for (const auto& decl : decls) {
+            const auto& name = GetImportedPackageName(*decl.match);
+            names.emplace_back(TreeSearchMatch{&name, {/* ignored context */}});
+          }
+          return names;
+        });
+  }
+}
+
+TEST(PackageImportTest, GetImportedItemName) {
+  constexpr int kTag = 1;  // value doesn't matter
+  const SyntaxTreeSearchTestCase kTestCases[] = {
+      {""},
+      {"module m; endmodule\n"},
+      {"package pkg; endpackage\nmodule m();\n import pkg::*;\nendmodule"},
+      {"package pkg;\n int my_int;\nendpackage\nmodule m();\n import "
+       "pkg::*;\nimport pkg::",
+       {kTag, "my_int"},
+       ";\nendmodule"},
+      {"package pkg;\n int my_int;\nclass "
+       "my_class;\nendclass\nendpackage\nmodule m();\n import "
+       "pkg::*;\nimport pkg::",
+       {kTag, "my_int"},
+       ";\nimport pkg::",
+       {kTag, "my_class"},
+       ";\nendmodule"},
+      {"package pkg;\n int my_int;\nclass "
+       "my_class;\nendclass\nendpackage\nmodule m\n import "
+       "pkg::*;\nimport pkg::",
+       {kTag, "my_int"},
+       ";\nimport pkg::",
+       {kTag, "my_class"},
+       ";\n();\n\nendmodule"},
+  };
+  for (const auto& test : kTestCases) {
+    TestVerilogSyntaxRangeMatches(
+        __FUNCTION__, test, [](const TextStructureView& text_structure) {
+          const auto& root = text_structure.SyntaxTree();
+          const auto decls = FindAllPackageImportItems(*ABSL_DIE_IF_NULL(root));
+
+          std::vector<TreeSearchMatch> names;
+          for (const auto& decl : decls) {
+            const auto* name =
+                GeImportedItemNameFromPackageImportItem(*decl.match);
+            if (name == nullptr) continue;
+            names.emplace_back(TreeSearchMatch{name, {/* ignored context
+            */}});
+          }
+          return names;
+        });
+  }
 }
 
 }  // namespace

--- a/verilog/tools/kythe/BUILD
+++ b/verilog/tools/kythe/BUILD
@@ -109,6 +109,7 @@ cc_library(
         "//common/analysis:syntax_tree_search",
         "//common/text:tree_context_visitor",
         "//common/text:tree_utils",
+        "//verilog/CST:package",
         "//verilog/CST:class",
         "//verilog/CST:declaration",
         "//verilog/CST:functions",

--- a/verilog/tools/kythe/indexing_facts_tree_extractor.h
+++ b/verilog/tools/kythe/indexing_facts_tree_extractor.h
@@ -69,6 +69,10 @@ class IndexingFactsTreeExtractor : public verible::TreeContextVisitor {
   void ExtractNetDeclaration(
       const verible::SyntaxTreeNode& net_declaration_node);
 
+  // Extract package declarations and creates its corresponding facts tree.
+  void ExtractPackageDeclaration(
+      const verible::SyntaxTreeNode& package_declaration_node);
+
   // Extract macro definitions and explores its arguments and creates its
   // corresponding facts tree.
   void ExtractMacroDefinition(
@@ -106,6 +110,9 @@ class IndexingFactsTreeExtractor : public verible::TreeContextVisitor {
   void ExtractClassInstances(
       const verible::SyntaxTreeNode& data_declaration,
       const std::vector<verible::TreeSearchMatch>& register_variables);
+
+  // Extracts package imports and creates its corresponding fact tree.
+  void ExtractPackageImport(const verible::SyntaxTreeNode& package_import_item);
 
   // The Root of the constructed tree
   IndexingFactNode root_{IndexingNodeData(IndexingFactType::kFile)};

--- a/verilog/tools/kythe/kythe_schema_constants.h
+++ b/verilog/tools/kythe/kythe_schema_constants.h
@@ -26,6 +26,7 @@ constexpr absl::string_view kModuleBuiltin = "module#builtin";
 // Kythe Nodes.
 constexpr absl::string_view kNodeAnchor = "anchor";
 constexpr absl::string_view kNodeRecord = "record";
+constexpr absl::string_view kNodePackage = "package";
 constexpr absl::string_view kNodeMacro = "macro";
 constexpr absl::string_view kNodeFile = "file";
 constexpr absl::string_view kNodeBuiltin = "tbuiltin";
@@ -48,6 +49,7 @@ constexpr absl::string_view kEdgeChildOf = "/kythe/edge/childof";
 constexpr absl::string_view kEdgeRef = "/kythe/edge/ref";
 constexpr absl::string_view kEdgeRefExpands = "/kythe/edge/ref/expands";
 constexpr absl::string_view kEdgeRefCall = "/kythe/edge/ref/call";
+constexpr absl::string_view kEdgeRefImports = "/kythe/edge/ref/imports";
 constexpr absl::string_view kEdgeTyped = "/kythe/edge/typed";
 
 }  // namespace kythe

--- a/verilog/tools/kythe/verilog_extractor_indexing_fact_type.h
+++ b/verilog/tools/kythe/verilog_extractor_indexing_fact_type.h
@@ -27,6 +27,7 @@ enum class IndexingFactType {
   kFile,
   kMacro,
   kModule,
+  kPackage,
   kMacroCall,
   kClass,
   kClassInstance,
@@ -35,6 +36,7 @@ enum class IndexingFactType {
   kVariableReference,
   kFunctionOrTask,
   kFunctionCall,
+  kPackageImport,
   // END GENERATE -- do not delete
 };
 


### PR DESCRIPTION
Kythe facts extraction for Packages.

Convers:
- package name (also package name after `endpackage`).
- package body.
- package imports: `import pkg::*` and `import pkg::my_var`

Fixes: #392 