### PR TITLE
Class and Package Member Access

### DIFF
--- a/verilog/tools/kythe/indexing_facts_tree_extractor.cc
+++ b/verilog/tools/kythe/indexing_facts_tree_extractor.cc
@@ -636,7 +636,7 @@ void IndexingFactsTreeExtractor::ExtractClassInstances(
       class_node.NewChild(
           IndexingNodeData({Anchor(instance_name, context_.base)},
                            IndexingFactType::kClassInstance));
-    } else {
+    } else if (tag == NodeEnum::kVariableDeclarationAssignment) {
       const SyntaxTreeLeaf& leaf =
           GetUnqualifiedIdFromVariableDeclarationAssignment(*instance.match);
       class_node.NewChild(IndexingNodeData({Anchor(leaf.get(), context_.base)},

--- a/verilog/tools/kythe/indexing_facts_tree_extractor.cc
+++ b/verilog/tools/kythe/indexing_facts_tree_extractor.cc
@@ -117,7 +117,7 @@ void IndexingFactsTreeExtractor::Visit(const SyntaxTreeNode& node) {
           break;
         }
 
-        // for primitive types inside tagged with kRegisterVariable;
+        // for primitive types inside tagged with kRegisterVariable.
         ExtractPrimitiveVariables(node, register_variables);
         break;
       }
@@ -134,6 +134,8 @@ void IndexingFactsTreeExtractor::Visit(const SyntaxTreeNode& node) {
           break;
         }
 
+        // for primitive types inside tagged with
+        // kVariableDeclarationAssignment.
         ExtractPrimitiveVariables(node, variable_declaration_assign);
         break;
       }
@@ -636,8 +638,7 @@ void IndexingFactsTreeExtractor::ExtractClassInstances(
                            IndexingFactType::kClassInstance));
     } else {
       const SyntaxTreeLeaf& leaf =
-          GetUnqualifiedIdFromVariableDeclarationAssignment(
-              *instance.match);
+          GetUnqualifiedIdFromVariableDeclarationAssignment(*instance.match);
       class_node.NewChild(IndexingNodeData({Anchor(leaf.get(), context_.base)},
                                            IndexingFactType::kClassInstance));
     }

--- a/verilog/tools/kythe/kythe_facts_extractor.cc
+++ b/verilog/tools/kythe/kythe_facts_extractor.cc
@@ -215,6 +215,7 @@ void KytheFactsExtractor::ConstructFlattenedScope(
           CreateSignature(node.Parent()->Value().Anchors()[0].Value()));
 
       scope_context_[vname.signature] = scope_context_[found_vname->signature];
+      break;
     }
     default: {
       break;

--- a/verilog/tools/kythe/kythe_facts_extractor.cc
+++ b/verilog/tools/kythe/kythe_facts_extractor.cc
@@ -211,7 +211,6 @@ void KytheFactsExtractor::ConstructFlattenedScope(
     }
     case IndexingFactType::kModuleInstance:
     case IndexingFactType::kClassInstance: {
-      // TODO(minatoma): Refactor this to get rid of this search.
       const VName* found_vname = vertical_scope_context_.SearchForDefinition(
           CreateSignature(node.Parent()->Value().Anchors()[0].Value()));
 

--- a/verilog/tools/kythe/kythe_facts_extractor.h
+++ b/verilog/tools/kythe/kythe_facts_extractor.h
@@ -132,7 +132,7 @@ class KytheFactsExtractor {
 
   // Searches for a definition suitable for the given reference within package
   // scope context of the given package name.
-  const VName* SearchForDefinitionVNameInPackage(
+  const VName* SearchForDefinitionVNameInScopeContext(
       absl::string_view package_name, absl::string_view reference_name) const;
 
   // Resolves the tag of the given node and directs the flow to the appropriate
@@ -140,13 +140,13 @@ class KytheFactsExtractor {
   void IndexingFactNodeTagResolver(const IndexingFactNode&);
 
   // Add the given VName to vnames_context (to be used in scope relative
-  // signatures) and visits the children of the given node.
+  // signatures) and visits the children of the given node creating a new scope
+  // for the given node.
   void Visit(const IndexingFactNode& node, const VName& vname,
              std::vector<VName>& current_scope);
 
-  // Directs the flow to the children of the given node creating new scope for
-  // that node.
-  void Visit(const IndexingFactNode& node, std::vector<VName>& current_scope);
+  // Directs the flow to the children of the given node.
+  void Visit(const IndexingFactNode& node);
 
   // Extracts Packages and saves its scope to package_scope_context to be used
   // for definition searching.
@@ -242,7 +242,7 @@ class KytheFactsExtractor {
 
   // Keeps track of scopes and definitions inside the scopes of ancestors as
   // the visitor traverses the facts tree.
-  ScopeContext scope_context_;
+  ScopeContext vertical_scope_context_;
 
   // Saved packages signatures alongside with their inner members.
   // This is used for resolving references to some variables after using import
@@ -263,7 +263,7 @@ class KytheFactsExtractor {
   //   "pkg1": ["my_fun", "my_class"],
   //   "pkg2": ["my_fun", "my_class"]
   // }
-  std::map<std::string, std::vector<VName>> package_scope_context_;
+  std::map<std::string, std::vector<VName>> scope_context_;
 
   // Output stream for capturing, redirecting, testing and verifying the
   // output.

--- a/verilog/tools/kythe/kythe_facts_extractor.h
+++ b/verilog/tools/kythe/kythe_facts_extractor.h
@@ -139,14 +139,28 @@ class KytheFactsExtractor {
   // function to extract kythe facts for that node.
   void IndexingFactNodeTagResolver(const IndexingFactNode&);
 
+  // Determines whether to create a scope for this node or not and visits the
+  // children.
+  void Visit(const IndexingFactNode& node, const VName& vname);
+
   // Add the given VName to vnames_context (to be used in scope relative
   // signatures) and visits the children of the given node creating a new scope
   // for the given node.
-  void Visit(const IndexingFactNode& node, const VName& vname,
-             std::vector<VName>& current_scope);
+  void Visit(const IndexingFactNode& node, const VName&, std::vector<VName>&);
 
   // Directs the flow to the children of the given node.
   void Visit(const IndexingFactNode& node);
+
+  // Determines whether or not to add the VName.
+  void AddVNameToVerticalScope(IndexingFactType, const VName&);
+
+  // Appends the extracted children vnames to the scope of the current node.
+  void ConstructFlattenedScope(const IndexingFactNode&, const VName&,
+                               const std::vector<VName>&);
+
+  // Determines whether or not to create a child of edge between the current
+  // node and the previous node.
+  void CreateChildOfEdge(IndexingFactType, const VName&);
 
   // Extracts Packages and saves its scope to package_scope_context to be used
   // for definition searching.
@@ -157,27 +171,25 @@ class KytheFactsExtractor {
 
   // Extracts kythe facts a reference to a user defined data type like class or
   // module.
-  VName ExtractDataTypeReference(const IndexingFactNode&);
+  void ExtractDataTypeReference(const IndexingFactNode&);
 
   // Extracts kythe facts from module instance node and returns it VName.
-  VName ExtractModuleInstanceFact(const IndexingFactNode&);
+  VName ExtractModuleInstance(const IndexingFactNode&);
 
-  // Extracts kythe facts from module named port node e.g("m(.in1(a))") and
-  // returns it VName.
-  VName ExtractModuleNamedPort(const IndexingFactNode&);
+  // Extracts kythe facts from module named port node e.g("m(.in1(a))").
+  void ExtractModuleNamedPort(const IndexingFactNode&);
 
   // Extracts kythe facts from module node and returns it VName.
   VName ExtractModuleFact(const IndexingFactNode&);
 
   // Extracts kythe facts from class node and returns it VName.
-  VName ExtractClassFact(const IndexingFactNode&);
+  VName ExtractClass(const IndexingFactNode&);
 
   // Extracts kythe facts from module port node and returns its VName.
-  VName ExtractVariableDefinitionFact(const IndexingFactNode& node);
+  VName ExtractVariableDefinition(const IndexingFactNode& node);
 
-  // Extracts kythe facts from a module port reference node and returns its
-  // VName.
-  VName ExtractVariableReferenceFact(const IndexingFactNode& node);
+  // Extracts kythe facts from a module port reference node.
+  void ExtractVariableReference(const IndexingFactNode& node);
 
   // Extracts Kythe facts from class instance node and return its VName.
   VName ExtractClassInstances(const IndexingFactNode& class_instance_fact_node);
@@ -185,29 +197,28 @@ class KytheFactsExtractor {
   // Extracts kythe facts from a function or task node and returns its VName.
   VName ExtractFunctionOrTask(const IndexingFactNode& function_fact_node);
 
-  // Extracts kythe facts from a function or task call node and returns its
-  // VName.
-  VName ExtractFunctionOrTaskCall(
+  // Extracts kythe facts from a function or task call node.
+  void ExtractFunctionOrTaskCall(
       const IndexingFactNode& function_call_fact_node);
 
   // Extracts kythe facts from a package declaration node and returns its VName.
   VName ExtractPackageDeclaration(const IndexingFactNode& node);
 
-  // Extracts kythe facts from package import node and returns its VName.
-  VName ExtractPackageImport(const IndexingFactNode& node);
+  // Extracts kythe facts from package import node.
+  void ExtractPackageImport(const IndexingFactNode& node);
 
   // Extracts kythe facts from a macro definition node and returns its VName.
   VName ExtractMacroDefinition(const IndexingFactNode& macro_definition_node);
 
-  // Extracts kythe facts from a macro call node and returns its VName.
-  VName ExtractMacroCall(const IndexingFactNode& macro_call_node);
+  // Extracts kythe facts from a macro call node.
+  void ExtractMacroCall(const IndexingFactNode& macro_call_node);
 
-  // Extracts kythe facts from member reference statement and return its vname.
+  // Extracts kythe facts from member reference statement.
   // e.g pkg::member or class::member or class.member
   // The names are treated as anchors e.g:
   // pkg::member => {Anchor(pkg), Anchor(member)}
   // pkg::class_name::var => {Anchor(pkg), Anchor(class_name), Anchor(var)}
-  VName ExtractMemberReference(const IndexingFactNode& member_reference_node);
+  void ExtractMemberReference(const IndexingFactNode& member_reference_node);
 
   // Generates an anchor VName for kythe.
   VName PrintAnchorVName(const Anchor&);

--- a/verilog/tools/kythe/testdata/more_testdata/nested_member_access.sv
+++ b/verilog/tools/kythe/testdata/more_testdata/nested_member_access.sv
@@ -1,0 +1,86 @@
+//- _FileNode.node/kind file
+
+//- @nested_class2 defines/binding NestedClass2
+//- NestedClass2.node/kind record
+class nested_class2;
+    //- @var1 defines/binding Var1Def
+    //- Var1Def.node/kind variable
+    //- Var1Def.complete definition
+    //- Var1Def childof NestedClass2
+    int var1 = 1;
+    
+    //- @nested_function defines/binding NestedFunctionNestedClass2
+    //- NestedFunctionNestedClass2.node/kind function
+    //- NestedFunctionNestedClass2.complete definition
+    //- NestedFunctionNestedClass2 childof NestedClass2
+    function int nested_function();
+        return 1;
+    endfunction
+
+endclass
+
+//- @nested_class1 defines/binding NestedClass1
+//- NestedClass1.node/kind record
+//- NestedClass1.complete definition
+class nested_class1;
+
+    //- @nested_class2 ref NestedClass2
+    //- @handle2 defines/binding Handle2
+    //- Handle2.node/kind variable
+    //- Handle2.complete definition
+    //- Handle2 childof NestedClass1
+    static nested_class2 handle2 = new();
+
+endclass
+
+//- @nested_class0 defines/binding NestedClass0
+//- NestedClass0.node/kind record
+//- NestedClass0.complete definition
+class nested_class0;
+    
+    //- @nested_class1 ref NestedClass1
+    //- @handle1 defines/binding Handle1
+    //- Handle1.node/kind variable
+    //- Handle1.complete definition
+    //- Handle1 childof NestedClass0
+    static nested_class1 handle1 = new();
+
+    //- @inner_class defines/binding InnerClass
+    //- InnerClass.node/kind record
+    //- InnerClass.complete definition
+    //- InnerClass childof NestedClass0
+    class inner_class;
+        //- @nested_function defines/binding NestedFunction
+        //- NestedFunction.node/kind function
+        //- NestedFunction.complete definition
+        //- NestedFunction childof InnerClass
+        function int nested_function();
+          return 1;
+        endfunction
+      endclass
+endclass
+
+//- @my_module defines/binding MyModule
+//- MyModule.node/kind record
+//- MyModule.subkind module
+//- MyModule.complete definition
+module my_module (
+
+);
+    //- @nested_class2 ref NestedClass2
+    //- @var1 ref Var1Def
+    initial $display(nested_class2::var1);
+
+    //- @nested_class1 ref NestedClass1
+    //- @handle2 ref Handle2
+    //- @var1 ref Var1Def
+    initial $display(nested_class1::handle2::var1);
+
+    //- @nested_class0 ref NestedClass0
+    //- @handle1 ref Handle1
+    //- @handle2 ref Handle2
+    //- @var1 ref Var1Def
+    initial $display(nested_class0::handle1::handle2::var1);
+
+  //- @my_module ref MyModule
+endmodule : my_module

--- a/verilog/tools/kythe/testdata/more_testdata/package_with_primitive.sv
+++ b/verilog/tools/kythe/testdata/more_testdata/package_with_primitive.sv
@@ -29,5 +29,3 @@ module my_module2;
 //- @my_integer ref MyInteger2
   initial $display(my_pkg2::my_integer);
 endmodule
-
-

--- a/verilog/tools/kythe/testdata/more_testdata/package_with_primitive.sv
+++ b/verilog/tools/kythe/testdata/more_testdata/package_with_primitive.sv
@@ -1,0 +1,33 @@
+// Copyright 2020 Google LLC.
+// SPDX-License-Identifier: Apache-2.0
+
+//- _FileNode.node/kind file
+//- @my_pkg1 defines/binding MyPkg1
+package my_pkg1;
+//- @my_integer defines/binding MyInteger
+  integer my_integer = 10;
+endpackage
+
+// Second package also defines my_integer.
+//- @my_pkg2 defines/binding MyPkg2
+package my_pkg2;
+//- @my_integer defines/binding MyInteger2
+  integer my_integer = 10;
+endpackage
+
+// First imported reference to the first package.
+module my_module1;
+//- @my_pkg1 ref/imports MyPkg1
+  import my_pkg1::*;
+//- @my_integer ref MyInteger
+  initial $display(my_integer);
+endmodule
+
+// Second reference to the second package.
+module my_module2;
+//- @my_pkg2 ref MyPkg2
+//- @my_integer ref MyInteger2
+  initial $display(my_pkg2::my_integer);
+endmodule
+
+


### PR DESCRIPTION
Fixes #464

Also handles the crashing for non-existent or not found definitions in `KytheFactsExtractor`.