### PR TITLE
For initialization list extraction

### DIFF
--- a/verilog/CST/BUILD
+++ b/verilog/CST/BUILD
@@ -702,6 +702,7 @@ cc_library(
     hdrs = ["statement.h"],
     deps = [
         ":verilog_matchers",  # fixdeps: keep
+        ":declaration",
         "//common/analysis:syntax_tree_search",
         "//common/analysis/matcher",
         "//common/analysis/matcher:matcher_builders",

--- a/verilog/CST/BUILD
+++ b/verilog/CST/BUILD
@@ -721,6 +721,7 @@ cc_test(
         ":statement",
         ":verilog_matchers",
         ":verilog_nonterminals",
+        ":match_test_utils",
         "//common/analysis:syntax_tree_search",
         "//common/analysis:syntax_tree_search_test_utils",
         "//common/analysis/matcher:matcher_builders",

--- a/verilog/CST/declaration.cc
+++ b/verilog/CST/declaration.cc
@@ -126,17 +126,22 @@ const SyntaxTreeNode& GetUnqualifiedIdFromLocalRoot(const Symbol& local_root) {
   return GetSubtreeAsNode(local_root, NodeEnum::kLocalRoot, 0);
 }
 
+const verible::SyntaxTreeNode& GetUnqualifiedIdFromReferenceCallBase(
+    const verible::Symbol& reference_call_base) {
+  const SyntaxTreeNode& refernce =
+      GetReferenceFromReferenceCallBase(reference_call_base);
+  const SyntaxTreeNode& local_root = GetLocalRootFromReference(refernce);
+  return GetUnqualifiedIdFromLocalRoot(local_root);
+}
+
 const verible::TokenInfo& GetTypeTokenInfoFromDataDeclaration(
     const verible::Symbol& data_declaration) {
   const SyntaxTreeNode& instantiation_type =
       GetTypeOfDataDeclaration(data_declaration);
   const SyntaxTreeNode& reference_call_base =
       GetReferenceCallBaseFromInstantiationType(instantiation_type);
-  const SyntaxTreeNode& reference =
-      GetReferenceFromReferenceCallBase(reference_call_base);
-  const SyntaxTreeNode& local_root = GetLocalRootFromReference(reference);
   const SyntaxTreeNode& unqualified_id =
-      GetUnqualifiedIdFromLocalRoot(local_root);
+      GetUnqualifiedIdFromReferenceCallBase(reference_call_base);
   const verible::SyntaxTreeLeaf* instance_symbol_identifier =
       GetIdentifier(unqualified_id);
   return instance_symbol_identifier->get();

--- a/verilog/CST/declaration.h
+++ b/verilog/CST/declaration.h
@@ -93,7 +93,8 @@ std::vector<verible::TreeSearchMatch> FindAllGateInstances(
 std::vector<verible::TreeSearchMatch> FindAllVariableDeclarationAssignment(
     const verible::Symbol&);
 
-// Returns node tagged with unqualified id from node reference call base.
+// Returns node tagged with unqualified id from node tagged with
+// kReferenceCallBase.
 const verible::SyntaxTreeNode& GetUnqualifiedIdFromReferenceCallBase(
     const verible::Symbol&);
 

--- a/verilog/CST/declaration.h
+++ b/verilog/CST/declaration.h
@@ -93,6 +93,10 @@ std::vector<verible::TreeSearchMatch> FindAllGateInstances(
 std::vector<verible::TreeSearchMatch> FindAllVariableDeclarationAssignment(
     const verible::Symbol&);
 
+// Returns node tagged with unqualified id from node reference call base.
+const verible::SyntaxTreeNode& GetUnqualifiedIdFromReferenceCallBase(
+    const verible::Symbol&);
+
 // For a given data declaration (includes module instantiation), returns the
 // subtree containing qualifiers.  e.g. from "const foo bar, baz;",
 // this returns the subtree spanning "const".  Returns nullptr if there

--- a/verilog/CST/statement.cc
+++ b/verilog/CST/statement.cc
@@ -34,9 +34,9 @@ using verible::Symbol;
 using verible::SymbolCastToNode;
 using verible::SyntaxTreeNode;
 
-std::vector<verible::TreeSearchMatch> FindAllForLoops(
+std::vector<verible::TreeSearchMatch> FindAllForLoopsInitializations(
     const verible::Symbol& root) {
-  return SearchSyntaxTree(root, NodekForSpec());
+  return SearchSyntaxTree(root, NodekForInitialization());
 }
 
 static const SyntaxTreeNode& GetGenericStatementBody(

--- a/verilog/CST/statement.h
+++ b/verilog/CST/statement.h
@@ -27,6 +27,9 @@ namespace verilog {
 std::vector<verible::TreeSearchMatch> FindAllConditionalStatements(
     const verible::Symbol& root);
 
+std::vector<verible::TreeSearchMatch> FindAllForLoops(
+    const verible::Symbol& root);
+
 // Generate flow control constructs
 //
 // TODO(fangism): consider moving the *GenerateBody functions to generate.{h,cc}
@@ -167,6 +170,18 @@ const verible::SyntaxTreeNode* GetAnyConditionalIfClause(
 // doesn't exist.
 const verible::SyntaxTreeNode* GetAnyConditionalElseClause(
     const verible::Symbol& conditional);
+
+// Returns the data type node from for loop initialization.
+const verible::SyntaxTreeNode* GetDataTypeFromForInitialization(
+    const verible::Symbol&);
+
+// Returns the variable name leaf from for loop initialization.
+const verible::SyntaxTreeLeaf& GetVariableNameFromForInitialization(
+    const verible::Symbol&);
+
+// Returns the rhs expression from for loop initialization.
+const verible::SyntaxTreeNode& GetExpressionFromForInitialization(
+    const verible::Symbol&);
 
 }  // namespace verilog
 

--- a/verilog/CST/statement.h
+++ b/verilog/CST/statement.h
@@ -27,7 +27,7 @@ namespace verilog {
 std::vector<verible::TreeSearchMatch> FindAllConditionalStatements(
     const verible::Symbol& root);
 
-std::vector<verible::TreeSearchMatch> FindAllForLoops(
+std::vector<verible::TreeSearchMatch> FindAllForLoopsInitializations(
     const verible::Symbol& root);
 
 // Generate flow control constructs

--- a/verilog/tools/kythe/BUILD
+++ b/verilog/tools/kythe/BUILD
@@ -120,6 +120,7 @@ cc_library(
         "//verilog/CST:functions",
         "//verilog/CST:identifier",
         "//verilog/CST:macro",
+        "//verilog/CST:statement",
         "//verilog/CST:module",
         "//verilog/CST:net",
         "//verilog/CST:package",

--- a/verilog/tools/kythe/indexing_facts_tree_extractor.cc
+++ b/verilog/tools/kythe/indexing_facts_tree_extractor.cc
@@ -29,6 +29,7 @@
 #include "verilog/CST/package.h"
 #include "verilog/CST/parameters.h"
 #include "verilog/CST/port.h"
+#include "verilog/CST/statement.h"
 #include "verilog/CST/tasks.h"
 #include "verilog/CST/verilog_matchers.h"
 #include "verilog/CST/verilog_nonterminals.h"
@@ -284,8 +285,6 @@ void IndexingFactsTreeExtractor::ExtractModuleHeader(
     } else if (tag == NodeEnum::kPort) {
       ExtractModulePort(GetPortReferenceFromPort(port_node),
                         has_propagated_type);
-    } else {
-      Visit(port_node);
     }
   }
 }
@@ -313,6 +312,18 @@ void IndexingFactsTreeExtractor::ExtractModulePort(
         {Anchor(leaf->get(), context_.base)},
         has_propagated_type ? IndexingFactType::kVariableDefinition
                             : IndexingFactType::kVariableReference));
+  }
+
+  // Extract unpacked and packed dimensions.
+  for (const auto& child : module_port_node.children()) {
+    if (child == nullptr || child.get()->Kind() == verible::SymbolKind::kLeaf) {
+      continue;
+    }
+    const auto tag = static_cast<verilog::NodeEnum>(child.get()->Tag().tag);
+    if (tag == NodeEnum::kUnqualifiedId) {
+      continue;
+    }
+    Visit(verible::SymbolCastToNode(*child));
   }
 }
 
@@ -820,7 +831,23 @@ void IndexingFactsTreeExtractor::ExtractQualifiedId(
 }
 
 void IndexingFactsTreeExtractor::ExtractForInitialization(
-    const verible::SyntaxTreeNode& for_initialization) {}
+    const verible::SyntaxTreeNode& for_initialization) {
+  const SyntaxTreeLeaf& variable_name =
+      GetVariableNameFromForInitialization(for_initialization);
+  facts_tree_context_.top().NewChild(
+      IndexingNodeData({Anchor(variable_name.get(), context_.base)},
+                       IndexingFactType::kVariableDefinition));
+
+  const SyntaxTreeNode* data_type_node =
+      GetDataTypeFromForInitialization(for_initialization);
+  if (data_type_node != nullptr) {
+    Visit(*data_type_node);
+  }
+
+  const SyntaxTreeNode& expression =
+      GetExpressionFromForInitialization(for_initialization);
+  Visit(expression);
+}
 
 }  // namespace kythe
 }  // namespace verilog

--- a/verilog/tools/kythe/indexing_facts_tree_extractor.cc
+++ b/verilog/tools/kythe/indexing_facts_tree_extractor.cc
@@ -198,6 +198,10 @@ void IndexingFactsTreeExtractor::Visit(const SyntaxTreeNode& node) {
       ExtractQualifiedId(node);
       break;
     }
+    case NodeEnum::kForInitialization: {
+      ExtractForInitialization(node);
+      break;
+    }
     default: {
       TreeContextVisitor::Visit(node);
     }
@@ -280,6 +284,8 @@ void IndexingFactsTreeExtractor::ExtractModuleHeader(
     } else if (tag == NodeEnum::kPort) {
       ExtractModulePort(GetPortReferenceFromPort(port_node),
                         has_propagated_type);
+    } else {
+      Visit(port_node);
     }
   }
 }
@@ -812,6 +818,9 @@ void IndexingFactsTreeExtractor::ExtractQualifiedId(
 
   facts_tree_context_.top().NewChild(member_reference_data);
 }
+
+void IndexingFactsTreeExtractor::ExtractForInitialization(
+    const verible::SyntaxTreeNode& for_initialization) {}
 
 }  // namespace kythe
 }  // namespace verilog

--- a/verilog/tools/kythe/indexing_facts_tree_extractor.h
+++ b/verilog/tools/kythe/indexing_facts_tree_extractor.h
@@ -144,6 +144,11 @@ class IndexingFactsTreeExtractor : public verible::TreeContextVisitor {
   // e.g pkg::member or class::member.
   void ExtractQualifiedId(const verible::SyntaxTreeNode& qualified_id);
 
+  // Extracts initializations in for loop and creates its corresponding fact
+  // tree. e.g for(int i = 0, j = k; ...) extracts "i", "j" and "k".
+  void ExtractForInitialization(
+      const verible::SyntaxTreeNode& for_initialization);
+
   // The Root of the constructed tree
   IndexingFactNode root_{IndexingNodeData(IndexingFactType::kFile)};
 

--- a/verilog/tools/kythe/testdata/more_testdata/array.sv
+++ b/verilog/tools/kythe/testdata/more_testdata/array.sv
@@ -1,0 +1,70 @@
+// Copyright 2020 Google LLC.
+// SPDX-License-Identifier: Apache-2.0
+
+//- @array defines/binding _
+module array (
+    //- @arr1 defines/binding Arr1
+    input bit[7:0] arr1
+);
+  //- @mock_arr defines/binding MockArr
+  bit [7:0] mock_arr;
+  //- @arr2 defines/binding Arr2
+  int arr2[8][32];
+
+  //- @arr1 ref Arr1
+  //- @mock_arr ref MockArr
+  assign mock_arr[0] = arr1[0];
+
+  //- @arr2 ref Arr2
+  assign arr2[0][31] = 42;
+endmodule
+
+//- @dynamic_arrays defines/binding _
+module dynamic_arrays;
+  //- @arr defines/binding Arr
+  bit [7:0] arr [];
+
+  initial begin
+    //- @arr ref Arr
+    arr = new[8];
+
+    //- @arr ref Arr
+    $display ("Array size: %d", arr.size());
+
+    //- @#0arr ref Arr
+    //- @#1arr ref Arr
+    arr = new[16](arr);
+  end
+
+endmodule
+
+//- @associative_arrays defines/binding _
+module associative_arrays;
+  //- @real_arr defines/binding RealArr
+  int real_arr [int];
+
+  initial begin
+    //- @real_arr ref RealArr
+    real_arr[80] = 81;
+    //- @real_arr ref RealArr
+    real_arr[0] = 1;
+
+    //- @var1 defines/binding Var1
+    //- @var2 defines/binding Var2
+    int var1 = 0, var2 = 0;
+
+    //- @#1i defines/binding I
+    //- @#3i ref I
+    //- @#4i ref I
+    //- @var1 ref Var1
+    //- @var2 ref Var2
+    //- @j defines/binding _
+    //- @m defines/binding _
+    for (int i = 0, j = 0, bit [var1:var2] m = 0; i < 50; i++) begin
+      //- @real_arr ref RealArr
+      //- @#0i ref I
+      //- @#1i ref I
+      real_arr[i] = i;
+    end
+  end
+endmodule

--- a/verilog/tools/kythe/testdata/more_testdata/array.sv
+++ b/verilog/tools/kythe/testdata/more_testdata/array.sv
@@ -57,10 +57,11 @@ module associative_arrays;
     //- @#3i ref I
     //- @#4i ref I
     //- @var1 ref Var1
-    //- @var2 ref Var2
+    //- @#0var2 ref Var2
+    //- @#1var2 ref Var2
     //- @j defines/binding _
     //- @m defines/binding _
-    for (int i = 0, j = 0, bit [var1:var2] m = 0; i < 50; i++) begin
+    for (int i = 0, j = 0, bit [var1:var2] m = var2; i < 50; i++) begin
       //- @real_arr ref RealArr
       //- @#0i ref I
       //- @#1i ref I

--- a/verilog/tools/kythe/testdata/more_testdata/module.sv
+++ b/verilog/tools/kythe/testdata/more_testdata/module.sv
@@ -122,3 +122,42 @@ module my_module (
 
   //- @my_module ref MyModule
 endmodule : my_module
+
+//- @int1 defines/binding Int1Def
+//- Int1Def.node/kind variable
+//- Int1Def.complete definition
+//- Int1Def childof MyPkg1
+//- @int2 defines/binding Int2Def
+//- Int2Def.node/kind variable
+//- Int2Def.complete definition
+//- Int2Def childof MyPkg1
+int int1, int2;
+
+//- @my_module2 defines/binding MyModule2
+//- MyModule2.node/kind record
+//- MyModule2.subkind module
+//- MyModule2.complete definition
+module my_module2 (
+  //- @x defines/binding XDef1
+  //- XDef1.node/kind variable
+  //- XDef1.complete definition
+  //- XDef1 childof MyModule2
+  //- @#0int1 ref LDef
+  //- @#1int1 ref LDef
+  //- @#0int2 ref RDef
+  //- @#1int2 ref RDef
+  input [int1:int2] x [int1:int2],
+  //- @y defines/binding YDef2
+  //- YDef2.node/kind variable
+  //- YDef2.complete definition
+  //- YDef2 childof MyModule2
+  //- @#0int1 ref LDef
+  //- @#1int1 ref LDef
+  //- @#0int2 ref RDef
+  //- @#1int2 ref RDef
+  input wire [int1:int2] y [int1:int2]
+);
+
+//- @my_module2 ref MyModule2
+endmodule : my_module2
+


### PR DESCRIPTION
Fix to unreported issues:
```
module m(bit [x,y] port_name [x, y]);
```
and
```
for(int i = 0, j = k, .... );
```

Extracts facts for `x`, `y` in module ports.
Extracts facts for `i`, `j` as definitions and `k` as reference.
