### PR TITLE
Fixed formatting of Authors page

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,16 +1,19 @@
 ---
 ---
 
-# This is the list of Verible authors for copyright purposes.
-#
-# This does not necessarily list everyone who has contributed code, since in
-# some cases, their employer may be the copyright holder.  To see the full list
-# of contributors, see the revision history in source control.
-Google LLC
-David Fang
-Sergey Sokolov
-Jonathan Mayer
-Jeremy Colebrook-Soucie
-Cameron Korzecke
-Carissa Kathuria
-Henner Zeller
+# Authors
+
+This is the list of Verible authors for copyright purposes.
+
+This does not necessarily list everyone who has contributed code, since in
+some cases, their employer may be the copyright holder.  To see the full list
+of contributors, see the revision history in source control.
+
+*  Google LLC
+*  David Fang
+*  Sergey Sokolov
+*  Jonathan Mayer
+*  Jeremy Colebrook-Soucie
+*  Cameron Korzecke
+*  Carissa Kathuria
+*  Henner Zeller


### PR DESCRIPTION
Fixed the formatting of the Authors page so it renders correctly on GitHub pages.