### PR TITLE
Fix module-level package import indentation

### DIFF
--- a/verilog/formatting/formatter_test.cc
+++ b/verilog/formatting/formatter_test.cc
@@ -6963,6 +6963,30 @@ static constexpr FormatterTestCase kFormatterTestCases[] = {
      "    type TT = my_pkg::my_type2_t\n"
      ");\n"
      "endinterface\n"},
+     {// wildcard import package at module header
+     "module foo import bar::*; (baz); endmodule\n",
+     "module foo\n"
+     "  import bar::*;\n"
+     "(\n"
+     "    baz\n"
+     ");\n"
+     "endmodule\n"},
+     {// import package at module header
+     "module foo import bar::baz; (qux); endmodule\n",
+     "module foo\n"
+     "  import bar::baz;\n"
+     "(\n"
+     "    qux\n"
+     ");\n"
+     "endmodule\n"},
+     {// wildcard import mutiple packages at module header
+     "module foo import bar::*,baz::*; (qux); endmodule\n",
+     "module foo\n"
+     "  import bar::*, baz::*;\n"
+     "(\n"
+     "    qux\n"
+     ");\n"
+     "endmodule\n"},
     //{   // parameterized class with 'parameter_declaration' and MACRO
     //    "class foo #(parameter int a = 2,\n"
     //    "parameter int aaa = `MACRO);\n"

--- a/verilog/formatting/tree_unwrapper.cc
+++ b/verilog/formatting/tree_unwrapper.cc
@@ -946,6 +946,7 @@ void TreeUnwrapper::SetIndentationsAndCreatePartitions(
 
     // For the following constructs, always expand the view to subpartitions.
     // Add a level of indentation.
+    case NodeEnum::kPackageImportList:
     case NodeEnum::kPackageItemList:
     case NodeEnum::kInterfaceClassDeclaration:
     case NodeEnum::kCasePatternItemList:


### PR DESCRIPTION
Fixes #498.

**Input:**
```verilog
module foo import bar::*; (baz); endmodule
```
**Formatter output before:**
```verilog
module foo
import bar::*;
(
    baz
);
endmodule
```

**Formatter output after:**
```verilog
module foo
  import bar::*;
(
    baz
);
endmodule
```
