### PR TITLE
Add space between return keyword and return value

### DIFF
--- a/verilog/formatting/formatter_test.cc
+++ b/verilog/formatting/formatter_test.cc
@@ -7042,6 +7042,43 @@ static constexpr FormatterTestCase kFormatterTestCases[] = {
      "    qux\n"
      ");\n"
      "endmodule\n"},
+    // Space between return keyword and return value
+    {
+     "function int foo(logic [31:0] data); return{<<8{data}}; endfunction",
+     "function int foo(logic [31:0] data);\n"
+     "  return {<<8{data}};\n"
+     "endfunction\n"
+     },
+     {
+     "function int f;return(1);endfunction",
+     "function int f;\n"
+     "  return (1);\n"
+     "endfunction\n"
+     },
+     {
+     "function int f;return-1;endfunction",
+     "function int f;\n"
+     "  return -1;\n"
+     "endfunction\n"
+     },
+     {
+     "function int f ;return    ! x\n;endfunction",
+     "function int f;\n"
+     "  return !x;\n"
+     "endfunction\n"
+     },
+     {
+     "function int f ;return    ~ x\n;endfunction",
+     "function int f;\n"
+     "  return ~x;\n"
+     "endfunction\n"
+     },
+    {
+     "function int f ;return    $x\n;endfunction",
+     "function int f;\n"
+     "  return $x;\n"
+     "endfunction\n"
+     },
     //{   // parameterized class with 'parameter_declaration' and MACRO
     //    "class foo #(parameter int a = 2,\n"
     //    "parameter int aaa = `MACRO);\n"

--- a/verilog/formatting/token_annotator.cc
+++ b/verilog/formatting/token_annotator.cc
@@ -201,6 +201,10 @@ static WithReason<int> SpacesRequiredBetween(
     return {1, "Require space after semicolon"};
   }
 
+  if (left.TokenEnum() == TK_return){
+    return {1, "Space between return keyword and return value"};
+  }
+
   if (right_context.IsInsideFirst({NodeEnum::kStreamingConcatenation}, {})) {
     if (left.TokenEnum() == TK_LS || left.TokenEnum() == TK_RS) {
       return {0, "No space around streaming operators"};

--- a/verilog/formatting/token_annotator_test.cc
+++ b/verilog/formatting/token_annotator_test.cc
@@ -4672,6 +4672,55 @@ TEST(TokenAnnotatorTest, AnnotateFormattingWithContextTest) {
           {/* any context */},
           {0, SpacingOptions::MustWrap},
       },
+      // Space between return keyword and return value
+      {
+          DefaultStyle,
+          {verilog_tokentype::TK_return, "return"},
+          {'{', "{"},
+          {/* unspecified context */},
+          {/* unspecified context */},
+          {1, SpacingOptions::Undecided},
+      },
+      {
+          DefaultStyle,
+          {verilog_tokentype::TK_return, "return"},
+          {'(', "("},
+          {/* unspecified context */},
+          {/* unspecified context */},
+          {1, SpacingOptions::Undecided},
+      },
+      {
+          DefaultStyle,
+          {verilog_tokentype::TK_return, "return"},
+          {'-', "-"},
+          {/* unspecified context */},
+          {/* unspecified context */},
+          {1, SpacingOptions::Undecided},
+      },
+      {
+          DefaultStyle,
+          {verilog_tokentype::TK_return, "return"},
+          {'!', "!"},
+          {/* unspecified context */},
+          {/* unspecified context */},
+          {1, SpacingOptions::Undecided},
+      },
+      {
+          DefaultStyle,
+          {verilog_tokentype::TK_return, "return"},
+          {'~', "~"},
+          {/* unspecified context */},
+          {/* unspecified context */},
+          {1, SpacingOptions::Undecided},
+      },
+      {
+          DefaultStyle,
+          {verilog_tokentype::TK_return, "return"},
+          {verilog_tokentype::SystemTFIdentifier, "$foo"},
+          {/* unspecified context */},
+          {/* unspecified context */},
+          {1, SpacingOptions::Undecided},
+      },
   };
   int test_index = 0;
   for (const auto& test_case : kTestCases) {


### PR DESCRIPTION
Fixes #493.

**Input:**
```verilog
  function int foo(logic [31:0] data);
    return {<<8{data}};
  endfunction
```
**Formatter output before:**
```verilog
  function int foo(logic [31:0] data);
    return{<<8{data}};
  endfunction
```

**Formatter output after:**
```verilog
  function int foo(logic [31:0] data);
    return {<<8{data}};
  endfunction
```
