### PR TITLE
Fix bug in extracting facts from file_list_node and print function

### DIFF
--- a/verilog/tools/kythe/kythe_facts_extractor.cc
+++ b/verilog/tools/kythe/kythe_facts_extractor.cc
@@ -63,7 +63,7 @@ std::vector<std::string> ConcatenateReferences(
 
 }  // namespace
 
-KytheIndexingData KytheFactsExtractor::ExtractKytheFacts(
+KytheIndexingData KytheFactsExtractor::ExtractFile(
     const IndexingFactNode& root) {
   // For every iteration:
   // saves the current number of extracted facts, do another iteration to
@@ -391,7 +391,7 @@ void KytheFactsExtractor::Visit(const IndexingFactNode& node) {
   }
 }
 
-KytheIndexingData KytheFactsExtractor::ExtractFileList(
+KytheIndexingData KytheFactsExtractor::ExtractKytheFacts(
     const IndexingFactNode& file_list) {
   // Create a new ScopeResolver and give the ownership to the scope_resolvers
   // vector so that it can outlive KytheFactsExtractor.
@@ -409,7 +409,7 @@ KytheIndexingData KytheFactsExtractor::ExtractFileList(
     KytheFactsExtractor kythe_extractor(file_path,
                                         scope_resolvers.back().get());
 
-    const auto indexing_data = kythe_extractor.ExtractKytheFacts(root);
+    const auto indexing_data = kythe_extractor.ExtractFile(root);
     aggregated_indexing_facts.facts.insert(indexing_data.facts.begin(),
                                            indexing_data.facts.end());
     aggregated_indexing_facts.edges.insert(indexing_data.edges.begin(),
@@ -986,7 +986,7 @@ void KytheFactsExtractor::CreateEdge(const VName& source_node,
 
 std::ostream& KytheFactsPrinter::Print(std::ostream& stream) const {
   auto indexing_data =
-      KytheFactsExtractor::ExtractFileList(file_list_facts_tree_);
+      KytheFactsExtractor::ExtractKytheFacts(file_list_facts_tree_);
 
   for (const Fact& fact : indexing_data.facts) {
     stream << fact;

--- a/verilog/tools/kythe/kythe_facts_extractor.h
+++ b/verilog/tools/kythe/kythe_facts_extractor.h
@@ -65,8 +65,9 @@ class KytheFactsExtractor {
                       ScopeResolver* previous_files_scopes)
       : file_path_(file_path), scope_resolver_(previous_files_scopes) {}
 
-  // Extracts kythe facts from the given IndexingFactsTree root.
-  KytheIndexingData ExtractKytheFacts(const IndexingFactNode&);
+  // Extracts node tagged with kFileList where it iterates over every child node
+  // tagged with kFile from the begining and extracts the facts for each file.
+  static KytheIndexingData ExtractFileList(const IndexingFactNode& file_list);
 
  private:
   // Container with a stack of VNames to hold context of VNames during traversal
@@ -90,6 +91,9 @@ class KytheFactsExtractor {
     // returns the top VName of the stack
     const VName& top() const { return *ABSL_DIE_IF_NULL(base_type::top()); }
   };
+
+  // Extracts kythe facts from the given IndexingFactsTree root.
+  KytheIndexingData ExtractKytheFacts(const IndexingFactNode&);
 
   // Resolves the tag of the given node and directs the flow to the appropriate
   // function to extract kythe facts for that node.
@@ -116,10 +120,6 @@ class KytheFactsExtractor {
   // Determines whether or not to create a child of edge between the current
   // node and the previous node.
   void CreateChildOfEdge(IndexingFactType, const VName&);
-
-  // Extracts node tagged with kFileList where it iterates over every child node
-  // tagged with kFile from the begining and extracts the facts for each file.
-  void ExtractFileList(const IndexingFactNode& file_list);
 
   // Extracts kythe facts from file node and returns it VName.
   VName ExtractFileFact(const IndexingFactNode&);

--- a/verilog/tools/kythe/kythe_facts_extractor.h
+++ b/verilog/tools/kythe/kythe_facts_extractor.h
@@ -67,7 +67,7 @@ class KytheFactsExtractor {
 
   // Extracts node tagged with kFileList where it iterates over every child node
   // tagged with kFile from the begining and extracts the facts for each file.
-  static KytheIndexingData ExtractFileList(const IndexingFactNode& file_list);
+  static KytheIndexingData ExtractKytheFacts(const IndexingFactNode& file_list);
 
  private:
   // Container with a stack of VNames to hold context of VNames during traversal
@@ -93,7 +93,7 @@ class KytheFactsExtractor {
   };
 
   // Extracts kythe facts from the given IndexingFactsTree root.
-  KytheIndexingData ExtractKytheFacts(const IndexingFactNode&);
+  KytheIndexingData ExtractFile(const IndexingFactNode&);
 
   // Resolves the tag of the given node and directs the flow to the appropriate
   // function to extract kythe facts for that node.

--- a/verilog/tools/kythe/verilog_kythe_extractor.cc
+++ b/verilog/tools/kythe/verilog_kythe_extractor.cc
@@ -17,16 +17,16 @@
 #include <iostream>
 #include <string>
 
-#include "google/protobuf/io/zero_copy_stream_impl.h"
 #include "absl/flags/flag.h"
 #include "absl/status/status.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/string_view.h"
 #include "absl/strings/substitute.h"
-#include "kythe/cxx/common/indexing/KytheCachingOutput.h"
-#include "kythe/proto/storage.pb.h"
 #include "common/util/file_util.h"
 #include "common/util/init_command_line.h"
+#include "google/protobuf/io/zero_copy_stream_impl.h"
+#include "kythe/cxx/common/indexing/KytheCachingOutput.h"
+#include "kythe/proto/storage.pb.h"
 #include "verilog/analysis/verilog_analyzer.h"
 #include "verilog/tools/kythe/indexing_facts_tree_extractor.h"
 #include "verilog/tools/kythe/kythe_facts_extractor.h"
@@ -64,10 +64,8 @@ VNameRef ConvertToVnameRef(const VName& vname,
 
 // Prints Kythe facts in proto format to stdout.
 void PrintKytheFactsProtoEntries(const IndexingFactNode& file_list_facts_tree) {
-  KytheFactsExtractor kythe_extractor(
-      GetFileListDirFromRoot(file_list_facts_tree),
-      /*previous_files_scopes=*/nullptr);
-  auto indexing_data = kythe_extractor.ExtractKytheFacts(file_list_facts_tree);
+  auto indexing_data =
+      KytheFactsExtractor::ExtractFileList(file_list_facts_tree);
   google::protobuf::io::FileOutputStream file_output(STDOUT_FILENO);
   file_output.SetCloseOnDelete(true);
   ::kythe::FileOutputStream kythe_output(&file_output);

--- a/verilog/tools/kythe/verilog_kythe_extractor.cc
+++ b/verilog/tools/kythe/verilog_kythe_extractor.cc
@@ -65,7 +65,7 @@ VNameRef ConvertToVnameRef(const VName& vname,
 // Prints Kythe facts in proto format to stdout.
 void PrintKytheFactsProtoEntries(const IndexingFactNode& file_list_facts_tree) {
   auto indexing_data =
-      KytheFactsExtractor::ExtractFileList(file_list_facts_tree);
+      KytheFactsExtractor::ExtractKytheFacts(file_list_facts_tree);
   google::protobuf::io::FileOutputStream file_output(STDOUT_FILENO);
   file_output.SetCloseOnDelete(true);
   ::kythe::FileOutputStream kythe_output(&file_output);


### PR DESCRIPTION
Fixing bug for extracting facts from `file_list_node` in the iterative loop which is not intended.
Simplifying the logic in `KytheFactsPrinter`'s `Print` function.