### PR TITLE
Add missing "fact_name" to edge JSON

### DIFF
--- a/verilog/tools/kythe/kythe_facts.cc
+++ b/verilog/tools/kythe/kythe_facts.cc
@@ -138,6 +138,7 @@ std::ostream& Edge::FormatJSON(std::ostream& stream, bool debug,
     stream << idt << "\"target\": ";
     target_node.FormatJSON(stream, debug, indent_more) << ",\n";
   }
+  { stream << idt << "\"fact_name\": \"\"\n"; }
   return stream << verible::Spacer(indentation) << "}";
 }
 

--- a/verilog/tools/kythe/kythe_facts_test.cc
+++ b/verilog/tools/kythe/kythe_facts_test.cc
@@ -165,6 +165,7 @@ TEST(EdgeTest, FormatJSON) {
     "root": "",
     "corpus": ""
   },
+  "fact_name": ""
 })");
 }
 


### PR DESCRIPTION
Kythe requires "fact_name" to be present. `entrystream` produces an error otherwise:
```
[mglb/fix-json-output 47186d0] Add missing "fact_name" to edge JSON
```
It also fixes invalid JSON syntax (`},}`) introduced when "fact_name" was removed. 