### PR TITLE
Do not use empty "fact_name"

### DIFF
--- a/verilog/tools/kythe/kythe_facts.cc
+++ b/verilog/tools/kythe/kythe_facts.cc
@@ -138,7 +138,7 @@ std::ostream& Edge::FormatJSON(std::ostream& stream, bool debug,
     stream << idt << "\"target\": ";
     target_node.FormatJSON(stream, debug, indent_more) << ",\n";
   }
-  { stream << idt << "\"fact_name\": \"\"\n"; }
+  { stream << idt << "\"fact_name\": \"/\"\n"; }
   return stream << verible::Spacer(indentation) << "}";
 }
 

--- a/verilog/tools/kythe/kythe_facts_test.cc
+++ b/verilog/tools/kythe/kythe_facts_test.cc
@@ -165,7 +165,7 @@ TEST(EdgeTest, FormatJSON) {
     "root": "",
     "corpus": ""
   },
-  "fact_name": ""
+  "fact_name": "/"
 })");
 }
 


### PR DESCRIPTION
This is required by Kythe: https://kythe.io/docs/kythe-storage.html#_a_id_termfact_a_fact