### PR TITLE
ci: use GITHUB_ENV instead of set-output

### DIFF
--- a/.github/workflows/success.sh
+++ b/.github/workflows/success.sh
@@ -34,7 +34,7 @@ bin)
     # Create a tag of form v0.0-183-gdf2b162-20191112132344
     rm -rf releasing/out
     git tag "$TAG" || true
-    echo "::set-output name=TAG::$(echo $TAG)"
+    echo "TAG=$TAG" >> $GITHUB_ENV
     ls -l /tmp/releases
     ;;
 

--- a/.github/workflows/verible-ci.yml
+++ b/.github/workflows/verible-ci.yml
@@ -97,6 +97,6 @@ jobs:
           with:
             repo_token: ${{ secrets.GITHUB_TOKEN }}
             file: /tmp/releases/verible-*.tar.gz
-            tag: ${{ steps.after_success.outputs.TAG }}
+            tag: ${{ env.TAG }}
             overwrite: true
             file_glob: true


### PR DESCRIPTION
See https://github.com/google/verible/pull/620#issuecomment-740269076.