### PR TITLE
ci: run Release on ubuntu-20.04

### DIFF
--- a/.github/workflows/verible-ci.yml
+++ b/.github/workflows/verible-ci.yml
@@ -52,7 +52,7 @@ jobs:
             CLEAN: true
 
    Release:
-      runs-on: ubuntu-16.04
+      runs-on: ubuntu-20.04
       strategy:
         fail-fast: false
         matrix:


### PR DESCRIPTION
As commented in https://github.com/google/verible/pull/623#discussion_r538736672, it might be sensible to run 'Release' jobs on Ubuntu 20.04 (even though Verible is built inside containers anyway).

'Check' jobs are still executed on ubuntu-16.04. Shall I bump that one too?