### PR TITLE
releasing: Remove eoan.

### DIFF
--- a/releasing/docker-generate.sh
+++ b/releasing/docker-generate.sh
@@ -44,7 +44,7 @@ fi
 # ==================================================================
 # Generate the Docker files for ubuntu versions
 # ==================================================================
-for UBUNTU_VERSION in xenial bionic eoan focal groovy; do
+for UBUNTU_VERSION in xenial bionic focal groovy; do
     # Install basic tools
     # --------------------------------------------------------------
     cat > ubuntu-${UBUNTU_VERSION}/Dockerfile <<EOF


### PR DESCRIPTION
The eoan Ubuntu version (19.10) is causing failures on CI and it went
out of support on July, 17 2020 (https://wiki.ubuntu.com/Releases).

Signed-off-by: Tim 'mithro' Ansell <me@mith.ro>