### PR TITLE
Lint: Allow `5'b?` in rule undersized-binary-literal

### DIFF
--- a/verilog/analysis/checkers/undersized_binary_literal_rule.cc
+++ b/verilog/analysis/checkers/undersized_binary_literal_rule.cc
@@ -92,10 +92,11 @@ void UndersizedBinaryLiteralRule::HandleSymbol(
                 << digits_text;
             // Detect binary values, whose literal width is shorter than the
             // declared width.
-            // Allow 'b0 as an exception.
+            // Allow 'b0 and 'b? as an exception.
             CHECK_EQ(number.base,
                      'b');  // guaranteed by matching TK_BinBase
-            if (width > number.literal.length() && number.literal != "0") {
+            if (width > number.literal.length() && number.literal != "0"
+                && number.literal != "?") {
               violations_.insert(LintViolation(
                   digits_leaf->get(),
                   FormatReason(width_text, base_text, digits_text), context));

--- a/verilog/analysis/checkers/undersized_binary_literal_rule_test.cc
+++ b/verilog/analysis/checkers/undersized_binary_literal_rule_test.cc
@@ -43,7 +43,7 @@ TEST(UndersizedBinaryLiteralTest, FunctionFailures) {
       {"localparam x = 3'b", {kToken, "00"}, ";"},  // only 2 0s for 3 bits
       {"localparam x = 32'b0;"},                    // exception granted for 0
       {"localparam x = 2'b", {kToken, "1"}, ";"},
-      {"localparam x = 2'b", {kToken, "?"}, ";"},
+      {"localparam x = 2'b?;"},                     // exception granted for ?
       {"localparam x = 2'b", {kToken, "x"}, ";"},
       {"localparam x = 2'b", {kToken, "z"}, ";"},
       {"localparam x = 2'b ", {kToken, "1"}, ";"},    // with space after base
@@ -62,6 +62,9 @@ TEST(UndersizedBinaryLiteralTest, FunctionFailures) {
       {"localparam x = 0 + 2'b", {kToken, "1"}, ";"},
       {"localparam x = 3'b", {kToken, "10"}, " + 3'b", {kToken, "1"}, ";"},
       {"localparam x = 2'b ", {kToken, "x"}, " & 2'b ", {kToken, "1"}, ";"},
+      {"localparam x = 5'b?????;"},
+      {"localparam x = 5'b?;"},                    // exception granted for ?
+      {"localparam x = 5'b", {kToken, "??"}, ";"}, // only 2 ?s for 5 bits
   };
 
   RunLintTestCases<VerilogAnalyzer, UndersizedBinaryLiteralRule>(kTestCases);


### PR DESCRIPTION
Closes #344