### PR TITLE
Check for genvar and generate region

### DIFF
--- a/verilog/analysis/checkers/BUILD
+++ b/verilog/analysis/checkers/BUILD
@@ -36,6 +36,7 @@ cc_library(
         ":generate_label_prefix_rule",
         ":generate_label_rule",
         ":interface_name_style_rule",
+        ":legacy_genvar_declaration_rule",
         ":line_length_rule",
         ":macro_name_style_rule",
         ":mismatched_labels_rule",
@@ -1816,6 +1817,43 @@ cc_test(
     srcs = ["interface_name_style_rule_test.cc"],
     deps = [
         ":interface_name_style_rule",
+        "//common/analysis:linter_test_utils",
+        "//common/analysis:syntax_tree_linter_test_utils",
+        "//common/text:symbol",
+        "//verilog/CST:verilog_nonterminals",
+        "//verilog/analysis:verilog_analyzer",
+        "//verilog/parser:verilog_token_enum",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_library(
+    name = "legacy_genvar_declaration_rule",
+    srcs = ["legacy_genvar_declaration_rule.cc"],
+    hdrs = ["legacy_genvar_declaration_rule.h"],
+    deps = [
+        "//common/analysis:citation",
+        "//common/analysis:lint_rule_status",
+        "//common/analysis:syntax_tree_lint_rule",
+        "//common/analysis/matcher",
+        "//common/analysis/matcher:bound_symbol_manager",
+        "//common/strings:naming_utils",
+        "//common/text:symbol",
+        "//common/text:syntax_tree_context",
+        "//verilog/CST:type",
+        "//verilog/CST:verilog_matchers",
+        "//verilog/analysis:descriptions",
+        "//verilog/analysis:lint_rule_registry",
+        "@com_google_absl//absl/strings",
+    ],
+    alwayslink = 1,
+)
+
+cc_test(
+    name = "legacy_genvar_declaration_rule_test",
+    srcs = ["legacy_genvar_declaration_rule_test.cc"],
+    deps = [
+        ":legacy_genvar_declaration_rule",
         "//common/analysis:linter_test_utils",
         "//common/analysis:syntax_tree_linter_test_utils",
         "//common/text:symbol",

--- a/verilog/analysis/checkers/BUILD
+++ b/verilog/analysis/checkers/BUILD
@@ -37,6 +37,7 @@ cc_library(
         ":generate_label_rule",
         ":interface_name_style_rule",
         ":legacy_genvar_declaration_rule",
+        ":legacy_generate_region_rule",
         ":line_length_rule",
         ":macro_name_style_rule",
         ":mismatched_labels_rule",
@@ -1854,6 +1855,43 @@ cc_test(
     srcs = ["legacy_genvar_declaration_rule_test.cc"],
     deps = [
         ":legacy_genvar_declaration_rule",
+        "//common/analysis:linter_test_utils",
+        "//common/analysis:syntax_tree_linter_test_utils",
+        "//common/text:symbol",
+        "//verilog/CST:verilog_nonterminals",
+        "//verilog/analysis:verilog_analyzer",
+        "//verilog/parser:verilog_token_enum",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_library(
+    name = "legacy_generate_region_rule",
+    srcs = ["legacy_generate_region_rule.cc"],
+    hdrs = ["legacy_generate_region_rule.h"],
+    deps = [
+        "//common/analysis:citation",
+        "//common/analysis:lint_rule_status",
+        "//common/analysis:syntax_tree_lint_rule",
+        "//common/analysis/matcher",
+        "//common/analysis/matcher:bound_symbol_manager",
+        "//common/strings:naming_utils",
+        "//common/text:symbol",
+        "//common/text:syntax_tree_context",
+        "//verilog/CST:type",
+        "//verilog/CST:verilog_matchers",
+        "//verilog/analysis:descriptions",
+        "//verilog/analysis:lint_rule_registry",
+        "@com_google_absl//absl/strings",
+    ],
+    alwayslink = 1,
+)
+
+cc_test(
+    name = "legacy_generate_region_rule_test",
+    srcs = ["legacy_generate_region_rule_test.cc"],
+    deps = [
+        ":legacy_generate_region_rule",
         "//common/analysis:linter_test_utils",
         "//common/analysis:syntax_tree_linter_test_utils",
         "//common/text:symbol",

--- a/verilog/analysis/checkers/legacy_generate_region_rule.cc
+++ b/verilog/analysis/checkers/legacy_generate_region_rule.cc
@@ -1,0 +1,77 @@
+// Copyright 2017-2020 The Verible Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "verilog/analysis/checkers/legacy_generate_region_rule.h"
+
+#include <set>
+#include <string>
+
+#include "absl/strings/match.h"
+#include "absl/strings/str_cat.h"
+#include "common/analysis/citation.h"
+#include "common/analysis/lint_rule_status.h"
+#include "common/analysis/matcher/bound_symbol_manager.h"
+#include "common/analysis/matcher/matcher.h"
+#include "common/strings/naming_utils.h"
+#include "common/text/symbol.h"
+#include "common/text/tree_utils.h"
+#include "verilog/CST/verilog_matchers.h"
+#include "verilog/analysis/lint_rule_registry.h"
+
+namespace verilog {
+namespace analysis {
+
+VERILOG_REGISTER_LINT_RULE(LegacyGenerateRegionRule);
+
+using verible::GetStyleGuideCitation;
+using verible::LintRuleStatus;
+using verible::LintViolation;
+using verible::SyntaxTreeContext;
+using verible::matcher::Matcher;
+using verible::matcher::EqualTagPredicate;
+using verible::FindFirstSubtree;
+
+absl::string_view LegacyGenerateRegionRule::Name() {
+  return "legacy-generate-region";
+}
+const char LegacyGenerateRegionRule::kTopic[] = "generate-constructs";
+const char LegacyGenerateRegionRule::kMessage[] =
+    "Do not use generate regions.";
+
+std::string LegacyGenerateRegionRule::GetDescription(
+    DescriptionType description_type) {
+  return absl::StrCat("Checks that there are no generate regions. See ",
+                      GetStyleGuideCitation(kTopic), ".");
+}
+
+void LegacyGenerateRegionRule::HandleNode(
+    const verible::SyntaxTreeNode& node,
+    const verible::SyntaxTreeContext& context) {
+
+  const auto tag = static_cast<verilog::NodeEnum>(node.Tag().tag);
+  if (tag == NodeEnum::kGenerateRegion) {
+    const auto* generate_keyword = ABSL_DIE_IF_NULL(FindFirstSubtree(&node,
+        EqualTagPredicate<verible::SymbolKind::kLeaf, verilog_tokentype,
+                          verilog_tokentype::TK_generate>));
+    const auto& leaf = verible::SymbolCastToLeaf(*generate_keyword);
+    violations_.insert(LintViolation(leaf.get(), kMessage));
+  }
+}
+
+LintRuleStatus LegacyGenerateRegionRule::Report() const {
+  return LintRuleStatus(violations_, Name(), GetStyleGuideCitation(kTopic));
+}
+
+}  // namespace analysis
+}  // namespace verilog

--- a/verilog/analysis/checkers/legacy_generate_region_rule.h
+++ b/verilog/analysis/checkers/legacy_generate_region_rule.h
@@ -1,0 +1,58 @@
+// Copyright 2017-2020 The Verible Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef VERIBLE_VERILOG_ANALYSIS_CHECKERS_LEGACY_GENERATE_REGION_RULE_H_
+#define VERIBLE_VERILOG_ANALYSIS_CHECKERS_LEGACY_GENERATE_REGION_RULE_H_
+
+#include <set>
+#include <string>
+
+#include "common/analysis/lint_rule_status.h"
+#include "common/analysis/syntax_tree_lint_rule.h"
+#include "common/text/concrete_syntax_tree.h"
+#include "common/text/syntax_tree_context.h"
+#include "verilog/analysis/descriptions.h"
+
+namespace verilog {
+namespace analysis {
+
+// LegacyGenerateRegionRule checks that generate regions are not used.
+class LegacyGenerateRegionRule : public verible::SyntaxTreeLintRule {
+ public:
+  using rule_type = verible::SyntaxTreeLintRule;
+  static absl::string_view Name();
+
+  // Returns the description of the rule implemented formatted for either the
+  // helper flag or markdown depending on the parameter type.
+  static std::string GetDescription(DescriptionType);
+
+  void HandleNode(const verible::SyntaxTreeNode& node,
+                  const verible::SyntaxTreeContext& context) override;
+
+  verible::LintRuleStatus Report() const override;
+
+ private:
+  // Link to style guide rule.
+  static const char kTopic[];
+
+  // Diagnostic message.
+  static const char kMessage[];
+
+  std::set<verible::LintViolation> violations_;
+};
+
+}  // namespace analysis
+}  // namespace verilog
+
+#endif  // VERIBLE_VERILOG_ANALYSIS_CHECKERS_LEGACY_GENERATE_REGION_RULE_H_

--- a/verilog/analysis/checkers/legacy_generate_region_rule_test.cc
+++ b/verilog/analysis/checkers/legacy_generate_region_rule_test.cc
@@ -1,0 +1,61 @@
+// Copyright 2017-2020 The Verible Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "verilog/analysis/checkers/legacy_generate_region_rule.h"
+
+#include <initializer_list>
+
+#include "gtest/gtest.h"
+#include "common/analysis/linter_test_utils.h"
+#include "common/analysis/syntax_tree_linter_test_utils.h"
+#include "verilog/CST/verilog_nonterminals.h"
+#include "verilog/analysis/verilog_analyzer.h"
+#include "verilog/parser/verilog_token_enum.h"
+
+namespace verilog {
+namespace analysis {
+namespace {
+
+using verible::LintTestCase;
+using verible::RunLintTestCases;
+
+TEST(LegacyGenerateRegionRuleTest, ValidCases) {
+  const std::initializer_list<LintTestCase> kTestCases = {
+    {""},
+    {"module M;\n"
+     "for (genvar k = 0; k < FooParam; k++) begin : gen_loop\n"
+     "  // code\n"
+     "end\n"
+     "endmodule\n"}
+  };
+  RunLintTestCases<VerilogAnalyzer, LegacyGenerateRegionRule>(kTestCases);
+}
+
+TEST(LegacyGenerateRegionRuleTest, InvalidCases) {
+  constexpr int kToken = TK_generate;
+  const std::initializer_list<LintTestCase> kTestCases = {
+    {"module M;\n",
+     {kToken, "generate"}, "\n"
+     "  for (genvar k = 0; k < FooParam; k++) begin : gen_loop\n"
+     "    // code\n"
+     "  end\n"
+     "endgenerate\n"
+     "endmodule\n"}
+  };
+  RunLintTestCases<VerilogAnalyzer, LegacyGenerateRegionRule>(kTestCases);
+}
+
+}  // namespace
+}  // namespace analysis
+}  // namespace verilog

--- a/verilog/analysis/checkers/legacy_genvar_declaration_rule.cc
+++ b/verilog/analysis/checkers/legacy_genvar_declaration_rule.cc
@@ -1,0 +1,77 @@
+// Copyright 2017-2020 The Verible Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "verilog/analysis/checkers/legacy_genvar_declaration_rule.h"
+
+#include <set>
+#include <string>
+
+#include "absl/strings/match.h"
+#include "absl/strings/str_cat.h"
+#include "common/analysis/citation.h"
+#include "common/analysis/lint_rule_status.h"
+#include "common/analysis/matcher/bound_symbol_manager.h"
+#include "common/analysis/matcher/matcher.h"
+#include "common/strings/naming_utils.h"
+#include "common/text/symbol.h"
+#include "common/text/syntax_tree_context.h"
+#include "verilog/CST/identifier.h"
+#include "verilog/CST/verilog_matchers.h"
+#include "verilog/analysis/lint_rule_registry.h"
+
+namespace verilog {
+namespace analysis {
+
+VERILOG_REGISTER_LINT_RULE(LegacyGenvarDeclarationRule);
+
+using verible::GetStyleGuideCitation;
+using verible::LintRuleStatus;
+using verible::LintViolation;
+using verible::SyntaxTreeContext;
+using verible::matcher::Matcher;
+
+absl::string_view LegacyGenvarDeclarationRule::Name() {
+  return "legacy-genvar-declaration";
+}
+const char LegacyGenvarDeclarationRule::kTopic[] = "generate-constructs";
+const char LegacyGenvarDeclarationRule::kMessage[] =
+    "Do not use separate genvar declaration.";
+
+std::string LegacyGenvarDeclarationRule::GetDescription(
+    DescriptionType description_type) {
+  return absl::StrCat("Checks that there are no separate ",
+                      Codify("genvar", description_type), " declarations. See ",
+                      GetStyleGuideCitation(kTopic), ".");
+}
+
+void LegacyGenvarDeclarationRule::HandleNode(
+    const verible::SyntaxTreeNode& node,
+    const verible::SyntaxTreeContext& context) {
+
+  const auto tag = static_cast<verilog::NodeEnum>(node.Tag().tag);
+  if (tag == NodeEnum::kGenvarDeclaration) {
+    const auto identifier_matches = FindAllSymbolIdentifierLeafs(node);
+    for (const auto& match: identifier_matches) {
+      const auto& leaf = verible::SymbolCastToLeaf(*match.match);
+      violations_.insert(LintViolation(leaf.get(), kMessage));
+    }
+  }
+}
+
+LintRuleStatus LegacyGenvarDeclarationRule::Report() const {
+  return LintRuleStatus(violations_, Name(), GetStyleGuideCitation(kTopic));
+}
+
+}  // namespace analysis
+}  // namespace verilog

--- a/verilog/analysis/checkers/legacy_genvar_declaration_rule.h
+++ b/verilog/analysis/checkers/legacy_genvar_declaration_rule.h
@@ -1,0 +1,59 @@
+// Copyright 2017-2020 The Verible Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef VERIBLE_VERILOG_ANALYSIS_CHECKERS_LEGACY_GENVAR_DECLARATION_RULE_H_
+#define VERIBLE_VERILOG_ANALYSIS_CHECKERS_LEGACY_GENVAR_DECLARATION_RULE_H_
+
+#include <set>
+#include <string>
+
+#include "common/analysis/lint_rule_status.h"
+#include "common/analysis/syntax_tree_lint_rule.h"
+#include "common/text/concrete_syntax_tree.h"
+#include "common/text/syntax_tree_context.h"
+#include "verilog/analysis/descriptions.h"
+
+namespace verilog {
+namespace analysis {
+
+// LegacyGenvarDeclarationRule checks that separate genvar declarations are not
+// used.
+class LegacyGenvarDeclarationRule : public verible::SyntaxTreeLintRule {
+ public:
+  using rule_type = verible::SyntaxTreeLintRule;
+  static absl::string_view Name();
+
+  // Returns the description of the rule implemented formatted for either the
+  // helper flag or markdown depending on the parameter type.
+  static std::string GetDescription(DescriptionType);
+
+  void HandleNode(const verible::SyntaxTreeNode& node,
+                  const verible::SyntaxTreeContext& context) override;
+
+  verible::LintRuleStatus Report() const override;
+
+ private:
+  // Link to style guide rule.
+  static const char kTopic[];
+
+  // Diagnostic message.
+  static const char kMessage[];
+
+  std::set<verible::LintViolation> violations_;
+};
+
+}  // namespace analysis
+}  // namespace verilog
+
+#endif  // VERIBLE_VERILOG_ANALYSIS_CHECKERS_LEGACY_GENVAR_DECLARATION_RULE_H_

--- a/verilog/analysis/checkers/legacy_genvar_declaration_rule_test.cc
+++ b/verilog/analysis/checkers/legacy_genvar_declaration_rule_test.cc
@@ -1,0 +1,63 @@
+// Copyright 2017-2020 The Verible Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "verilog/analysis/checkers/legacy_genvar_declaration_rule.h"
+
+#include <initializer_list>
+
+#include "gtest/gtest.h"
+#include "common/analysis/linter_test_utils.h"
+#include "common/analysis/syntax_tree_linter_test_utils.h"
+#include "common/text/symbol.h"
+#include "verilog/CST/verilog_nonterminals.h"
+#include "verilog/analysis/verilog_analyzer.h"
+#include "verilog/parser/verilog_token_enum.h"
+
+namespace verilog {
+namespace analysis {
+namespace {
+
+using verible::LintTestCase;
+using verible::RunLintTestCases;
+
+TEST(LegacyGenvarDeclarationRuleTest, ValidCases) {
+  const std::initializer_list<LintTestCase> kTestCases = {
+    {""},
+    {"module M;\n"
+     "for (genvar k = 0; k < FooParam; k++) begin : gen_loop\n"
+     "  // code\n"
+     "end\n"
+     "endmodule\n"}
+  };
+  RunLintTestCases<VerilogAnalyzer, LegacyGenvarDeclarationRule>(kTestCases);
+}
+
+TEST(LegacyGenvarDeclarationRuleTest, InvalidCases) {
+  constexpr int kToken = SymbolIdentifier;
+  const std::initializer_list<LintTestCase> kTestCases = {
+    {"module M;\n",
+     "genvar ", {kToken, "k"}, ";\n"
+     "generate\n"
+     "  for (k = 0; k < FooParam; k++) begin : gen_loop\n"
+     "    // code\n"
+     "  end\n"
+     "endgenerate\n"
+     "endmodule\n"}
+  };
+  RunLintTestCases<VerilogAnalyzer, LegacyGenvarDeclarationRule>(kTestCases);
+}
+
+}  // namespace
+}  // namespace analysis
+}  // namespace verilog

--- a/verilog/tools/lint/BUILD
+++ b/verilog/tools/lint/BUILD
@@ -36,6 +36,7 @@ _linter_test_configs = [
     ("invalid-system-task-function", "psprintf", True),
     ("interface-name-style", "interface_type_name_style", True),
     ("legacy-genvar-declaration", "legacy_genvar_declaration", False),
+    ("legacy-generate-region", "legacy_generate_region", False),
     ("macro-name-style", "macro_name_style", True),
     ("mismatched-labels", "mismatched_labels", False),
     ("module-begin-block", "module_begin_block", True),

--- a/verilog/tools/lint/BUILD
+++ b/verilog/tools/lint/BUILD
@@ -35,6 +35,7 @@ _linter_test_configs = [
     ("generate-label-prefix", "generate_label_prefix", True),
     ("invalid-system-task-function", "psprintf", True),
     ("interface-name-style", "interface_type_name_style", True),
+    ("legacy-genvar-declaration", "legacy_genvar_declaration", False),
     ("macro-name-style", "macro_name_style", True),
     ("mismatched-labels", "mismatched_labels", False),
     ("module-begin-block", "module_begin_block", True),

--- a/verilog/tools/lint/testdata/generate-label-module-body.sv
+++ b/verilog/tools/lint/testdata/generate-label-module-body.sv
@@ -1,4 +1,5 @@
 // verilog_syntax: parse-as-module-body
+// verilog_lint: waive legacy-generate-region
 generate if (foo) begin
   baz bam;
 end

--- a/verilog/tools/lint/testdata/generate_begin_module.sv
+++ b/verilog/tools/lint/testdata/generate_begin_module.sv
@@ -1,4 +1,5 @@
 module generate_begin_module;
+  // verilog_lint: waive legacy-generate-region
   generate
     begin : gen_block1
       always @(posedge clk) foo <= bar;

--- a/verilog/tools/lint/testdata/generate_label_module.sv
+++ b/verilog/tools/lint/testdata/generate_label_module.sv
@@ -1,4 +1,5 @@
 module generate_label_module;
+  // verilog_lint: waive legacy-generate-region
   generate if (foo) begin
     baz bam;
   end

--- a/verilog/tools/lint/testdata/generate_label_prefix.sv
+++ b/verilog/tools/lint/testdata/generate_label_prefix.sv
@@ -1,4 +1,5 @@
 module generate_label_prefix;
+  // verilog_lint: waive legacy-genvar-declaration
   genvar i;
   for (i = 0; i < 5; ++i) begin : invalid_label
   end

--- a/verilog/tools/lint/testdata/legacy_generate_region.sv
+++ b/verilog/tools/lint/testdata/legacy_generate_region.sv
@@ -1,0 +1,6 @@
+// verilog_syntax: parse-as-module-body
+generate
+  for (genvar k = 0; k < FooParam; k++) begin : gen_loop
+    // code
+  end
+endgenerate

--- a/verilog/tools/lint/testdata/legacy_genvar_declaration.sv
+++ b/verilog/tools/lint/testdata/legacy_genvar_declaration.sv
@@ -1,0 +1,5 @@
+// verilog_syntax: parse-as-module-body
+genvar k;
+for (k = 0; k < FooParam; k++) begin : gen_loop
+  // code
+end


### PR DESCRIPTION
Closes #525

Note that this does not remove `v2001-generate-begin` rule mentioned in the issue.