### PR TITLE
Run clang-format once to have a baseline for future formatting.

### DIFF
--- a/common/analysis/command_file_lexer_test.cc
+++ b/common/analysis/command_file_lexer_test.cc
@@ -17,10 +17,10 @@
 #include <initializer_list>
 #include <utility>
 
-#include "gtest/gtest.h"
 #include "absl/strings/string_view.h"
 #include "common/lexer/lexer_test_util.h"
 #include "common/text/token_info.h"
+#include "gtest/gtest.h"
 
 namespace verible {
 namespace {

--- a/common/analysis/file_analyzer_test.cc
+++ b/common/analysis/file_analyzer_test.cc
@@ -19,12 +19,12 @@
 #include <sstream>
 #include <string>
 
-#include "gtest/gtest.h"
 #include "absl/status/status.h"
 #include "absl/strings/match.h"
 #include "absl/strings/string_view.h"
 #include "common/text/text_structure.h"
 #include "common/text/token_info.h"
+#include "gtest/gtest.h"
 
 namespace verible {
 namespace {

--- a/common/analysis/line_linter_test.cc
+++ b/common/analysis/line_linter_test.cc
@@ -18,12 +18,12 @@
 #include <memory>
 #include <vector>
 
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
 #include "absl/strings/string_view.h"
 #include "common/analysis/line_lint_rule.h"
 #include "common/analysis/lint_rule_status.h"
 #include "common/text/token_info.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 namespace verible {
 namespace {

--- a/common/analysis/lint_rule_status_test.cc
+++ b/common/analysis/lint_rule_status_test.cc
@@ -18,12 +18,12 @@
 #include <string>
 #include <vector>
 
-#include "gtest/gtest.h"
 #include "absl/strings/str_split.h"
 #include "absl/strings/string_view.h"
 #include "common/text/concrete_syntax_tree.h"
 #include "common/text/token_info.h"
 #include "common/text/tree_builder_test_util.h"
+#include "gtest/gtest.h"
 
 namespace verible {
 namespace {

--- a/common/analysis/lint_waiver_test.cc
+++ b/common/analysis/lint_waiver_test.cc
@@ -17,12 +17,12 @@
 #include <cstddef>
 #include <vector>
 
-#include "gtest/gtest.h"
 #include "common/strings/line_column_map.h"
 #include "common/text/text_structure_test_utils.h"
 #include "common/text/token_info.h"
 #include "common/text/token_stream_view.h"
 #include "common/util/iterator_range.h"
+#include "gtest/gtest.h"
 
 #undef EXPECT_OK
 #undef EXPECT_NOK

--- a/common/analysis/linter_test_utils.h
+++ b/common/analysis/linter_test_utils.h
@@ -22,12 +22,12 @@
 #include <set>
 #include <sstream>
 
-#include "gtest/gtest.h"
 #include "absl/status/status.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/string_view.h"
 #include "common/analysis/lint_rule_status.h"
 #include "common/text/token_info_test_util.h"
+#include "gtest/gtest.h"
 
 namespace verible {
 

--- a/common/analysis/linter_test_utils_test.cc
+++ b/common/analysis/linter_test_utils_test.cc
@@ -18,11 +18,11 @@
 #include <string>
 #include <vector>
 
-#include "gtest/gtest.h"
 #include "absl/strings/match.h"
 #include "absl/strings/string_view.h"
 #include "common/analysis/lint_rule_status.h"
 #include "common/util/range.h"
+#include "gtest/gtest.h"
 
 namespace verible {
 namespace {

--- a/common/analysis/matcher/core_matchers_test.cc
+++ b/common/analysis/matcher/core_matchers_test.cc
@@ -16,13 +16,13 @@
 
 #include <memory>
 
-#include "gtest/gtest.h"
 #include "common/analysis/matcher/bound_symbol_manager.h"
 #include "common/analysis/matcher/matcher.h"
 #include "common/analysis/matcher/matcher_builders.h"
 #include "common/analysis/matcher/matcher_test_utils.h"
 #include "common/text/symbol.h"
 #include "common/text/tree_builder_test_util.h"
+#include "gtest/gtest.h"
 
 namespace verible {
 namespace matcher {

--- a/common/analysis/matcher/descent_path_test.cc
+++ b/common/analysis/matcher/descent_path_test.cc
@@ -17,12 +17,12 @@
 #include <memory>
 #include <vector>
 
-#include "gtest/gtest.h"
 #include "common/text/concrete_syntax_leaf.h"
 #include "common/text/concrete_syntax_tree.h"
 #include "common/text/symbol.h"
 #include "common/text/token_info.h"
 #include "common/text/tree_builder_test_util.h"
+#include "gtest/gtest.h"
 
 namespace verible {
 namespace matcher {

--- a/common/analysis/matcher/matcher_builders_test.cc
+++ b/common/analysis/matcher/matcher_builders_test.cc
@@ -16,7 +16,6 @@
 
 #include <memory>
 
-#include "gtest/gtest.h"
 #include "common/analysis/matcher/bound_symbol_manager.h"
 #include "common/analysis/matcher/matcher.h"
 #include "common/analysis/matcher/matcher_test_utils.h"
@@ -24,6 +23,7 @@
 #include "common/text/concrete_syntax_tree.h"
 #include "common/text/symbol.h"
 #include "common/text/tree_builder_test_util.h"
+#include "gtest/gtest.h"
 
 namespace verible {
 namespace matcher {

--- a/common/analysis/matcher/matcher_test.cc
+++ b/common/analysis/matcher/matcher_test.cc
@@ -17,7 +17,6 @@
 #include <memory>
 #include <vector>
 
-#include "gtest/gtest.h"
 #include "common/analysis/matcher/bound_symbol_manager.h"
 #include "common/analysis/matcher/inner_match_handlers.h"
 #include "common/analysis/matcher/matcher_builders.h"
@@ -25,6 +24,7 @@
 #include "common/text/concrete_syntax_tree.h"
 #include "common/text/symbol.h"
 #include "common/text/tree_builder_test_util.h"
+#include "gtest/gtest.h"
 
 namespace verible {
 namespace matcher {

--- a/common/analysis/matcher/matcher_test_utils.cc
+++ b/common/analysis/matcher/matcher_test_utils.cc
@@ -17,7 +17,6 @@
 #include <map>
 #include <utility>
 
-#include "gtest/gtest.h"
 #include "absl/strings/string_view.h"
 #include "common/analysis/matcher/bound_symbol_manager.h"
 #include "common/analysis/matcher/matcher.h"
@@ -25,6 +24,7 @@
 #include "common/text/concrete_syntax_tree.h"
 #include "common/text/symbol.h"
 #include "common/text/visitors.h"
+#include "gtest/gtest.h"
 
 namespace verible {
 namespace matcher {

--- a/common/analysis/matcher/matcher_test_utils.h
+++ b/common/analysis/matcher/matcher_test_utils.h
@@ -18,12 +18,12 @@
 #include <map>
 #include <string>
 
-#include "gtest/gtest.h"
 #include "absl/status/status.h"
 #include "absl/strings/string_view.h"
 #include "common/analysis/matcher/matcher.h"
 #include "common/text/concrete_syntax_tree.h"
 #include "common/text/symbol.h"
+#include "gtest/gtest.h"
 
 namespace verible {
 namespace matcher {

--- a/common/analysis/syntax_tree_linter_test.cc
+++ b/common/analysis/syntax_tree_linter_test.cc
@@ -17,7 +17,6 @@
 #include <memory>
 #include <vector>
 
-#include "gtest/gtest.h"
 #include "common/analysis/lint_rule_status.h"
 #include "common/analysis/syntax_tree_lint_rule.h"
 #include "common/text/concrete_syntax_leaf.h"
@@ -26,6 +25,7 @@
 #include "common/text/syntax_tree_context.h"
 #include "common/text/token_info.h"
 #include "common/text/tree_builder_test_util.h"
+#include "gtest/gtest.h"
 
 namespace verible {
 namespace {

--- a/common/analysis/syntax_tree_linter_test_utils.h
+++ b/common/analysis/syntax_tree_linter_test_utils.h
@@ -19,7 +19,6 @@
 #include <utility>
 #include <vector>
 
-#include "gtest/gtest.h"
 #include "absl/strings/string_view.h"
 #include "common/analysis/lint_rule_status.h"
 #include "common/analysis/linter_test_utils.h"
@@ -27,6 +26,7 @@
 #include "common/analysis/syntax_tree_linter.h"
 #include "common/text/text_structure.h"
 #include "common/util/logging.h"
+#include "gtest/gtest.h"
 
 namespace verible {
 

--- a/common/analysis/syntax_tree_search_test.cc
+++ b/common/analysis/syntax_tree_search_test.cc
@@ -17,13 +17,13 @@
 #include <memory>
 #include <vector>
 
-#include "gtest/gtest.h"
 #include "common/analysis/matcher/matcher.h"
 #include "common/analysis/matcher/matcher_builders.h"
 #include "common/text/symbol.h"
 #include "common/text/syntax_tree_context.h"
 #include "common/text/tree_builder_test_util.h"
 #include "common/text/tree_utils.h"
+#include "gtest/gtest.h"
 
 namespace verible {
 namespace {

--- a/common/analysis/syntax_tree_search_test_utils.h
+++ b/common/analysis/syntax_tree_search_test_utils.h
@@ -21,10 +21,10 @@
 #include <string>
 #include <vector>
 
-#include "gtest/gtest.h"
 #include "absl/strings/string_view.h"
 #include "common/analysis/syntax_tree_search.h"
 #include "common/lexer/lexer_test_util.h"
+#include "gtest/gtest.h"
 
 namespace verible {
 

--- a/common/analysis/syntax_tree_search_test_utils_test.cc
+++ b/common/analysis/syntax_tree_search_test_utils_test.cc
@@ -18,11 +18,11 @@
 #include <string>
 #include <vector>
 
-#include "gtest/gtest.h"
 #include "absl/strings/match.h"
 #include "absl/strings/string_view.h"
 #include "common/text/tree_builder_test_util.h"
 #include "common/util/range.h"
+#include "gtest/gtest.h"
 
 namespace verible {
 namespace {

--- a/common/analysis/text_structure_linter_test.cc
+++ b/common/analysis/text_structure_linter_test.cc
@@ -17,14 +17,14 @@
 #include <memory>
 #include <vector>
 
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
 #include "absl/strings/match.h"
 #include "absl/strings/string_view.h"
 #include "common/analysis/lint_rule_status.h"
 #include "common/analysis/text_structure_lint_rule.h"
 #include "common/text/text_structure.h"
 #include "common/text/token_info.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 namespace verible {
 namespace {

--- a/common/analysis/text_structure_linter_test_utils.h
+++ b/common/analysis/text_structure_linter_test_utils.h
@@ -19,13 +19,13 @@
 #include <utility>
 #include <vector>
 
-#include "gtest/gtest.h"
 #include "absl/status/status.h"
 #include "common/analysis/lint_rule_status.h"
 #include "common/analysis/linter_test_utils.h"
 #include "common/analysis/text_structure_linter.h"
 #include "common/text/symbol.h"
 #include "common/util/logging.h"
+#include "gtest/gtest.h"
 
 namespace verible {
 

--- a/common/analysis/token_stream_linter_test.cc
+++ b/common/analysis/token_stream_linter_test.cc
@@ -17,13 +17,13 @@
 #include <memory>
 #include <vector>
 
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
 #include "absl/strings/string_view.h"
 #include "common/analysis/lint_rule_status.h"
 #include "common/analysis/token_stream_lint_rule.h"
 #include "common/text/token_info.h"
 #include "common/text/token_stream_view.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 namespace verible {
 namespace {

--- a/common/formatting/align_test.cc
+++ b/common/formatting/align_test.cc
@@ -19,8 +19,6 @@
 #include <utility>
 #include <vector>
 
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
 #include "absl/strings/str_split.h"
 #include "common/formatting/format_token.h"
 #include "common/formatting/token_partition_tree.h"
@@ -28,6 +26,8 @@
 #include "common/text/tree_builder_test_util.h"
 #include "common/util/range.h"
 #include "common/util/spacer.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 namespace verible {
 namespace {
@@ -35,10 +35,10 @@ namespace {
 using ::testing::ElementsAre;
 
 TEST(AlignmentPolicyTest, StringRepresentation) {
-    std::ostringstream stream;
-    stream << AlignmentPolicy::kAlign;
-    EXPECT_EQ(stream.str(), "align");
-    EXPECT_EQ(AbslUnparseFlag(AlignmentPolicy::kAlign), "align");
+  std::ostringstream stream;
+  stream << AlignmentPolicy::kAlign;
+  EXPECT_EQ(stream.str(), "align");
+  EXPECT_EQ(AbslUnparseFlag(AlignmentPolicy::kAlign), "align");
 }
 
 TEST(AlignmentPolicyTest, InvalidEnum) {

--- a/common/formatting/format_token_test.cc
+++ b/common/formatting/format_token_test.cc
@@ -18,12 +18,12 @@
 #include <string>
 #include <vector>
 
-#include "gtest/gtest.h"
 #include "absl/strings/string_view.h"
 #include "common/formatting/unwrapped_line.h"
 #include "common/formatting/unwrapped_line_test_utils.h"
 #include "common/text/token_info.h"
 #include "common/util/range.h"
+#include "gtest/gtest.h"
 
 namespace verible {
 namespace {

--- a/common/formatting/line_wrap_searcher_test.cc
+++ b/common/formatting/line_wrap_searcher_test.cc
@@ -16,13 +16,13 @@
 
 #include <vector>
 
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
 #include "absl/strings/match.h"
 #include "common/formatting/basic_format_style.h"
 #include "common/formatting/format_token.h"
 #include "common/formatting/unwrapped_line.h"
 #include "common/formatting/unwrapped_line_test_utils.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 namespace verible {
 namespace {

--- a/common/formatting/state_node_test.cc
+++ b/common/formatting/state_node_test.cc
@@ -19,7 +19,6 @@
 #include <string>
 #include <vector>
 
-#include "gtest/gtest.h"
 #include "absl/memory/memory.h"
 #include "absl/strings/string_view.h"
 #include "common/formatting/basic_format_style.h"
@@ -27,6 +26,7 @@
 #include "common/formatting/unwrapped_line.h"
 #include "common/formatting/unwrapped_line_test_utils.h"
 #include "common/util/logging.h"
+#include "gtest/gtest.h"
 
 namespace verible {
 namespace {

--- a/common/formatting/token_partition_tree_test.cc
+++ b/common/formatting/token_partition_tree_test.cc
@@ -19,8 +19,6 @@
 #include <string>
 #include <vector>
 
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
 #include "absl/strings/str_split.h"
 #include "absl/strings/string_view.h"
 #include "common/formatting/format_token.h"
@@ -28,6 +26,8 @@
 #include "common/formatting/unwrapped_line_test_utils.h"
 #include "common/util/container_iterator_range.h"
 #include "common/util/vector_tree.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 namespace verible {
 namespace {

--- a/common/formatting/tree_annotator_test.cc
+++ b/common/formatting/tree_annotator_test.cc
@@ -14,13 +14,13 @@
 
 #include "common/formatting/tree_annotator.h"
 
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
 #include "common/formatting/format_token.h"
 #include "common/text/constants.h"
 #include "common/text/token_info.h"
 #include "common/text/tree_builder_test_util.h"
 #include "common/util/iterator_range.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 namespace verible {
 namespace {

--- a/common/formatting/tree_unwrapper_test.cc
+++ b/common/formatting/tree_unwrapper_test.cc
@@ -19,7 +19,6 @@
 #include <memory>
 #include <vector>
 
-#include "gtest/gtest.h"
 #include "absl/strings/ascii.h"
 #include "absl/strings/string_view.h"
 #include "common/formatting/format_token.h"
@@ -32,6 +31,7 @@
 #include "common/text/token_stream_view.h"
 #include "common/util/container_iterator_range.h"
 #include "common/util/range.h"
+#include "gtest/gtest.h"
 
 namespace verible {
 

--- a/common/formatting/unwrapped_line_test.cc
+++ b/common/formatting/unwrapped_line_test.cc
@@ -18,11 +18,11 @@
 #include <sstream>
 #include <vector>
 
-#include "gtest/gtest.h"
 #include "common/formatting/format_token.h"
 #include "common/formatting/unwrapped_line_test_utils.h"
 #include "common/text/tree_builder_test_util.h"
 #include "common/util/container_iterator_range.h"
+#include "gtest/gtest.h"
 
 namespace verible {
 namespace {

--- a/common/formatting/verification_test.cc
+++ b/common/formatting/verification_test.cc
@@ -14,9 +14,9 @@
 
 #include "common/formatting/verification.h"
 
+#include "absl/strings/match.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
-#include "absl/strings/match.h"
 
 namespace verible {
 namespace {

--- a/common/lexer/lexer_test_util.h
+++ b/common/lexer/lexer_test_util.h
@@ -28,11 +28,11 @@
 #include <string>
 #include <vector>
 
-#include "gtest/gtest.h"
 #include "absl/strings/string_view.h"
 #include "common/text/constants.h"
 #include "common/text/token_info.h"
 #include "common/text/token_info_test_util.h"
+#include "gtest/gtest.h"
 
 namespace verible {
 

--- a/common/lexer/lexer_test_util_test.cc
+++ b/common/lexer/lexer_test_util_test.cc
@@ -18,12 +18,12 @@
 #include <iterator>
 #include <vector>
 
-#include "gtest/gtest.h"
 #include "absl/strings/match.h"
 #include "absl/strings/string_view.h"
 #include "common/text/constants.h"
 #include "common/text/token_info.h"
 #include "common/util/logging.h"
+#include "gtest/gtest.h"
 
 namespace verible {
 namespace {

--- a/common/lexer/token_stream_adapter_test.cc
+++ b/common/lexer/token_stream_adapter_test.cc
@@ -14,12 +14,12 @@
 
 #include "common/lexer/token_stream_adapter.h"
 
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
 #include "absl/status/status.h"
 #include "common/lexer/lexer.h"
 #include "common/lexer/lexer_test_util.h"
 #include "common/text/token_info.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 namespace verible {
 namespace {

--- a/common/parser/bison_parser_common_test.cc
+++ b/common/parser/bison_parser_common_test.cc
@@ -18,7 +18,6 @@
 
 #include <memory>
 
-#include "gtest/gtest.h"
 #include "absl/strings/string_view.h"
 #include "common/lexer/lexer.h"
 #include "common/lexer/token_stream_adapter.h"
@@ -27,6 +26,7 @@
 #include "common/text/concrete_syntax_tree.h"
 #include "common/text/symbol.h"
 #include "common/text/token_info.h"
+#include "gtest/gtest.h"
 
 namespace verible {
 namespace {

--- a/common/parser/parser_test_util.h
+++ b/common/parser/parser_test_util.h
@@ -20,13 +20,13 @@
 #include <string>  // for string
 #include <vector>
 
-#include "gtest/gtest.h"
 #include "absl/status/status.h"
 #include "common/analysis/matcher/descent_path.h"
 #include "common/text/parser_verifier.h"
 #include "common/text/symbol.h"
 #include "common/text/token_info.h"
 #include "common/text/token_info_test_util.h"
+#include "gtest/gtest.h"
 
 namespace verible {
 

--- a/common/strings/comment_utils_test.cc
+++ b/common/strings/comment_utils_test.cc
@@ -14,9 +14,9 @@
 
 #include "common/strings/comment_utils.h"
 
-#include "gtest/gtest.h"
 #include "absl/strings/string_view.h"
 #include "common/util/range.h"
+#include "gtest/gtest.h"
 
 namespace verible {
 namespace {

--- a/common/strings/diff_test.cc
+++ b/common/strings/diff_test.cc
@@ -17,9 +17,9 @@
 #include <initializer_list>
 #include <sstream>
 
+#include "absl/strings/string_view.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
-#include "absl/strings/string_view.h"
 
 namespace diff {
 // Print functions copied from external_libs/editscript_test.cc

--- a/common/strings/line_column_map_test.cc
+++ b/common/strings/line_column_map_test.cc
@@ -19,9 +19,9 @@
 #include <sstream>  // IWYU pragma: keep  // for ostringstream
 #include <vector>
 
-#include "gtest/gtest.h"
 #include "absl/strings/str_split.h"
 #include "absl/strings/string_view.h"
+#include "gtest/gtest.h"
 
 namespace verible {
 namespace {

--- a/common/strings/obfuscator_test.cc
+++ b/common/strings/obfuscator_test.cc
@@ -14,10 +14,10 @@
 
 #include "common/strings/obfuscator.h"
 
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
 #include "common/util/bijective_map.h"
 #include "common/util/logging.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 namespace verible {
 namespace {

--- a/common/strings/patch.cc
+++ b/common/strings/patch.cc
@@ -431,7 +431,7 @@ absl::Status FilePatch::PickApply(std::istream& ins, std::ostream& outs,
   // Needs own copy of string due to potential splitting into temporary hunks.
   std::vector<std::string> output_lines;
 
-  int last_consumed_line = 0;  // 0-indexed
+  int last_consumed_line = 0;                                     // 0-indexed
   std::deque<Hunk> hunks_worklist(hunks_.begin(), hunks_.end());  // copy-fill
   while (!hunks_worklist.empty()) {
     VLOG(1) << "hunks remaining: " << hunks_worklist.size();

--- a/common/strings/patch_test.cc
+++ b/common/strings/patch_test.cc
@@ -18,13 +18,13 @@
 #include <sstream>
 #include <vector>
 
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
 #include "absl/status/status.h"
 #include "absl/strings/match.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_join.h"
 #include "absl/strings/string_view.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 namespace verible {
 

--- a/common/strings/range_test.cc
+++ b/common/strings/range_test.cc
@@ -14,9 +14,9 @@
 
 #include "common/strings/range.h"
 
+#include "common/util/range.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
-#include "common/util/range.h"
 
 namespace verible {
 namespace {

--- a/common/strings/rebase_test.cc
+++ b/common/strings/rebase_test.cc
@@ -18,10 +18,10 @@
 
 #include <string>
 
-#include "gtest/gtest.h"
 #include "absl/base/macros.h"
 #include "absl/strings/string_view.h"
 #include "common/util/range.h"
+#include "gtest/gtest.h"
 
 namespace verible {
 namespace {

--- a/common/strings/split_test.cc
+++ b/common/strings/split_test.cc
@@ -14,10 +14,10 @@
 
 #include "common/strings/split.h"
 
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
 #include "common/strings/range.h"
 #include "common/util/range.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 namespace verible {
 namespace {

--- a/common/strings/string_memory_map_test.cc
+++ b/common/strings/string_memory_map_test.cc
@@ -17,11 +17,11 @@
 #include <memory>
 #include <string>
 
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
 #include "absl/memory/memory.h"
 #include "common/strings/range.h"
 #include "common/util/range.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 namespace verible {
 namespace {

--- a/common/text/concrete_syntax_leaf_test.cc
+++ b/common/text/concrete_syntax_leaf_test.cc
@@ -16,8 +16,8 @@
 
 #include "common/text/concrete_syntax_leaf.h"
 
-#include "gtest/gtest.h"
 #include "common/text/token_info.h"
+#include "gtest/gtest.h"
 
 namespace verible {
 namespace {

--- a/common/text/concrete_syntax_tree_test.cc
+++ b/common/text/concrete_syntax_tree_test.cc
@@ -19,13 +19,13 @@
 #include <memory>
 #include <utility>
 
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
 #include "common/text/concrete_syntax_leaf.h"
 #include "common/text/symbol.h"
 #include "common/text/tree_builder_test_util.h"
 #include "common/text/tree_compare.h"
 #include "common/util/logging.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 namespace verible {
 

--- a/common/text/config_utils_test.cc
+++ b/common/text/config_utils_test.cc
@@ -18,10 +18,10 @@
 #include <string>
 #include <vector>
 
-#include "gtest/gtest.h"
 #include "absl/status/status.h"
 #include "absl/strings/match.h"
 #include "absl/strings/string_view.h"
+#include "gtest/gtest.h"
 
 namespace verible {
 namespace config {

--- a/common/text/macro_definition_test.cc
+++ b/common/text/macro_definition_test.cc
@@ -18,10 +18,10 @@
 
 #include <vector>
 
-#include "gtest/gtest.h"
 #include "absl/status/status.h"
 #include "common/text/token_info.h"
 #include "common/util/container_util.h"
+#include "gtest/gtest.h"
 
 namespace verible {
 namespace {

--- a/common/text/parser_verifier_test.cc
+++ b/common/text/parser_verifier_test.cc
@@ -17,12 +17,12 @@
 #include <memory>
 #include <vector>
 
-#include "gtest/gtest.h"
 #include "absl/strings/string_view.h"
 #include "common/text/constants.h"
 #include "common/text/token_info.h"
 #include "common/text/token_stream_view.h"
 #include "common/text/tree_builder_test_util.h"
+#include "gtest/gtest.h"
 
 namespace verible {
 

--- a/common/text/syntax_tree_context_test.cc
+++ b/common/text/syntax_tree_context_test.cc
@@ -14,10 +14,10 @@
 
 #include "common/text/syntax_tree_context.h"
 
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
 #include "common/text/concrete_syntax_tree.h"
 #include "common/util/iterator_range.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 namespace verible {
 namespace {

--- a/common/text/text_structure_test.cc
+++ b/common/text/text_structure_test.cc
@@ -22,8 +22,6 @@
 #include <utility>
 #include <vector>
 
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
 #include "absl/memory/memory.h"
 #include "absl/status/status.h"
 #include "absl/strings/string_view.h"
@@ -39,6 +37,8 @@
 #include "common/util/logging.h"
 #include "common/util/range.h"
 #include "common/util/value_saver.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 #undef EXPECT_OK
 #define EXPECT_OK(value) EXPECT_TRUE((value).ok())

--- a/common/text/token_info_test.cc
+++ b/common/text/token_info_test.cc
@@ -19,11 +19,11 @@
 #include <string>
 #include <vector>
 
-#include "gtest/gtest.h"
 #include "absl/base/macros.h"
 #include "absl/strings/string_view.h"
 #include "common/text/constants.h"
 #include "common/util/range.h"
+#include "gtest/gtest.h"
 
 namespace verible {
 namespace {

--- a/common/text/token_info_test_util_test.cc
+++ b/common/text/token_info_test_util_test.cc
@@ -16,10 +16,10 @@
 
 #include <vector>
 
-#include "gtest/gtest.h"
 #include "absl/strings/string_view.h"
 #include "common/text/token_info.h"
 #include "common/util/logging.h"
+#include "gtest/gtest.h"
 
 namespace verible {
 namespace {

--- a/common/text/token_stream_view_test.cc
+++ b/common/text/token_stream_view_test.cc
@@ -18,11 +18,11 @@
 #include <iterator>
 #include <vector>
 
-#include "gtest/gtest.h"
 #include "common/text/text_structure.h"
 #include "common/text/text_structure_test_utils.h"
 #include "common/text/token_info.h"
 #include "common/util/iterator_range.h"
+#include "gtest/gtest.h"
 
 namespace verible {
 

--- a/common/text/tree_builder_test_util_test.cc
+++ b/common/text/tree_builder_test_util_test.cc
@@ -14,8 +14,8 @@
 
 #include "common/text/tree_builder_test_util.h"
 
-#include "gtest/gtest.h"
 #include "common/text/tree_utils.h"
+#include "gtest/gtest.h"
 
 namespace verible {
 namespace {

--- a/common/text/tree_compare_test.cc
+++ b/common/text/tree_compare_test.cc
@@ -14,9 +14,9 @@
 
 #include "common/text/tree_compare.h"
 
-#include "gtest/gtest.h"
 #include "common/text/concrete_syntax_tree.h"
 #include "common/text/tree_builder_test_util.h"
+#include "gtest/gtest.h"
 
 namespace verible {
 namespace {

--- a/common/text/tree_context_visitor_test.cc
+++ b/common/text/tree_context_visitor_test.cc
@@ -16,9 +16,9 @@
 
 #include <vector>
 
+#include "common/text/tree_builder_test_util.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
-#include "common/text/tree_builder_test_util.h"
 
 namespace verible {
 namespace {

--- a/common/text/tree_utils_test.cc
+++ b/common/text/tree_utils_test.cc
@@ -19,7 +19,6 @@
 #include <string>
 #include <vector>
 
-#include "gtest/gtest.h"
 #include "common/text/concrete_syntax_leaf.h"
 #include "common/text/concrete_syntax_tree.h"
 #include "common/text/symbol.h"
@@ -28,6 +27,7 @@
 #include "common/text/tree_compare.h"
 #include "common/util/logging.h"
 #include "common/util/range.h"
+#include "gtest/gtest.h"
 
 namespace verible {
 namespace {

--- a/common/util/algorithm_test.cc
+++ b/common/util/algorithm_test.cc
@@ -19,10 +19,10 @@
 #include <string>
 #include <vector>
 
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
 #include "absl/strings/string_view.h"
 #include "common/util/iterator_range.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 namespace verible {
 namespace {

--- a/common/util/auto_pop_stack_test.cc
+++ b/common/util/auto_pop_stack_test.cc
@@ -14,9 +14,9 @@
 
 #include "common/util/auto_pop_stack.h"
 
+#include "common/util/iterator_range.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
-#include "common/util/iterator_range.h"
 
 namespace verible {
 namespace {

--- a/common/util/bijective_map_test.cc
+++ b/common/util/bijective_map_test.cc
@@ -16,10 +16,10 @@
 
 #include <string>
 
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
 #include "common/strings/compare.h"
 #include "common/util/logging.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 namespace verible {
 namespace {

--- a/common/util/enum_flags_test.cc
+++ b/common/util/enum_flags_test.cc
@@ -19,10 +19,10 @@
 #include <sstream>
 #include <string>
 
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
 #include "absl/strings/match.h"
 #include "absl/strings/string_view.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 namespace verible {
 namespace {

--- a/common/util/expandable_tree_view_test.cc
+++ b/common/util/expandable_tree_view_test.cc
@@ -17,12 +17,12 @@
 #include <sstream>
 #include <vector>
 
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
 #include "absl/strings/str_join.h"
 #include "absl/strings/string_view.h"
 #include "common/util/vector_tree.h"
 #include "common/util/vector_tree_test_util.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 namespace verible {
 namespace {

--- a/common/util/file_util_test.cc
+++ b/common/util/file_util_test.cc
@@ -18,9 +18,9 @@
 #include <string>
 #include <vector>
 
-#include "gtest/gtest.h"
 #include "absl/status/status.h"
 #include "absl/strings/string_view.h"
+#include "gtest/gtest.h"
 
 #undef EXPECT_OK
 #define EXPECT_OK(value) EXPECT_TRUE((value).ok())

--- a/common/util/forward_test.cc
+++ b/common/util/forward_test.cc
@@ -16,9 +16,9 @@
 
 #include <string>
 
+#include "absl/strings/string_view.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
-#include "absl/strings/string_view.h"
 
 namespace verible {
 namespace {

--- a/common/util/interval_map_test.cc
+++ b/common/util/interval_map_test.cc
@@ -18,10 +18,10 @@
 #include <tuple>
 #include <vector>
 
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
 #include "absl/memory/memory.h"
 #include "common/util/range.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 namespace verible {
 namespace {

--- a/common/util/iterator_range_test.cc
+++ b/common/util/iterator_range_test.cc
@@ -20,9 +20,9 @@
 #include <utility>
 #include <vector>
 
+#include "common/util/range.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
-#include "common/util/range.h"
 
 namespace verible {
 namespace {

--- a/common/util/map_tree_test.cc
+++ b/common/util/map_tree_test.cc
@@ -17,9 +17,9 @@
 #include <sstream>
 #include <string>
 
+#include "common/util/spacer.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
-#include "common/util/spacer.h"
 
 namespace verible {
 namespace {

--- a/common/util/range_test.cc
+++ b/common/util/range_test.cc
@@ -17,9 +17,9 @@
 #include <iterator>
 #include <string>
 
-#include "gtest/gtest.h"
 #include "absl/strings/string_view.h"
 #include "common/util/iterator_range.h"
+#include "gtest/gtest.h"
 
 namespace verible {
 namespace {

--- a/common/util/subcommand_test.cc
+++ b/common/util/subcommand_test.cc
@@ -19,9 +19,9 @@
 #include <string>
 #include <vector>
 
+#include "absl/strings/match.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
-#include "absl/strings/match.h"
 
 namespace verible {
 namespace {

--- a/common/util/vector_tree_test.cc
+++ b/common/util/vector_tree_test.cc
@@ -21,12 +21,12 @@
 #include <utility>
 #include <vector>
 
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_join.h"
 #include "absl/strings/string_view.h"
 #include "common/util/vector_tree_test_util.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 namespace verible {
 namespace {

--- a/common/util/vector_tree_test_util.cc
+++ b/common/util/vector_tree_test_util.cc
@@ -17,9 +17,9 @@
 #include <iostream>
 #include <vector>
 
-#include "gtest/gtest.h"
 #include "absl/strings/string_view.h"
 #include "common/util/vector_tree.h"
+#include "gtest/gtest.h"
 
 namespace verible {
 namespace testing {

--- a/external_libs/editscript.h
+++ b/external_libs/editscript.h
@@ -97,8 +97,7 @@ namespace diff_impl {
  * @param edits Cumulative vector of edits (inout).
  */
 inline void AppendEdit(Operation op, int64_t start, int64_t end, Edits *edits) {
-  if (!edits->empty() &&
-      edits->back().operation == op &&
+  if (!edits->empty() && edits->back().operation == op &&
       edits->back().end == start) {
     // Merge into previous edit operation.
     edits->back().end = end;
@@ -121,8 +120,7 @@ inline void InsertEditAt(int64_t index, Operation op, int64_t start,
                          int64_t end, Edits *edits) {
   if (index > 0) {
     Edit &prev_edit = (*edits)[index - 1];
-    if (prev_edit.operation == op &&
-        prev_edit.end == start) {
+    if (prev_edit.operation == op && prev_edit.end == start) {
       // Merge into previous edit operation.
       prev_edit.end = end;
       return;
@@ -130,8 +128,7 @@ inline void InsertEditAt(int64_t index, Operation op, int64_t start,
   }
   if (index < static_cast<int64_t>(edits->size())) {
     Edit &next_edit = (*edits)[index];
-    if (next_edit.operation == op &&
-        next_edit.end == start) {
+    if (next_edit.operation == op && next_edit.end == start) {
       // Merge into subsequent edit operation.
       next_edit.end = end;
       return;
@@ -184,9 +181,8 @@ inline int64_t CommonAffix(TokenIter span1_begin, TokenIter span1_end,
 template <typename TokenIter>
 class Diff {
  private:
-  friend Edits
-  GetTokenDiffs<>(TokenIter tokens1_begin, TokenIter tokens1_end,
-                  TokenIter tokens2_begin, TokenIter tokens2_end);
+  friend Edits GetTokenDiffs<>(TokenIter tokens1_begin, TokenIter tokens1_end,
+                               TokenIter tokens2_begin, TokenIter tokens2_end);
 
   /**
    * Finds the differences between two vectors of tokens, returning edits
@@ -236,8 +232,7 @@ class Diff {
       }
 
       // Find longest common prefix and suffix.
-      prefix_size =
-          CommonAffix(span1_begin, span1_end, span2_begin, span2_end);
+      prefix_size = CommonAffix(span1_begin, span1_end, span2_begin, span2_end);
       suffix_size =
           CommonAffix(Reverse(span1_end), Reverse(span1_begin + prefix_size),
                       Reverse(span2_end), Reverse(span2_begin + prefix_size));
@@ -247,9 +242,8 @@ class Diff {
     }
 
     // Compute the diff on the middle block.
-    Compute(b1 + prefix_size, e1 - suffix_size,
-            b2 + prefix_size, e2 - suffix_size,
-            edits);
+    Compute(b1 + prefix_size, e1 - suffix_size, b2 + prefix_size,
+            e2 - suffix_size, edits);
 
     // Restore the prefix and suffix.
     if (prefix_size != 0) {
@@ -423,7 +417,7 @@ class Diff {
         int64_t y2 = x2 - k2;
         while (x2 < length1 && y2 < length2 &&
                *(tokens1_begin_ + (b1 + length1 - x2 - 1)) ==
-               *(tokens2_begin_ + (b2 + length2 - y2 - 1))) {
+                   *(tokens2_begin_ + (b2 + length2 - y2 - 1))) {
           x2++;
           y2++;
         }
@@ -490,9 +484,8 @@ inline Edits GetTokenDiffs(TokenIter tokens1_begin, TokenIter tokens1_end,
                            TokenIter tokens2_begin, TokenIter tokens2_end) {
   Edits token_edits;
   diff_impl::Diff<TokenIter>(tokens1_begin, tokens2_begin)
-      .Generate(0, std::distance(tokens1_begin, tokens1_end),
-                0, std::distance(tokens2_begin, tokens2_end),
-                &token_edits);
+      .Generate(0, std::distance(tokens1_begin, tokens1_end), 0,
+                std::distance(tokens2_begin, tokens2_end), &token_edits);
   return token_edits;  // efficient: uses named return value optimization
 }
 

--- a/external_libs/editscript_test.cc
+++ b/external_libs/editscript_test.cc
@@ -20,9 +20,9 @@
 #include <sstream>
 #include <vector>
 
-#include "gtest/gtest.h"
 #include "absl/strings/str_join.h"
 #include "absl/strings/string_view.h"
+#include "gtest/gtest.h"
 
 namespace diff {
 namespace {

--- a/verilog/CST/DPI_test.cc
+++ b/verilog/CST/DPI_test.cc
@@ -16,14 +16,14 @@
 
 #include <utility>
 
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
 #include "common/analysis/syntax_tree_search.h"
 #include "common/analysis/syntax_tree_search_test_utils.h"
 #include "common/text/text_structure.h"
 #include "common/text/token_info_test_util.h"
 #include "common/text/tree_utils.h"
 #include "common/util/range.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 #include "verilog/CST/match_test_utils.h"
 #include "verilog/analysis/verilog_analyzer.h"
 

--- a/verilog/CST/class_test.cc
+++ b/verilog/CST/class_test.cc
@@ -26,8 +26,6 @@
 #include <sstream>
 #include <vector>
 
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
 #include "common/analysis/syntax_tree_search_test_utils.h"
 #include "common/text/concrete_syntax_tree.h"
 #include "common/text/symbol.h"
@@ -37,6 +35,8 @@
 #include "common/util/casts.h"
 #include "common/util/logging.h"
 #include "common/util/range.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 #include "verilog/CST/match_test_utils.h"
 #include "verilog/analysis/verilog_analyzer.h"
 

--- a/verilog/CST/constraints_test.cc
+++ b/verilog/CST/constraints_test.cc
@@ -19,8 +19,6 @@
 #include <utility>
 #include <vector>
 
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
 #include "absl/strings/string_view.h"
 #include "common/analysis/syntax_tree_search_test_utils.h"
 #include "common/text/concrete_syntax_leaf.h"
@@ -30,6 +28,8 @@
 #include "common/text/token_info.h"
 #include "common/util/casts.h"
 #include "common/util/logging.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 #include "verilog/CST/match_test_utils.h"
 #include "verilog/CST/verilog_nonterminals.h"
 #include "verilog/analysis/verilog_analyzer.h"

--- a/verilog/CST/context_functions_test.cc
+++ b/verilog/CST/context_functions_test.cc
@@ -14,12 +14,12 @@
 
 #include "verilog/CST/context_functions.h"
 
-#include "gtest/gtest.h"
 #include "common/text/concrete_syntax_tree.h"
 #include "common/text/symbol.h"
 #include "common/text/syntax_tree_context.h"
 #include "common/text/tree_builder_test_util.h"
 #include "common/util/casts.h"
+#include "gtest/gtest.h"
 #include "verilog/CST/verilog_nonterminals.h"
 
 namespace verilog {

--- a/verilog/CST/data_test.cc
+++ b/verilog/CST/data_test.cc
@@ -23,13 +23,13 @@
 
 #include <vector>
 
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
 #include "absl/strings/str_cat.h"
 #include "common/analysis/syntax_tree_search.h"
 #include "common/text/syntax_tree_context.h"
 #include "common/text/text_structure.h"
 #include "common/util/logging.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 #include "verilog/CST/verilog_nonterminals.h"
 #include "verilog/analysis/verilog_analyzer.h"
 

--- a/verilog/CST/declaration_test.cc
+++ b/verilog/CST/declaration_test.cc
@@ -16,12 +16,12 @@
 
 #include <vector>
 
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
 #include "common/analysis/syntax_tree_search.h"
 #include "common/analysis/syntax_tree_search_test_utils.h"
 #include "common/text/text_structure.h"
 #include "common/text/tree_utils.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 #include "verilog/CST/match_test_utils.h"
 
 #undef ASSERT_OK

--- a/verilog/CST/dimensions_test.cc
+++ b/verilog/CST/dimensions_test.cc
@@ -20,8 +20,6 @@
 #include <memory>
 #include <vector>
 
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
 #include "common/analysis/matcher/matcher.h"
 #include "common/analysis/matcher/matcher_builders.h"
 #include "common/analysis/syntax_tree_search.h"
@@ -33,6 +31,8 @@
 #include "common/text/tree_utils.h"
 #include "common/util/casts.h"
 #include "common/util/logging.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 #include "verilog/CST/verilog_matchers.h"  // IWYU pragma: keep
 #include "verilog/analysis/verilog_analyzer.h"
 

--- a/verilog/CST/expression_test.cc
+++ b/verilog/CST/expression_test.cc
@@ -17,12 +17,12 @@
 #include <memory>
 #include <utility>
 
-#include "gtest/gtest.h"
 #include "common/analysis/syntax_tree_search.h"
 #include "common/analysis/syntax_tree_search_test_utils.h"
 #include "common/text/symbol.h"
 #include "common/text/tree_utils.h"
 #include "common/util/logging.h"
+#include "gtest/gtest.h"
 #include "verilog/CST/match_test_utils.h"
 #include "verilog/CST/verilog_nonterminals.h"
 #include "verilog/CST/verilog_tree_print.h"

--- a/verilog/CST/functions_test.cc
+++ b/verilog/CST/functions_test.cc
@@ -19,8 +19,6 @@
 #include <utility>
 #include <vector>
 
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
 #include "absl/strings/string_view.h"
 #include "common/analysis/matcher/matcher_builders.h"
 #include "common/analysis/syntax_tree_search.h"
@@ -35,6 +33,8 @@
 #include "common/util/casts.h"
 #include "common/util/logging.h"
 #include "common/util/range.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 #include "verilog/CST/identifier.h"
 #include "verilog/CST/match_test_utils.h"
 #include "verilog/analysis/verilog_analyzer.h"

--- a/verilog/CST/identifier_test.cc
+++ b/verilog/CST/identifier_test.cc
@@ -19,8 +19,6 @@
 #include <utility>
 #include <vector>
 
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
 #include "absl/strings/string_view.h"
 #include "common/analysis/syntax_tree_search.h"
 #include "common/analysis/syntax_tree_search_test_utils.h"
@@ -28,6 +26,8 @@
 #include "common/text/text_structure.h"
 #include "common/text/token_info.h"
 #include "common/util/logging.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 #include "verilog/CST/match_test_utils.h"
 #include "verilog/analysis/verilog_analyzer.h"
 

--- a/verilog/CST/macro_test.cc
+++ b/verilog/CST/macro_test.cc
@@ -14,13 +14,13 @@
 
 #include "verilog/CST/macro.h"
 
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
 #include "common/analysis/syntax_tree_search.h"
 #include "common/analysis/syntax_tree_search_test_utils.h"
 #include "common/text/text_structure.h"
 #include "common/text/token_info_test_util.h"
 #include "common/util/range.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 #include "verilog/CST/match_test_utils.h"
 #include "verilog/CST/verilog_nonterminals.h"
 #include "verilog/analysis/verilog_analyzer.h"

--- a/verilog/CST/match_test_utils.cc
+++ b/verilog/CST/match_test_utils.cc
@@ -17,11 +17,11 @@
 #include <sstream>
 #include <vector>
 
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
 #include "common/analysis/syntax_tree_search.h"
 #include "common/analysis/syntax_tree_search_test_utils.h"
 #include "common/text/text_structure.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 #include "verilog/analysis/verilog_analyzer.h"
 
 #undef ASSERT_OK

--- a/verilog/CST/module_test.cc
+++ b/verilog/CST/module_test.cc
@@ -25,8 +25,6 @@
 #include <memory>
 #include <vector>
 
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
 #include "common/analysis/syntax_tree_search.h"
 #include "common/analysis/syntax_tree_search_test_utils.h"
 #include "common/text/concrete_syntax_tree.h"
@@ -37,6 +35,8 @@
 #include "common/util/casts.h"
 #include "common/util/logging.h"
 #include "common/util/range.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 #include "verilog/CST/match_test_utils.h"
 #include "verilog/analysis/verilog_analyzer.h"
 

--- a/verilog/CST/net_test.cc
+++ b/verilog/CST/net_test.cc
@@ -23,14 +23,14 @@
 
 #include <vector>
 
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
 #include "absl/strings/str_cat.h"
 #include "common/analysis/syntax_tree_search.h"
 #include "common/analysis/syntax_tree_search_test_utils.h"
 #include "common/text/syntax_tree_context.h"
 #include "common/text/text_structure.h"
 #include "common/util/logging.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 #include "verilog/CST/declaration.h"
 #include "verilog/CST/match_test_utils.h"
 #include "verilog/CST/verilog_nonterminals.h"

--- a/verilog/CST/numbers_test.cc
+++ b/verilog/CST/numbers_test.cc
@@ -17,8 +17,8 @@
 #include <sstream>
 #include <utility>
 
-#include "gtest/gtest.h"
 #include "absl/strings/string_view.h"
+#include "gtest/gtest.h"
 
 namespace verilog {
 namespace analysis {

--- a/verilog/CST/package_test.cc
+++ b/verilog/CST/package_test.cc
@@ -25,8 +25,6 @@
 #include <memory>
 #include <vector>
 
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
 #include "absl/status/status.h"
 #include "common/analysis/syntax_tree_search.h"
 #include "common/analysis/syntax_tree_search_test_utils.h"
@@ -36,6 +34,8 @@
 #include "common/text/token_info.h"
 #include "common/util/casts.h"
 #include "common/util/logging.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 #include "verilog/CST/match_test_utils.h"
 #include "verilog/analysis/verilog_analyzer.h"
 

--- a/verilog/CST/parameters_test.cc
+++ b/verilog/CST/parameters_test.cc
@@ -19,8 +19,6 @@
 #include <utility>
 #include <vector>
 
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
 #include "absl/strings/string_view.h"
 #include "common/analysis/syntax_tree_search.h"
 #include "common/analysis/syntax_tree_search_test_utils.h"
@@ -31,6 +29,8 @@
 #include "common/text/token_info.h"
 #include "common/util/casts.h"
 #include "common/util/logging.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 #include "verilog/CST/match_test_utils.h"
 #include "verilog/CST/verilog_nonterminals.h"
 #include "verilog/analysis/verilog_analyzer.h"

--- a/verilog/CST/port_test.cc
+++ b/verilog/CST/port_test.cc
@@ -28,8 +28,6 @@
 #include <utility>
 #include <vector>
 
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/string_view.h"
 #include "common/analysis/syntax_tree_search.h"
@@ -39,6 +37,8 @@
 #include "common/text/text_structure.h"
 #include "common/text/token_info.h"
 #include "common/util/logging.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 #include "verilog/CST/match_test_utils.h"
 #include "verilog/CST/type.h"
 #include "verilog/CST/verilog_nonterminals.h"

--- a/verilog/CST/seq_block_test.cc
+++ b/verilog/CST/seq_block_test.cc
@@ -16,13 +16,13 @@
 
 #include <vector>
 
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
 #include "absl/strings/str_cat.h"
 #include "common/analysis/syntax_tree_search.h"
 #include "common/text/syntax_tree_context.h"
 #include "common/text/text_structure.h"
 #include "common/util/logging.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 #include "verilog/CST/verilog_matchers.h"
 #include "verilog/CST/verilog_nonterminals.h"
 #include "verilog/analysis/verilog_analyzer.h"

--- a/verilog/CST/statement_test.cc
+++ b/verilog/CST/statement_test.cc
@@ -17,8 +17,6 @@
 #include <memory>
 #include <vector>
 
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
 #include "common/analysis/matcher/matcher_builders.h"
 #include "common/analysis/syntax_tree_search.h"
 #include "common/analysis/syntax_tree_search_test_utils.h"
@@ -30,6 +28,8 @@
 #include "common/util/casts.h"
 #include "common/util/logging.h"
 #include "common/util/range.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 #include "verilog/CST/match_test_utils.h"
 #include "verilog/CST/verilog_matchers.h"
 #include "verilog/CST/verilog_nonterminals.h"

--- a/verilog/CST/tasks_test.cc
+++ b/verilog/CST/tasks_test.cc
@@ -19,8 +19,6 @@
 #include <utility>
 #include <vector>
 
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
 #include "absl/strings/string_view.h"
 #include "common/analysis/syntax_tree_search.h"
 #include "common/analysis/syntax_tree_search_test_utils.h"
@@ -32,6 +30,8 @@
 #include "common/text/tree_utils.h"
 #include "common/util/casts.h"
 #include "common/util/logging.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 #include "verilog/CST/identifier.h"
 #include "verilog/CST/match_test_utils.h"
 #include "verilog/CST/verilog_nonterminals.h"

--- a/verilog/CST/type_test.cc
+++ b/verilog/CST/type_test.cc
@@ -19,13 +19,13 @@
 #include <utility>
 #include <vector>
 
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
 #include "common/analysis/syntax_tree_search.h"
 #include "common/analysis/syntax_tree_search_test_utils.h"
 #include "common/text/text_structure.h"
 #include "common/text/tree_utils.h"
 #include "common/util/logging.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 #include "verilog/CST/context_functions.h"
 #include "verilog/CST/declaration.h"
 #include "verilog/CST/match_test_utils.h"

--- a/verilog/CST/verilog_matchers_test.cc
+++ b/verilog/CST/verilog_matchers_test.cc
@@ -14,11 +14,11 @@
 
 #include "verilog/CST/verilog_matchers.h"
 
-#include "gtest/gtest.h"
 #include "common/analysis/matcher/core_matchers.h"
 #include "common/analysis/matcher/matcher.h"
 #include "common/analysis/matcher/matcher_builders.h"
 #include "common/analysis/matcher/matcher_test_utils.h"
+#include "gtest/gtest.h"
 #include "verilog/CST/verilog_treebuilder_utils.h"
 #include "verilog/analysis/verilog_analyzer.h"
 

--- a/verilog/CST/verilog_nonterminals_test.cc
+++ b/verilog/CST/verilog_nonterminals_test.cc
@@ -17,8 +17,8 @@
 #include <sstream>
 #include <string>
 
-#include "gtest/gtest.h"
 #include "common/text/constants.h"
+#include "gtest/gtest.h"
 
 namespace verilog {
 namespace {

--- a/verilog/CST/verilog_tree_print.cc
+++ b/verilog/CST/verilog_tree_print.cc
@@ -28,7 +28,7 @@
 #include "common/text/token_info.h"
 #include "common/util/value_saver.h"
 #include "verilog/CST/verilog_nonterminals.h"  // for NodeEnumToString
-#include "verilog/parser/verilog_parser.h"  // for verilog_symbol_name
+#include "verilog/parser/verilog_parser.h"     // for verilog_symbol_name
 
 namespace verilog {
 

--- a/verilog/CST/verilog_tree_print_test.cc
+++ b/verilog/CST/verilog_tree_print_test.cc
@@ -18,9 +18,9 @@
 #include <sstream>  // IWYU pragma: keep  // for ostringstream
 #include <string>
 
-#include "gtest/gtest.h"
 #include "absl/memory/memory.h"
 #include "common/text/symbol.h"
+#include "gtest/gtest.h"
 #include "verilog/analysis/verilog_analyzer.h"
 
 namespace verilog {

--- a/verilog/CST/verilog_treebuilder_utils_test.cc
+++ b/verilog/CST/verilog_treebuilder_utils_test.cc
@@ -14,10 +14,10 @@
 
 #include "verilog/CST/verilog_treebuilder_utils.h"
 
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
 #include "common/text/tree_builder_test_util.h"
 #include "common/text/tree_utils.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 namespace verilog {
 namespace {

--- a/verilog/analysis/checkers/always_comb_blocking_rule_test.cc
+++ b/verilog/analysis/checkers/always_comb_blocking_rule_test.cc
@@ -16,10 +16,10 @@
 
 #include <initializer_list>
 
-#include "gtest/gtest.h"
 #include "common/analysis/linter_test_utils.h"
 #include "common/analysis/syntax_tree_linter_test_utils.h"
 #include "common/text/symbol.h"
+#include "gtest/gtest.h"
 #include "verilog/CST/verilog_nonterminals.h"
 #include "verilog/CST/verilog_treebuilder_utils.h"
 #include "verilog/analysis/verilog_analyzer.h"

--- a/verilog/analysis/checkers/always_comb_rule_test.cc
+++ b/verilog/analysis/checkers/always_comb_rule_test.cc
@@ -16,10 +16,10 @@
 
 #include <initializer_list>
 
-#include "gtest/gtest.h"
 #include "common/analysis/linter_test_utils.h"
 #include "common/analysis/syntax_tree_linter_test_utils.h"
 #include "common/text/symbol.h"
+#include "gtest/gtest.h"
 #include "verilog/CST/verilog_nonterminals.h"
 #include "verilog/CST/verilog_treebuilder_utils.h"
 #include "verilog/analysis/verilog_analyzer.h"

--- a/verilog/analysis/checkers/always_ff_non_blocking_rule_test.cc
+++ b/verilog/analysis/checkers/always_ff_non_blocking_rule_test.cc
@@ -16,10 +16,10 @@
 
 #include <initializer_list>
 
-#include "gtest/gtest.h"
 #include "common/analysis/linter_test_utils.h"
 #include "common/analysis/syntax_tree_linter_test_utils.h"
 #include "common/text/symbol.h"
+#include "gtest/gtest.h"
 #include "verilog/CST/verilog_nonterminals.h"
 #include "verilog/CST/verilog_treebuilder_utils.h"
 #include "verilog/analysis/verilog_analyzer.h"

--- a/verilog/analysis/checkers/banned_declared_name_patterns_rule_test.cc
+++ b/verilog/analysis/checkers/banned_declared_name_patterns_rule_test.cc
@@ -16,10 +16,10 @@
 
 #include <initializer_list>
 
-#include "gtest/gtest.h"
 #include "common/analysis/linter_test_utils.h"
 #include "common/analysis/syntax_tree_linter_test_utils.h"
 #include "common/text/symbol.h"
+#include "gtest/gtest.h"
 #include "verilog/CST/verilog_nonterminals.h"
 #include "verilog/analysis/verilog_analyzer.h"
 

--- a/verilog/analysis/checkers/case_missing_default_rule_test.cc
+++ b/verilog/analysis/checkers/case_missing_default_rule_test.cc
@@ -16,10 +16,10 @@
 
 #include <initializer_list>
 
-#include "gtest/gtest.h"
 #include "common/analysis/linter_test_utils.h"
 #include "common/analysis/syntax_tree_linter_test_utils.h"
 #include "common/text/symbol.h"
+#include "gtest/gtest.h"
 #include "verilog/CST/verilog_nonterminals.h"
 #include "verilog/analysis/verilog_analyzer.h"
 #include "verilog/parser/verilog_token_enum.h"

--- a/verilog/analysis/checkers/constraint_name_style_rule_test.cc
+++ b/verilog/analysis/checkers/constraint_name_style_rule_test.cc
@@ -16,10 +16,10 @@
 
 #include <initializer_list>
 
-#include "gtest/gtest.h"
 #include "common/analysis/linter_test_utils.h"
 #include "common/analysis/syntax_tree_linter_test_utils.h"
 #include "common/text/symbol.h"
+#include "gtest/gtest.h"
 #include "verilog/CST/verilog_nonterminals.h"
 #include "verilog/analysis/verilog_analyzer.h"
 #include "verilog/parser/verilog_token_enum.h"

--- a/verilog/analysis/checkers/create_object_name_match_rule_test.cc
+++ b/verilog/analysis/checkers/create_object_name_match_rule_test.cc
@@ -16,10 +16,10 @@
 
 #include <initializer_list>
 
-#include "gtest/gtest.h"
 #include "common/analysis/linter_test_utils.h"
 #include "common/analysis/syntax_tree_linter_test_utils.h"
 #include "common/text/symbol.h"
+#include "gtest/gtest.h"
 #include "verilog/CST/verilog_treebuilder_utils.h"
 #include "verilog/analysis/verilog_analyzer.h"
 #include "verilog/parser/verilog_token_enum.h"

--- a/verilog/analysis/checkers/endif_comment_rule_test.cc
+++ b/verilog/analysis/checkers/endif_comment_rule_test.cc
@@ -16,10 +16,10 @@
 
 #include <initializer_list>
 
-#include "gtest/gtest.h"
 #include "common/analysis/linter_test_utils.h"
 #include "common/analysis/token_stream_linter_test_utils.h"
 #include "common/text/symbol.h"
+#include "gtest/gtest.h"
 #include "verilog/analysis/verilog_analyzer.h"
 #include "verilog/parser/verilog_token_enum.h"
 

--- a/verilog/analysis/checkers/enum_name_style_rule_test.cc
+++ b/verilog/analysis/checkers/enum_name_style_rule_test.cc
@@ -16,10 +16,10 @@
 
 #include <initializer_list>
 
-#include "gtest/gtest.h"
 #include "common/analysis/linter_test_utils.h"
 #include "common/analysis/syntax_tree_linter_test_utils.h"
 #include "common/text/symbol.h"
+#include "gtest/gtest.h"
 #include "verilog/CST/verilog_nonterminals.h"
 #include "verilog/analysis/verilog_analyzer.h"
 #include "verilog/parser/verilog_token_enum.h"

--- a/verilog/analysis/checkers/explicit_function_lifetime_rule_test.cc
+++ b/verilog/analysis/checkers/explicit_function_lifetime_rule_test.cc
@@ -16,10 +16,10 @@
 
 #include <initializer_list>
 
-#include "gtest/gtest.h"
 #include "common/analysis/linter_test_utils.h"
 #include "common/analysis/syntax_tree_linter_test_utils.h"
 #include "common/text/symbol.h"
+#include "gtest/gtest.h"
 #include "verilog/CST/verilog_nonterminals.h"
 #include "verilog/analysis/verilog_analyzer.h"
 #include "verilog/parser/verilog_token_enum.h"

--- a/verilog/analysis/checkers/explicit_function_task_parameter_type_rule_test.cc
+++ b/verilog/analysis/checkers/explicit_function_task_parameter_type_rule_test.cc
@@ -16,7 +16,6 @@
 
 #include <initializer_list>
 
-#include "gtest/gtest.h"
 #include "absl/memory/memory.h"
 #include "absl/status/status.h"
 #include "common/analysis/lint_rule_status.h"
@@ -26,6 +25,7 @@
 #include "common/analysis/syntax_tree_linter_test_utils.h"
 #include "common/text/symbol.h"
 #include "common/text/token_info.h"
+#include "gtest/gtest.h"
 #include "verilog/analysis/verilog_analyzer.h"
 #include "verilog/parser/verilog_token_enum.h"
 

--- a/verilog/analysis/checkers/explicit_parameter_storage_type_rule_test.cc
+++ b/verilog/analysis/checkers/explicit_parameter_storage_type_rule_test.cc
@@ -16,11 +16,11 @@
 
 #include <initializer_list>
 
-#include "gtest/gtest.h"
 #include "absl/strings/match.h"
 #include "common/analysis/linter_test_utils.h"
 #include "common/analysis/syntax_tree_linter_test_utils.h"
 #include "common/text/symbol.h"
+#include "gtest/gtest.h"
 #include "verilog/CST/verilog_nonterminals.h"
 #include "verilog/analysis/verilog_analyzer.h"
 #include "verilog/parser/verilog_token_enum.h"

--- a/verilog/analysis/checkers/explicit_task_lifetime_rule_test.cc
+++ b/verilog/analysis/checkers/explicit_task_lifetime_rule_test.cc
@@ -16,10 +16,10 @@
 
 #include <initializer_list>
 
-#include "gtest/gtest.h"
 #include "common/analysis/linter_test_utils.h"
 #include "common/analysis/syntax_tree_linter_test_utils.h"
 #include "common/text/symbol.h"
+#include "gtest/gtest.h"
 #include "verilog/CST/verilog_nonterminals.h"
 #include "verilog/analysis/verilog_analyzer.h"
 #include "verilog/parser/verilog_token_enum.h"

--- a/verilog/analysis/checkers/forbid_consecutive_null_statements_rule_test.cc
+++ b/verilog/analysis/checkers/forbid_consecutive_null_statements_rule_test.cc
@@ -16,10 +16,10 @@
 
 #include <initializer_list>
 
-#include "gtest/gtest.h"
 #include "common/analysis/linter_test_utils.h"
 #include "common/analysis/syntax_tree_linter_test_utils.h"
 #include "common/text/symbol.h"
+#include "gtest/gtest.h"
 #include "verilog/CST/verilog_nonterminals.h"
 #include "verilog/CST/verilog_treebuilder_utils.h"
 #include "verilog/analysis/verilog_analyzer.h"

--- a/verilog/analysis/checkers/forbid_defparam_rule_test.cc
+++ b/verilog/analysis/checkers/forbid_defparam_rule_test.cc
@@ -16,10 +16,10 @@
 
 #include <initializer_list>
 
-#include "gtest/gtest.h"
 #include "common/analysis/linter_test_utils.h"
 #include "common/analysis/syntax_tree_linter_test_utils.h"
 #include "common/text/symbol.h"
+#include "gtest/gtest.h"
 #include "verilog/CST/verilog_nonterminals.h"
 #include "verilog/analysis/verilog_analyzer.h"
 #include "verilog/parser/verilog_token_enum.h"

--- a/verilog/analysis/checkers/forbidden_anonymous_enums_rule_test.cc
+++ b/verilog/analysis/checkers/forbidden_anonymous_enums_rule_test.cc
@@ -16,9 +16,9 @@
 
 #include <initializer_list>
 
-#include "gtest/gtest.h"
 #include "common/analysis/syntax_tree_linter_test_utils.h"
 #include "common/text/symbol.h"
+#include "gtest/gtest.h"
 #include "verilog/analysis/verilog_analyzer.h"
 #include "verilog/parser/verilog_token_enum.h"
 

--- a/verilog/analysis/checkers/forbidden_anonymous_structs_unions_rule.h
+++ b/verilog/analysis/checkers/forbidden_anonymous_structs_unions_rule.h
@@ -87,4 +87,4 @@ class ForbiddenAnonymousStructsUnionsRule : public verible::SyntaxTreeLintRule {
 }  // namespace analysis
 }  // namespace verilog
 
-#endif  // VERIBLE_VERILOG_ANALYSIS_CHECKERS_FORBIDDEN_ANONYMOUS_STRUCTS_UNIONS_RULE_H_ // NOLINT
+#endif  // VERIBLE_VERILOG_ANALYSIS_CHECKERS_FORBIDDEN_ANONYMOUS_STRUCTS_UNIONS_RULE_H_

--- a/verilog/analysis/checkers/forbidden_anonymous_structs_unions_rule_test.cc
+++ b/verilog/analysis/checkers/forbidden_anonymous_structs_unions_rule_test.cc
@@ -16,10 +16,10 @@
 
 #include <initializer_list>
 
-#include "gtest/gtest.h"
 #include "absl/strings/match.h"
 #include "common/analysis/syntax_tree_linter_test_utils.h"
 #include "common/text/symbol.h"
+#include "gtest/gtest.h"
 #include "verilog/analysis/verilog_analyzer.h"
 #include "verilog/parser/verilog_token_enum.h"
 

--- a/verilog/analysis/checkers/forbidden_macro_rule_test.cc
+++ b/verilog/analysis/checkers/forbidden_macro_rule_test.cc
@@ -16,10 +16,10 @@
 
 #include <initializer_list>
 
-#include "gtest/gtest.h"
 #include "common/analysis/linter_test_utils.h"
 #include "common/analysis/syntax_tree_linter_test_utils.h"
 #include "common/text/symbol.h"
+#include "gtest/gtest.h"
 #include "verilog/CST/verilog_treebuilder_utils.h"
 #include "verilog/analysis/verilog_analyzer.h"
 #include "verilog/parser/verilog_token_enum.h"

--- a/verilog/analysis/checkers/forbidden_symbol_rule_test.cc
+++ b/verilog/analysis/checkers/forbidden_symbol_rule_test.cc
@@ -16,10 +16,10 @@
 
 #include <initializer_list>
 
-#include "gtest/gtest.h"
 #include "common/analysis/linter_test_utils.h"
 #include "common/analysis/syntax_tree_linter_test_utils.h"
 #include "common/text/symbol.h"
+#include "gtest/gtest.h"
 #include "verilog/CST/verilog_treebuilder_utils.h"
 #include "verilog/analysis/verilog_analyzer.h"
 #include "verilog/parser/verilog_token_enum.h"

--- a/verilog/analysis/checkers/generate_label_prefix_rule_test.cc
+++ b/verilog/analysis/checkers/generate_label_prefix_rule_test.cc
@@ -16,10 +16,10 @@
 
 #include <initializer_list>
 
-#include "gtest/gtest.h"
 #include "common/analysis/linter_test_utils.h"
 #include "common/analysis/syntax_tree_linter_test_utils.h"
 #include "common/text/symbol.h"
+#include "gtest/gtest.h"
 #include "verilog/CST/verilog_nonterminals.h"
 #include "verilog/CST/verilog_treebuilder_utils.h"
 #include "verilog/analysis/verilog_analyzer.h"

--- a/verilog/analysis/checkers/generate_label_rule_test.cc
+++ b/verilog/analysis/checkers/generate_label_rule_test.cc
@@ -16,10 +16,10 @@
 
 #include <initializer_list>
 
-#include "gtest/gtest.h"
 #include "common/analysis/linter_test_utils.h"
 #include "common/analysis/syntax_tree_linter_test_utils.h"
 #include "common/text/symbol.h"
+#include "gtest/gtest.h"
 #include "verilog/CST/verilog_nonterminals.h"
 #include "verilog/CST/verilog_treebuilder_utils.h"
 #include "verilog/analysis/verilog_analyzer.h"

--- a/verilog/analysis/checkers/interface_name_style_rule_test.cc
+++ b/verilog/analysis/checkers/interface_name_style_rule_test.cc
@@ -16,10 +16,10 @@
 
 #include <initializer_list>
 
-#include "gtest/gtest.h"
 #include "common/analysis/linter_test_utils.h"
 #include "common/analysis/syntax_tree_linter_test_utils.h"
 #include "common/text/symbol.h"
+#include "gtest/gtest.h"
 #include "verilog/CST/verilog_nonterminals.h"
 #include "verilog/analysis/verilog_analyzer.h"
 #include "verilog/parser/verilog_token_enum.h"

--- a/verilog/analysis/checkers/legacy_generate_region_rule_test.cc
+++ b/verilog/analysis/checkers/legacy_generate_region_rule_test.cc
@@ -16,9 +16,9 @@
 
 #include <initializer_list>
 
-#include "gtest/gtest.h"
 #include "common/analysis/linter_test_utils.h"
 #include "common/analysis/syntax_tree_linter_test_utils.h"
+#include "gtest/gtest.h"
 #include "verilog/CST/verilog_nonterminals.h"
 #include "verilog/analysis/verilog_analyzer.h"
 #include "verilog/parser/verilog_token_enum.h"
@@ -32,27 +32,26 @@ using verible::RunLintTestCases;
 
 TEST(LegacyGenerateRegionRuleTest, ValidCases) {
   const std::initializer_list<LintTestCase> kTestCases = {
-    {""},
-    {"module M;\n"
-     "for (genvar k = 0; k < FooParam; k++) begin : gen_loop\n"
-     "  // code\n"
-     "end\n"
-     "endmodule\n"}
-  };
+      {""},
+      {"module M;\n"
+       "for (genvar k = 0; k < FooParam; k++) begin : gen_loop\n"
+       "  // code\n"
+       "end\n"
+       "endmodule\n"}};
   RunLintTestCases<VerilogAnalyzer, LegacyGenerateRegionRule>(kTestCases);
 }
 
 TEST(LegacyGenerateRegionRuleTest, InvalidCases) {
   constexpr int kToken = TK_generate;
   const std::initializer_list<LintTestCase> kTestCases = {
-    {"module M;\n",
-     {kToken, "generate"}, "\n"
-     "  for (genvar k = 0; k < FooParam; k++) begin : gen_loop\n"
-     "    // code\n"
-     "  end\n"
-     "endgenerate\n"
-     "endmodule\n"}
-  };
+      {"module M;\n",
+       {kToken, "generate"},
+       "\n"
+       "  for (genvar k = 0; k < FooParam; k++) begin : gen_loop\n"
+       "    // code\n"
+       "  end\n"
+       "endgenerate\n"
+       "endmodule\n"}};
   RunLintTestCases<VerilogAnalyzer, LegacyGenerateRegionRule>(kTestCases);
 }
 

--- a/verilog/analysis/checkers/legacy_genvar_declaration_rule_test.cc
+++ b/verilog/analysis/checkers/legacy_genvar_declaration_rule_test.cc
@@ -16,10 +16,10 @@
 
 #include <initializer_list>
 
-#include "gtest/gtest.h"
 #include "common/analysis/linter_test_utils.h"
 #include "common/analysis/syntax_tree_linter_test_utils.h"
 #include "common/text/symbol.h"
+#include "gtest/gtest.h"
 #include "verilog/CST/verilog_nonterminals.h"
 #include "verilog/analysis/verilog_analyzer.h"
 #include "verilog/parser/verilog_token_enum.h"
@@ -33,28 +33,28 @@ using verible::RunLintTestCases;
 
 TEST(LegacyGenvarDeclarationRuleTest, ValidCases) {
   const std::initializer_list<LintTestCase> kTestCases = {
-    {""},
-    {"module M;\n"
-     "for (genvar k = 0; k < FooParam; k++) begin : gen_loop\n"
-     "  // code\n"
-     "end\n"
-     "endmodule\n"}
-  };
+      {""},
+      {"module M;\n"
+       "for (genvar k = 0; k < FooParam; k++) begin : gen_loop\n"
+       "  // code\n"
+       "end\n"
+       "endmodule\n"}};
   RunLintTestCases<VerilogAnalyzer, LegacyGenvarDeclarationRule>(kTestCases);
 }
 
 TEST(LegacyGenvarDeclarationRuleTest, InvalidCases) {
   constexpr int kToken = SymbolIdentifier;
   const std::initializer_list<LintTestCase> kTestCases = {
-    {"module M;\n",
-     "genvar ", {kToken, "k"}, ";\n"
-     "generate\n"
-     "  for (k = 0; k < FooParam; k++) begin : gen_loop\n"
-     "    // code\n"
-     "  end\n"
-     "endgenerate\n"
-     "endmodule\n"}
-  };
+      {"module M;\n",
+       "genvar ",
+       {kToken, "k"},
+       ";\n"
+       "generate\n"
+       "  for (k = 0; k < FooParam; k++) begin : gen_loop\n"
+       "    // code\n"
+       "  end\n"
+       "endgenerate\n"
+       "endmodule\n"}};
   RunLintTestCases<VerilogAnalyzer, LegacyGenvarDeclarationRule>(kTestCases);
 }
 

--- a/verilog/analysis/checkers/line_length_rule_test.cc
+++ b/verilog/analysis/checkers/line_length_rule_test.cc
@@ -18,11 +18,11 @@
 #include <iostream>
 #include <string>
 
-#include "gtest/gtest.h"
 #include "absl/strings/match.h"
 #include "common/analysis/linter_test_utils.h"
 #include "common/analysis/text_structure_linter_test_utils.h"
 #include "common/text/symbol.h"
+#include "gtest/gtest.h"
 #include "verilog/analysis/verilog_analyzer.h"
 #include "verilog/parser/verilog_token_enum.h"
 

--- a/verilog/analysis/checkers/macro_name_style_rule_test.cc
+++ b/verilog/analysis/checkers/macro_name_style_rule_test.cc
@@ -16,10 +16,10 @@
 
 #include <initializer_list>
 
-#include "gtest/gtest.h"
 #include "common/analysis/linter_test_utils.h"
 #include "common/analysis/token_stream_linter_test_utils.h"
 #include "common/text/symbol.h"
+#include "gtest/gtest.h"
 #include "verilog/analysis/verilog_analyzer.h"
 #include "verilog/parser/verilog_token_enum.h"
 

--- a/verilog/analysis/checkers/mismatched_labels_rule_test.cc
+++ b/verilog/analysis/checkers/mismatched_labels_rule_test.cc
@@ -16,10 +16,10 @@
 
 #include <initializer_list>
 
-#include "gtest/gtest.h"
 #include "common/analysis/linter_test_utils.h"
 #include "common/analysis/syntax_tree_linter_test_utils.h"
 #include "common/text/symbol.h"
+#include "gtest/gtest.h"
 #include "verilog/CST/verilog_nonterminals.h"
 #include "verilog/analysis/verilog_analyzer.h"
 #include "verilog/parser/verilog_token_enum.h"

--- a/verilog/analysis/checkers/module_begin_block_rule_test.cc
+++ b/verilog/analysis/checkers/module_begin_block_rule_test.cc
@@ -16,10 +16,10 @@
 
 #include <initializer_list>
 
-#include "gtest/gtest.h"
 #include "common/analysis/linter_test_utils.h"
 #include "common/analysis/syntax_tree_linter_test_utils.h"
 #include "common/text/symbol.h"
+#include "gtest/gtest.h"
 #include "verilog/CST/verilog_nonterminals.h"
 #include "verilog/analysis/verilog_analyzer.h"
 #include "verilog/parser/verilog_token_enum.h"

--- a/verilog/analysis/checkers/module_filename_rule_test.cc
+++ b/verilog/analysis/checkers/module_filename_rule_test.cc
@@ -17,10 +17,10 @@
 #include <initializer_list>
 #include <string>
 
-#include "gtest/gtest.h"
 #include "common/analysis/linter_test_utils.h"
 #include "common/analysis/text_structure_linter_test_utils.h"
 #include "common/text/symbol.h"
+#include "gtest/gtest.h"
 #include "verilog/analysis/verilog_analyzer.h"
 #include "verilog/parser/verilog_token_enum.h"
 

--- a/verilog/analysis/checkers/module_instantiation_rules_test.cc
+++ b/verilog/analysis/checkers/module_instantiation_rules_test.cc
@@ -16,10 +16,10 @@
 
 #include <initializer_list>
 
-#include "gtest/gtest.h"
 #include "common/analysis/linter_test_utils.h"
 #include "common/analysis/syntax_tree_linter_test_utils.h"
 #include "common/text/symbol.h"
+#include "gtest/gtest.h"
 #include "verilog/CST/verilog_nonterminals.h"
 #include "verilog/CST/verilog_treebuilder_utils.h"
 #include "verilog/analysis/verilog_analyzer.h"

--- a/verilog/analysis/checkers/no_tabs_rule_test.cc
+++ b/verilog/analysis/checkers/no_tabs_rule_test.cc
@@ -16,10 +16,10 @@
 
 #include <initializer_list>
 
-#include "gtest/gtest.h"
 #include "common/analysis/line_linter_test_utils.h"
 #include "common/analysis/linter_test_utils.h"
 #include "common/text/symbol.h"
+#include "gtest/gtest.h"
 #include "verilog/analysis/verilog_analyzer.h"
 #include "verilog/parser/verilog_token_enum.h"
 

--- a/verilog/analysis/checkers/no_trailing_spaces_rule_test.cc
+++ b/verilog/analysis/checkers/no_trailing_spaces_rule_test.cc
@@ -16,10 +16,10 @@
 
 #include <initializer_list>
 
-#include "gtest/gtest.h"
 #include "common/analysis/line_linter_test_utils.h"
 #include "common/analysis/linter_test_utils.h"
 #include "common/text/symbol.h"
+#include "gtest/gtest.h"
 #include "verilog/analysis/verilog_analyzer.h"
 #include "verilog/parser/verilog_token_enum.h"
 

--- a/verilog/analysis/checkers/numeric_format_string_style_rule_test.cc
+++ b/verilog/analysis/checkers/numeric_format_string_style_rule_test.cc
@@ -16,10 +16,10 @@
 
 #include <initializer_list>
 
-#include "gtest/gtest.h"
 #include "common/analysis/linter_test_utils.h"
 #include "common/analysis/token_stream_linter_test_utils.h"
 #include "common/text/symbol.h"
+#include "gtest/gtest.h"
 #include "verilog/analysis/verilog_analyzer.h"
 #include "verilog/parser/verilog_token_enum.h"
 

--- a/verilog/analysis/checkers/one_module_per_file_rule_test.cc
+++ b/verilog/analysis/checkers/one_module_per_file_rule_test.cc
@@ -17,10 +17,10 @@
 #include <initializer_list>
 #include <string>
 
-#include "gtest/gtest.h"
 #include "common/analysis/linter_test_utils.h"
 #include "common/analysis/text_structure_linter_test_utils.h"
 #include "common/text/symbol.h"
+#include "gtest/gtest.h"
 #include "verilog/analysis/verilog_analyzer.h"
 #include "verilog/parser/verilog_token_enum.h"
 

--- a/verilog/analysis/checkers/package_filename_rule_test.cc
+++ b/verilog/analysis/checkers/package_filename_rule_test.cc
@@ -16,10 +16,10 @@
 
 #include <string>
 
-#include "gtest/gtest.h"
 #include "common/analysis/linter_test_utils.h"
 #include "common/analysis/text_structure_linter_test_utils.h"
 #include "common/text/symbol.h"
+#include "gtest/gtest.h"
 #include "verilog/analysis/verilog_analyzer.h"
 #include "verilog/parser/verilog_token_enum.h"
 

--- a/verilog/analysis/checkers/packed_dimensions_rule_test.cc
+++ b/verilog/analysis/checkers/packed_dimensions_rule_test.cc
@@ -16,10 +16,10 @@
 
 #include <initializer_list>
 
-#include "gtest/gtest.h"
 #include "common/analysis/linter_test_utils.h"
 #include "common/analysis/syntax_tree_linter_test_utils.h"
 #include "common/text/symbol.h"
+#include "gtest/gtest.h"
 #include "verilog/CST/verilog_nonterminals.h"
 #include "verilog/analysis/verilog_analyzer.h"
 #include "verilog/parser/verilog_token_enum.h"

--- a/verilog/analysis/checkers/parameter_name_style_rule_test.cc
+++ b/verilog/analysis/checkers/parameter_name_style_rule_test.cc
@@ -16,10 +16,10 @@
 
 #include <initializer_list>
 
-#include "gtest/gtest.h"
 #include "common/analysis/linter_test_utils.h"
 #include "common/analysis/syntax_tree_linter_test_utils.h"
 #include "common/text/symbol.h"
+#include "gtest/gtest.h"
 #include "verilog/CST/verilog_nonterminals.h"
 #include "verilog/analysis/verilog_analyzer.h"
 #include "verilog/parser/verilog_token_enum.h"

--- a/verilog/analysis/checkers/parameter_type_name_style_rule_test.cc
+++ b/verilog/analysis/checkers/parameter_type_name_style_rule_test.cc
@@ -16,10 +16,10 @@
 
 #include <initializer_list>
 
-#include "gtest/gtest.h"
 #include "common/analysis/linter_test_utils.h"
 #include "common/analysis/syntax_tree_linter_test_utils.h"
 #include "common/text/symbol.h"
+#include "gtest/gtest.h"
 #include "verilog/CST/verilog_nonterminals.h"
 #include "verilog/analysis/verilog_analyzer.h"
 #include "verilog/parser/verilog_token_enum.h"

--- a/verilog/analysis/checkers/plusarg_assignment_rule_test.cc
+++ b/verilog/analysis/checkers/plusarg_assignment_rule_test.cc
@@ -16,10 +16,10 @@
 
 #include <initializer_list>
 
-#include "gtest/gtest.h"
 #include "common/analysis/linter_test_utils.h"
 #include "common/analysis/syntax_tree_linter_test_utils.h"
 #include "common/text/symbol.h"
+#include "gtest/gtest.h"
 #include "verilog/CST/verilog_treebuilder_utils.h"
 #include "verilog/analysis/verilog_analyzer.h"
 #include "verilog/parser/verilog_token_enum.h"

--- a/verilog/analysis/checkers/positive_meaning_parameter_name_rule_test.cc
+++ b/verilog/analysis/checkers/positive_meaning_parameter_name_rule_test.cc
@@ -16,10 +16,10 @@
 
 #include <initializer_list>
 
-#include "gtest/gtest.h"
 #include "common/analysis/linter_test_utils.h"
 #include "common/analysis/syntax_tree_linter_test_utils.h"
 #include "common/text/symbol.h"
+#include "gtest/gtest.h"
 #include "verilog/CST/verilog_nonterminals.h"
 #include "verilog/analysis/verilog_analyzer.h"
 #include "verilog/parser/verilog_token_enum.h"

--- a/verilog/analysis/checkers/posix_eof_rule_test.cc
+++ b/verilog/analysis/checkers/posix_eof_rule_test.cc
@@ -16,10 +16,10 @@
 
 #include <initializer_list>
 
-#include "gtest/gtest.h"
 #include "common/analysis/linter_test_utils.h"
 #include "common/analysis/text_structure_linter_test_utils.h"
 #include "common/text/symbol.h"
+#include "gtest/gtest.h"
 #include "verilog/analysis/verilog_analyzer.h"
 #include "verilog/parser/verilog_token_enum.h"
 

--- a/verilog/analysis/checkers/proper_parameter_declaration_rule_test.cc
+++ b/verilog/analysis/checkers/proper_parameter_declaration_rule_test.cc
@@ -16,10 +16,10 @@
 
 #include <initializer_list>
 
-#include "gtest/gtest.h"
 #include "common/analysis/linter_test_utils.h"
 #include "common/analysis/syntax_tree_linter_test_utils.h"
 #include "common/text/symbol.h"
+#include "gtest/gtest.h"
 #include "verilog/CST/verilog_nonterminals.h"
 #include "verilog/analysis/verilog_analyzer.h"
 #include "verilog/parser/verilog_token_enum.h"

--- a/verilog/analysis/checkers/signal_name_style_rule_test.cc
+++ b/verilog/analysis/checkers/signal_name_style_rule_test.cc
@@ -16,10 +16,10 @@
 
 #include <initializer_list>
 
-#include "gtest/gtest.h"
 #include "common/analysis/linter_test_utils.h"
 #include "common/analysis/syntax_tree_linter_test_utils.h"
 #include "common/text/symbol.h"
+#include "gtest/gtest.h"
 #include "verilog/CST/verilog_nonterminals.h"
 #include "verilog/analysis/verilog_analyzer.h"
 #include "verilog/parser/verilog_token_enum.h"

--- a/verilog/analysis/checkers/struct_union_name_style_rule_test.cc
+++ b/verilog/analysis/checkers/struct_union_name_style_rule_test.cc
@@ -16,10 +16,10 @@
 
 #include <initializer_list>
 
-#include "gtest/gtest.h"
 #include "common/analysis/linter_test_utils.h"
 #include "common/analysis/syntax_tree_linter_test_utils.h"
 #include "common/text/symbol.h"
+#include "gtest/gtest.h"
 #include "verilog/CST/verilog_nonterminals.h"
 #include "verilog/analysis/verilog_analyzer.h"
 #include "verilog/parser/verilog_token_enum.h"

--- a/verilog/analysis/checkers/undersized_binary_literal_rule_test.cc
+++ b/verilog/analysis/checkers/undersized_binary_literal_rule_test.cc
@@ -16,10 +16,10 @@
 
 #include <initializer_list>
 
-#include "gtest/gtest.h"
 #include "common/analysis/linter_test_utils.h"
 #include "common/analysis/syntax_tree_linter_test_utils.h"
 #include "common/text/symbol.h"
+#include "gtest/gtest.h"
 #include "verilog/CST/verilog_nonterminals.h"
 #include "verilog/analysis/verilog_analyzer.h"
 #include "verilog/parser/verilog_token_enum.h"

--- a/verilog/analysis/checkers/unpacked_dimensions_rule_test.cc
+++ b/verilog/analysis/checkers/unpacked_dimensions_rule_test.cc
@@ -16,10 +16,10 @@
 
 #include <initializer_list>
 
-#include "gtest/gtest.h"
 #include "common/analysis/linter_test_utils.h"
 #include "common/analysis/syntax_tree_linter_test_utils.h"
 #include "common/text/symbol.h"
+#include "gtest/gtest.h"
 #include "verilog/CST/verilog_nonterminals.h"
 #include "verilog/analysis/verilog_analyzer.h"
 #include "verilog/parser/verilog_token_enum.h"

--- a/verilog/analysis/checkers/uvm_macro_semicolon_rule_test.cc
+++ b/verilog/analysis/checkers/uvm_macro_semicolon_rule_test.cc
@@ -16,10 +16,10 @@
 
 #include <initializer_list>
 
-#include "gtest/gtest.h"
 #include "common/analysis/linter_test_utils.h"
 #include "common/analysis/syntax_tree_linter_test_utils.h"
 #include "common/text/symbol.h"
+#include "gtest/gtest.h"
 #include "verilog/CST/verilog_nonterminals.h"
 #include "verilog/analysis/verilog_analyzer.h"
 

--- a/verilog/analysis/checkers/v2001_generate_begin_rule_test.cc
+++ b/verilog/analysis/checkers/v2001_generate_begin_rule_test.cc
@@ -16,10 +16,10 @@
 
 #include <initializer_list>
 
-#include "gtest/gtest.h"
 #include "common/analysis/linter_test_utils.h"
 #include "common/analysis/syntax_tree_linter_test_utils.h"
 #include "common/text/symbol.h"
+#include "gtest/gtest.h"
 #include "verilog/CST/verilog_nonterminals.h"
 #include "verilog/CST/verilog_treebuilder_utils.h"
 #include "verilog/analysis/verilog_analyzer.h"

--- a/verilog/analysis/checkers/void_cast_rule_test.cc
+++ b/verilog/analysis/checkers/void_cast_rule_test.cc
@@ -14,10 +14,10 @@
 
 #include "verilog/analysis/checkers/void_cast_rule.h"
 
-#include "gtest/gtest.h"
 #include "common/analysis/linter_test_utils.h"
 #include "common/analysis/syntax_tree_linter_test_utils.h"
 #include "common/text/symbol.h"
+#include "gtest/gtest.h"
 #include "verilog/CST/verilog_nonterminals.h"
 #include "verilog/CST/verilog_treebuilder_utils.h"
 #include "verilog/analysis/verilog_analyzer.h"

--- a/verilog/analysis/dependencies_test.cc
+++ b/verilog/analysis/dependencies_test.cc
@@ -14,10 +14,10 @@
 
 #include "verilog/analysis/dependencies.h"
 
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
 #include "absl/status/status.h"
 #include "common/util/file_util.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 namespace verilog {
 namespace {

--- a/verilog/analysis/descriptions_test.cc
+++ b/verilog/analysis/descriptions_test.cc
@@ -16,8 +16,8 @@
 
 #include <utility>
 
-#include "gtest/gtest.h"
 #include "absl/strings/string_view.h"
+#include "gtest/gtest.h"
 
 namespace verilog {
 namespace analysis {

--- a/verilog/analysis/extractors_test.cc
+++ b/verilog/analysis/extractors_test.cc
@@ -14,8 +14,8 @@
 
 #include "verilog/analysis/extractors.h"
 
-#include "gtest/gtest.h"
 #include "absl/strings/string_view.h"
+#include "gtest/gtest.h"
 
 #undef EXPECT_OK
 #define EXPECT_OK(value) EXPECT_TRUE((value).ok())

--- a/verilog/analysis/lint_rule_registry_test.cc
+++ b/verilog/analysis/lint_rule_registry_test.cc
@@ -21,7 +21,6 @@
 #include <string>
 #include <utility>
 
-#include "gtest/gtest.h"
 #include "absl/strings/match.h"
 #include "absl/strings/string_view.h"
 #include "common/analysis/line_lint_rule.h"
@@ -34,6 +33,7 @@
 #include "common/text/syntax_tree_context.h"
 #include "common/text/text_structure.h"
 #include "common/text/token_info.h"
+#include "gtest/gtest.h"
 #include "verilog/analysis/descriptions.h"
 
 namespace verilog {

--- a/verilog/analysis/symbol_table_test.cc
+++ b/verilog/analysis/symbol_table_test.cc
@@ -20,8 +20,6 @@
 #include <sstream>
 #include <vector>
 
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
 #include "absl/base/attributes.h"
 #include "absl/memory/memory.h"
 #include "absl/status/status.h"
@@ -31,6 +29,8 @@
 #include "common/util/file_util.h"
 #include "common/util/logging.h"
 #include "common/util/range.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 #include "verilog/analysis/verilog_project.h"
 
 namespace verilog {

--- a/verilog/analysis/verilog_analyzer_test.cc
+++ b/verilog/analysis/verilog_analyzer_test.cc
@@ -20,8 +20,6 @@
 #include <utility>
 #include <vector>
 
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
 #include "absl/base/casts.h"
 #include "absl/memory/memory.h"
 #include "absl/status/status.h"
@@ -41,6 +39,8 @@
 #include "common/text/tree_utils.h"
 #include "common/util/casts.h"
 #include "common/util/logging.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 #include "verilog/analysis/verilog_excerpt_parse.h"
 #include "verilog/parser/verilog_token_enum.h"
 

--- a/verilog/analysis/verilog_equivalence_test.cc
+++ b/verilog/analysis/verilog_equivalence_test.cc
@@ -18,14 +18,14 @@
 #include <memory>
 #include <vector>
 
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
 #include "absl/status/status.h"
 #include "absl/strings/match.h"
 #include "absl/strings/string_view.h"
 #include "absl/types/span.h"
 #include "common/text/token_info.h"
 #include "common/util/logging.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 #undef EXPECT_OK
 #define EXPECT_OK(value) EXPECT_TRUE((value).ok())

--- a/verilog/analysis/verilog_linter_configuration_test.cc
+++ b/verilog/analysis/verilog_linter_configuration_test.cc
@@ -22,8 +22,6 @@
 #include <utility>
 #include <vector>
 
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
 #include "absl/strings/string_view.h"
 #include "common/analysis/line_lint_rule.h"
 #include "common/analysis/lint_rule_status.h"
@@ -37,6 +35,8 @@
 #include "common/text/text_structure.h"
 #include "common/text/token_info.h"
 #include "common/text/tree_builder_test_util.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 #include "verilog/analysis/default_rules.h"
 #include "verilog/analysis/descriptions.h"
 #include "verilog/analysis/lint_rule_registry.h"

--- a/verilog/analysis/verilog_linter_test.cc
+++ b/verilog/analysis/verilog_linter_test.cc
@@ -27,14 +27,14 @@
 #include <utility>
 #include <vector>
 
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
 #include "absl/memory/memory.h"
 #include "absl/status/status.h"
 #include "absl/strings/match.h"
 #include "absl/strings/string_view.h"
 #include "common/util/file_util.h"
 #include "common/util/logging.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 #include "verilog/analysis/default_rules.h"
 #include "verilog/analysis/verilog_analyzer.h"
 #include "verilog/analysis/verilog_linter_configuration.h"

--- a/verilog/analysis/verilog_project_test.cc
+++ b/verilog/analysis/verilog_project_test.cc
@@ -14,14 +14,14 @@
 
 #include "verilog/analysis/verilog_project.h"
 
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
 #include "absl/memory/memory.h"
 #include "absl/strings/match.h"
 #include "common/text/text_structure.h"
 #include "common/util/file_util.h"
 #include "common/util/logging.h"
 #include "common/util/range.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 #include "verilog/CST/module.h"
 
 namespace verilog {

--- a/verilog/formatting/comment_controls_test.cc
+++ b/verilog/formatting/comment_controls_test.cc
@@ -16,11 +16,11 @@
 
 #include <initializer_list>
 
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
 #include "absl/strings/str_join.h"
 #include "common/strings/line_column_map.h"
 #include "common/text/token_info_test_util.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 #include "verilog/analysis/verilog_analyzer.h"
 
 namespace verilog {

--- a/verilog/formatting/formatter_test.cc
+++ b/verilog/formatting/formatter_test.cc
@@ -25,8 +25,6 @@
 #include <string>
 #include <vector>
 
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
 #include "absl/status/status.h"
 #include "absl/strings/match.h"
 #include "absl/strings/string_view.h"
@@ -34,6 +32,8 @@
 #include "common/strings/position.h"
 #include "common/text/text_structure.h"
 #include "common/util/logging.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 #include "verilog/analysis/verilog_analyzer.h"
 #include "verilog/formatting/format_style.h"
 

--- a/verilog/formatting/formatter_tuning_test.cc
+++ b/verilog/formatting/formatter_tuning_test.cc
@@ -18,12 +18,12 @@
 
 #include <sstream>
 
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
 #include "absl/status/status.h"
 #include "absl/strings/string_view.h"
 #include "common/strings/position.h"
 #include "common/util/logging.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 #include "verilog/formatting/format_style.h"
 
 #undef EXPECT_OK

--- a/verilog/formatting/token_annotator_test.cc
+++ b/verilog/formatting/token_annotator_test.cc
@@ -20,7 +20,6 @@
 #include <ostream>
 #include <vector>
 
-#include "gtest/gtest.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/string_view.h"
 #include "common/formatting/format_token.h"
@@ -31,6 +30,7 @@
 #include "common/text/tree_builder_test_util.h"
 #include "common/util/casts.h"
 #include "common/util/iterator_adaptors.h"
+#include "gtest/gtest.h"
 #include "verilog/CST/verilog_nonterminals.h"
 #include "verilog/formatting/format_style.h"
 #include "verilog/formatting/verilog_token.h"

--- a/verilog/formatting/tree_unwrapper_test.cc
+++ b/verilog/formatting/tree_unwrapper_test.cc
@@ -22,8 +22,6 @@
 #include <utility>
 #include <vector>
 
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
 #include "absl/memory/memory.h"
 #include "absl/status/status.h"
 #include "absl/strings/str_join.h"
@@ -37,6 +35,8 @@
 #include "common/util/logging.h"
 #include "common/util/spacer.h"
 #include "common/util/vector_tree.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 #include "verilog/analysis/verilog_analyzer.h"
 
 #undef EXPECT_OK

--- a/verilog/formatting/verilog_token_test.cc
+++ b/verilog/formatting/verilog_token_test.cc
@@ -14,9 +14,9 @@
 
 #include "verilog/formatting/verilog_token.h"
 
-#include "gtest/gtest.h"
 #include "common/formatting/format_token.h"
 #include "common/text/token_info.h"
+#include "gtest/gtest.h"
 #include "verilog/parser/verilog_token_enum.h"
 
 namespace verilog {

--- a/verilog/parser/verilog_lexer_unittest.cc
+++ b/verilog/parser/verilog_lexer_unittest.cc
@@ -18,11 +18,11 @@
 #include <initializer_list>
 #include <utility>
 
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
 #include "absl/strings/string_view.h"
 #include "common/lexer/lexer_test_util.h"
 #include "common/text/token_info.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 #include "verilog/parser/verilog_token_enum.h"
 
 namespace verilog {

--- a/verilog/parser/verilog_lexical_context_test.cc
+++ b/verilog/parser/verilog_lexical_context_test.cc
@@ -32,8 +32,6 @@
 #include <string>
 #include <vector>
 
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
 #include "absl/memory/memory.h"
 #include "absl/strings/match.h"
 #include "absl/strings/string_view.h"
@@ -41,8 +39,10 @@
 #include "common/text/token_info.h"
 #include "common/text/token_stream_view.h"
 #include "common/util/logging.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 #include "verilog/analysis/verilog_analyzer.h"  // only used for lexing
-#include "verilog/parser/verilog_parser.h"  // only used for diagnostics
+#include "verilog/parser/verilog_parser.h"      // only used for diagnostics
 #include "verilog/parser/verilog_token_enum.h"
 
 #undef EXPECT_OK

--- a/verilog/parser/verilog_parser_unittest.cc
+++ b/verilog/parser/verilog_parser_unittest.cc
@@ -19,7 +19,6 @@
 #include <initializer_list>
 #include <string>
 
-#include "gtest/gtest.h"
 #include "absl/status/status.h"
 #include "absl/strings/str_cat.h"
 #include "common/parser/bison_parser_common.h"
@@ -28,6 +27,7 @@
 #include "common/text/symbol.h"
 #include "common/text/token_info.h"
 #include "common/text/token_info_test_util.h"
+#include "gtest/gtest.h"
 #include "verilog/CST/verilog_nonterminals.h"
 #include "verilog/analysis/verilog_analyzer.h"
 #include "verilog/analysis/verilog_excerpt_parse.h"

--- a/verilog/preprocessor/verilog_preprocess_test.cc
+++ b/verilog/preprocessor/verilog_preprocess_test.cc
@@ -17,12 +17,12 @@
 #include <map>
 #include <vector>
 
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
 #include "absl/status/status.h"
 #include "common/text/macro_definition.h"
 #include "common/text/token_info.h"
 #include "common/util/container_util.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 #include "verilog/analysis/verilog_analyzer.h"
 
 namespace verilog {

--- a/verilog/tools/kythe/indexing_facts_tree_extractor_test.cc
+++ b/verilog/tools/kythe/indexing_facts_tree_extractor_test.cc
@@ -16,12 +16,12 @@
 
 #include <functional>
 
-#include "gtest/gtest.h"
 #include "absl/status/status.h"
 #include "common/analysis/syntax_tree_search_test_utils.h"
 #include "common/text/concrete_syntax_tree.h"
 #include "common/util/file_util.h"
 #include "common/util/range.h"
+#include "gtest/gtest.h"
 #include "verilog/analysis/verilog_analyzer.h"
 #include "verilog/analysis/verilog_project.h"
 #include "verilog/tools/kythe/indexing_facts_tree.h"

--- a/verilog/tools/kythe/indexing_facts_tree_test.cc
+++ b/verilog/tools/kythe/indexing_facts_tree_test.cc
@@ -16,12 +16,12 @@
 
 #include <sstream>
 
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
 #include "absl/memory/memory.h"
 #include "absl/strings/match.h"
 #include "common/text/token_info.h"
 #include "common/util/range.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 #include "verilog/tools/kythe/verilog_extractor_indexing_fact_type.h"
 
 namespace verilog {

--- a/verilog/tools/kythe/verilog_kythe_extractor.cc
+++ b/verilog/tools/kythe/verilog_kythe_extractor.cc
@@ -17,18 +17,18 @@
 #include <iostream>
 #include <string>
 
-#include "google/protobuf/io/zero_copy_stream_impl.h"
 #include "absl/flags/flag.h"
 #include "absl/status/status.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/string_view.h"
 #include "absl/strings/substitute.h"
-#include "kythe/cxx/common/indexing/KytheCachingOutput.h"
-#include "kythe/proto/storage.pb.h"
 #include "common/util/bijective_map.h"
 #include "common/util/enum_flags.h"
 #include "common/util/file_util.h"
 #include "common/util/init_command_line.h"
+#include "google/protobuf/io/zero_copy_stream_impl.h"
+#include "kythe/cxx/common/indexing/KytheCachingOutput.h"
+#include "kythe/proto/storage.pb.h"
 #include "verilog/analysis/verilog_analyzer.h"
 #include "verilog/analysis/verilog_project.h"
 #include "verilog/tools/kythe/indexing_facts_tree_extractor.h"

--- a/verilog/transform/obfuscate_test.cc
+++ b/verilog/transform/obfuscate_test.cc
@@ -16,9 +16,9 @@
 
 #include <sstream>
 
+#include "common/strings/obfuscator.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
-#include "common/strings/obfuscator.h"
 
 namespace verilog {
 namespace {

--- a/verilog/transform/strip_comments_test.cc
+++ b/verilog/transform/strip_comments_test.cc
@@ -16,9 +16,9 @@
 
 #include <sstream>
 
+#include "absl/strings/string_view.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
-#include "absl/strings/string_view.h"
 
 namespace verilog {
 namespace {


### PR DESCRIPTION
	clang-format -i --style=Google $(find . -name "*.cc" -o -name "*.h")

Mostly the headers sorting was a little bit off as they originally
inherited a different prefix.

No functional changes.

Issues: #653

Signed-off-by: Henner Zeller <h.zeller@acm.org>