### PR TITLE
Fix confusing --rules_config flag: it shows a default but doesn't use…

### DIFF
--- a/verilog/analysis/verilog_linter.cc
+++ b/verilog/analysis/verilog_linter.cc
@@ -57,12 +57,11 @@ ABSL_FLAG(verilog::RuleBundle, rules, {},
           "Comma-separated of lint rules to enable.  "
           "No prefix or a '+' prefix enables it, '-' disable it. "
           "Configuration values for each rules placed after '=' character.");
-static const char kDefaultRulesConfig[] = ".rules.verible_lint";
-ABSL_FLAG(std::string, rules_config, kDefaultRulesConfig,
+ABSL_FLAG(std::string, rules_config, "",
           "Path to lint rules configuration file. "
-          "Disables --rule_config_search.");
+          "Disables --rule_config_search if set.");
 ABSL_FLAG(bool, rules_config_search, false,
-          "Look for lint rules configuration file, "
+          "Look for lint rules configuration file '.rules.verible_lint' "
           "searching upward from the location of each analyzed file.");
 ABSL_FLAG(verilog::RuleSet, ruleset, verilog::RuleSet::kDefault,
           "[default|all|none], the base set of rules used by linter");
@@ -256,8 +255,6 @@ LinterConfiguration LinterConfigurationFromFlags(
       .ruleset = absl::GetFlag(FLAGS_ruleset),
       .rules = absl::GetFlag(FLAGS_rules),
       .config_file = absl::GetFlag(FLAGS_rules_config),
-      .config_file_is_custom =
-          absl::GetFlag(FLAGS_rules_config) != kDefaultRulesConfig,
       .rules_config_search = absl::GetFlag(FLAGS_rules_config_search),
       .linting_start_file = std::string(linting_start_file),
       .waiver_files = absl::GetFlag(FLAGS_waiver_files)};

--- a/verilog/analysis/verilog_linter_configuration.cc
+++ b/verilog/analysis/verilog_linter_configuration.cc
@@ -311,7 +311,7 @@ absl::Status LinterConfiguration::ConfigureFromOptions(
   // migrate these into hosted project configurations.
   UseRuleSet(options.ruleset);
 
-  if (options.config_file_is_custom) {
+  if (!options.config_file.empty()) {
     const absl::Status config_read_status = AppendFromFile(options.config_file);
 
     if (!config_read_status.ok()) {
@@ -320,6 +320,10 @@ absl::Status LinterConfiguration::ConfigureFromOptions(
                    << config_read_status << std::endl;
     }
 
+    if (options.rules_config_search) {
+      LOG(WARNING) << "Explicit config file " << options.config_file
+                   << " disables --rules_config_search";
+    }
   } else if (options.rules_config_search) {
     // Search upward if search is enabled and no configuration file is
     // specified

--- a/verilog/analysis/verilog_linter_configuration.h
+++ b/verilog/analysis/verilog_linter_configuration.h
@@ -142,9 +142,6 @@ struct LinterOptions {
   // Path to a file with extra linter configuration, applied on top of the
   // base 'ruleset' and extra 'rules'
   std::string config_file;
-  // Indicates whether the 'config_file' is the default config file or a custom
-  // one
-  bool config_file_is_custom;
   // Enables upward config file search
   bool rules_config_search;
   // Defines the starting point for the upward config search algorithm,

--- a/verilog/analysis/verilog_linter_configuration_test.cc
+++ b/verilog/analysis/verilog_linter_configuration_test.cc
@@ -781,8 +781,7 @@ TEST(ConfigureFromOptionsTest, Basic) {
 
   LinterOptions options = {.ruleset = RuleSet::kAll,
                            .rules = RuleBundle(),
-                           .config_file = "-",
-                           .config_file_is_custom = false,
+                           .config_file = "",
                            .rules_config_search = false,
                            .linting_start_file = "filename",
                            .waiver_files = "filename"};
@@ -796,8 +795,7 @@ TEST(ConfigureFromOptionsTest, RulesNumber) {
 
   LinterOptions options = {.ruleset = RuleSet::kAll,
                            .rules = RuleBundle(),
-                           .config_file = "-",
-                           .config_file_is_custom = false,
+                           .config_file = "",
                            .rules_config_search = false,
                            .linting_start_file = "filename",
                            .waiver_files = "filename"};
@@ -821,8 +819,7 @@ TEST(ConfigureFromOptionsTest, RulesSelective) {
 
   LinterOptions options = {.ruleset = RuleSet::kAll,
                            .rules = bundle,
-                           .config_file = "-",
-                           .config_file_is_custom = false,
+                           .config_file = "",
                            .rules_config_search = false,
                            .linting_start_file = "filename",
                            .waiver_files = "filename"};


### PR DESCRIPTION
… it.

The --rules_config flag only works if there is a file explicitly set. So
set the default to an empty string to clarify that this is what is
happening.

Could also simplify the logic, as we now can just look at the empty
string instead of having a separate flag containing the information if
the flag was set.

(The default value was a left-over from before there was a choice
between filename and upwards search I think)

Issues #229

Signed-off-by: Henner Zeller <h.zeller@acm.org>