### PR TITLE
Add .editorconfig to provide basic code indentation rules.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+# Editor config file, see http://editorconfig.org/
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{h,cc,sv,sh,yml}]
+indent_size = 2
+
+[BUILD]
+indent_size = 4
+


### PR DESCRIPTION
This file is supported by most editors/IDEs (https://editorconfig.org/)

Signed-off-by: Henner Zeller <h.zeller@acm.org>