### PR TITLE
Now that we have a .clang-format, use that file as reference.

### DIFF
--- a/.github/workflows/run-clang-format.sh
+++ b/.github/workflows/run-clang-format.sh
@@ -16,14 +16,14 @@
 FORMAT_OUT=${TMPDIR:-/tmp}/clang-format-diff.out
 
 # Run on all the files that are affected
-clang-format -i --style=Google $(git diff --name-only --diff-filter=AM -r origin/master | grep '\(\.cc\|\.h\)$')
+clang-format -i --style=file $(git diff --name-only --diff-filter=AM -r origin/master | grep '\(\.cc\|\.h\)$') 2> /dev/null
 
 # Check if we got any diff
 git diff > ${FORMAT_OUT}
 
 if [ -s ${FORMAT_OUT} ]; then
    echo "Style not matching (see https://github.com/google/verible/blob/master/CONTRIBUTING.md#style)"
-   echo "On your *.h, *.cc files, please run clang-format -i --style=Google"
+   echo "On your *.h, *.cc files, please run clang-format -i --style=file <your changed files>"
    cat ${FORMAT_OUT}
    exit 1
 fi


### PR DESCRIPTION
Previously, we choose a particular clang-format built-in style
('Google'), but since we now have a .clang-format configuration file
use that instead to make sure we always apply the same rules.

Issues #653

Signed-off-by: Henner Zeller <h.zeller@acm.org>