### PR TITLE
[SymbolTable] Add support of enumeration types

### DIFF
--- a/verilog/analysis/symbol_table.h
+++ b/verilog/analysis/symbol_table.h
@@ -54,6 +54,8 @@ enum class SymbolMetaType {
   kFunction,
   kTask,
   kStruct,
+  kEnumType,
+  kEnumConstant,
   kInterface,
 
   // The following enums represent classes/groups of the above types,


### PR DESCRIPTION
Fixes segfault caused by missing support of enumeration types:
```
F0211 18:06:09.305649 13750 symbol_table.cc:1522] Check failed: node.Parent() == nullptr
```
Test case:
```
enum { x1, x2, x3 } xx;
```