### PR TITLE
Add a missing space in documentation generation.

### DIFF
--- a/verilog/analysis/checkers/token_stream_lint_rule.cc
+++ b/verilog/analysis/checkers/token_stream_lint_rule.cc
@@ -54,7 +54,7 @@ std::string TokenStreamLintRule::GetDescription(
     DescriptionType description_type) {
   return absl::StrCat("Checks that there are no occurrences of ",
                       Codify("\'\\\'", description_type),
-                      " when breaking the string literal line.",
+                      " when breaking the string literal line. ",
                       "Use concatenation operator with braces instead. See ",
                       GetStyleGuideCitation(kTopic), ".");
 }


### PR DESCRIPTION
Signed-off-by: Henner Zeller <h.zeller@acm.org>