### PR TITLE
Don't build all release artifacts on every pull request commit.

### DIFF
--- a/.github/workflows/verible-ci.yml
+++ b/.github/workflows/verible-ci.yml
@@ -56,7 +56,7 @@ jobs:
     name: Check · ${{ matrix.mode }}
 
     steps:
-    
+
     - name: Cancel previous
       uses: styfle/cancel-workflow-action@0.8.0
       with:
@@ -160,6 +160,9 @@ jobs:
   Build:
     needs: Matrix
     runs-on: ubuntu-20.04
+    # Github actions resources are limited; don't build artifacts for all
+    # platforms on every pull request, only on push.
+    if: ${{github.event_name == 'push'}}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Github actions resource allowance is limited, so skip building all
artifacts in pull reqeuests. The checks and tests shall be sufficient
for now.

Signed-off-by: Henner Zeller <h.zeller@acm.org>