### PR TITLE
formatter: Fix missing space before hashtag

### DIFF
--- a/verilog/formatting/formatter_test.cc
+++ b/verilog/formatting/formatter_test.cc
@@ -3379,7 +3379,7 @@ static constexpr FormatterTestCase kFormatterTestCases[] = {
      "endclass\n"},
     // class extends from type with named parameters
     {"class foo extends bar #(.N(N), .M(M)); endclass",
-     "class foo extends bar#(\n"
+     "class foo extends bar #(\n"
      "    .N(N),\n"
      "    .M(M)\n"
      ");\n"

--- a/verilog/formatting/token_annotator.cc
+++ b/verilog/formatting/token_annotator.cc
@@ -504,7 +504,7 @@ static WithReason<int> SpacesRequiredBetween(
     //   type#(params...)::method(...);
     if (left_context.DirectParentIs(NodeEnum::kUnqualifiedId) &&
         !left_context.IsInsideFirst(
-            {NodeEnum::kInstantiationType, NodeEnum::kBindTargetInstance},
+            {NodeEnum::kInstantiationType, NodeEnum::kBindTargetInstance, NodeEnum::kExtendsList},
             {})) {
       return {0, "No space before # when direct parent is kUnqualifiedId."};
     } else {


### PR DESCRIPTION
Fix missing space before hashtag in class declarations extending parameterized class:
```
class aes_env_cfg extends cip_base_env_cfg #(
    .RAL_T(aes_reg_block)
);
```

Fixes #444