### PR TITLE
formatter: Fix constraints blocks formatting

### DIFF
--- a/verilog/formatting/tree_unwrapper.cc
+++ b/verilog/formatting/tree_unwrapper.cc
@@ -1671,6 +1671,23 @@ void TreeUnwrapper::ReshapeTokenPartitions(
       break;
     }
 
+    case NodeEnum::kConstraintBlockItemList: {
+      HoistOnlyChildPartition(&partition);
+
+      // Alwyas expand constraint(s) blocks with braces inside them
+      const auto& uwline = partition.Value();
+      const auto& ftokens = uwline.TokensRange();
+      auto found = std::find_if(ftokens.begin(), ftokens.end(),
+                                [](const verible::PreFormatToken& token) {
+                                  return token.TokenEnum() == '{';
+                                });
+      if (found != ftokens.end()) {
+        VLOG(4) << "Found brace group, forcing expansion";
+        partition.Value().SetPartitionPolicy(PartitionPolicyEnum::kAlwaysExpand);
+      }
+      break;
+    }
+
       // This group of cases is temporary: simplify these during the
       // rewrite/refactor of this function.
       // See search-anchor: STATEMENT_TYPES


### PR DESCRIPTION
Expands constraints blocks with more than one partition, e.g. if-statements
```
constraint xx {
  if (a) b;
}
```
But keeps constraints blocks with simple statements unexpanded, e.g.
```
constraint only_vec_instr_c {soft only_vec_instr == 0;}
```

Fixes #445