### PR TITLE
clang-format: use style Google; always format all files.

### DIFF
--- a/.github/workflows/run-clang-format.sh
+++ b/.github/workflows/run-clang-format.sh
@@ -15,8 +15,9 @@
 
 FORMAT_OUT=${TMPDIR:-/tmp}/clang-format-diff.out
 
-# Run on all the files that are affected
-clang-format -i --style=file $(git diff --name-only --diff-filter=AM -r origin/master | grep '\(\.cc\|\.h\)$') 2> /dev/null
+# Run on all files.
+find . -name "*.h" -o -name "*.cc" -print0 \
+     | xargs -0 -P 2 clang-format --style=Google -i
 
 # Check if we got any diff
 git diff > ${FORMAT_OUT}


### PR DESCRIPTION
 * -style=file does not seem to work in CI; more investigation
   needed. For now: use Google style explicitly.
 * Always format all files in repo to avoid corner-cases
   with git branches.

Signed-off-by: Henner Zeller <h.zeller@acm.org>