### PR TITLE
Avoid unnecessary get() on smartpointers.

### DIFF
--- a/verilog/analysis/checkers/token_stream_lint_rule.cc
+++ b/verilog/analysis/checkers/token_stream_lint_rule.cc
@@ -76,9 +76,9 @@ void TokenStreamLintRule::HandleSymbol(const verible::Symbol& symbol,
   const auto& literal =
       std::find_if(node_children.begin(), node_children.end(),
                    [](const verible::SymbolPtr& p) {
-                     return p.get()->Tag().tag == TK_StringLiteral;
+                     return p->Tag().tag == TK_StringLiteral;
                    });
-  const auto& string_literal = SymbolCastToLeaf(*literal->get());
+  const auto& string_literal = SymbolCastToLeaf(**literal);
   if (absl::StrContains(string_literal.get().text(), "\\\n")) {
     violations_.insert(LintViolation(string_literal, kMessage, context));
   }


### PR DESCRIPTION
Signed-off-by: Henner Zeller <h.zeller@acm.org>