### PR TITLE
Flex: Switch off dependencies on <unistd.h> header and isatty()

### DIFF
--- a/common/analysis/command_file.lex
+++ b/common/analysis/command_file.lex
@@ -20,12 +20,14 @@
 #define yy_set_top_state(state)  { yy_pop_state(); yy_push_state(state); }
 %}
 
+%option c++
+%option never-interactive
 %option nodefault
+%option nounistd
 %option noyywrap
 %option prefix="veribleCommandFile"
-%option c++
-%option yylineno
 %option yyclass="verible::CommandFileLexer"
+%option yylineno
 
 LineTerminator \r|\n|\r\n
 InputCharacter [^\r\n\0]

--- a/verilog/parser/verilog.lex
+++ b/verilog/parser/verilog.lex
@@ -54,15 +54,16 @@
 %}
 
 %option 8bit
+%option c++
 %option case-sensitive
 %option never-interactive
+%option nounistd
 %option nounput
 %option noyywrap
 %option prefix="verilog"
-%option c++
-%option yyclass="verilog::VerilogLexer"
 /* to enable stack of initial condition states: */
 %option stack
+%option yyclass="verilog::VerilogLexer"
 
 /* various lexer states, INITIAL = 0 */
 %x TIMESCALE_DIRECTIVE


### PR DESCRIPTION
Working towards a more platform-independent build.

Issues #260 #307 #726

Signed-off-by: Henner Zeller <h.zeller@acm.org>