### PR TITLE
[kythe] Extend VerilogProject to support adding virtual files

### DIFF
--- a/verilog/analysis/symbol_table.cc
+++ b/verilog/analysis/symbol_table.cc
@@ -1815,7 +1815,7 @@ static void ParseFileAndBuildSymbolTable(
 
 void SymbolTable::Build(std::vector<absl::Status>* diagnostics) {
   for (auto& translation_unit : *project_) {
-    ParseFileAndBuildSymbolTable(&translation_unit.second, this, project_,
+    ParseFileAndBuildSymbolTable(translation_unit.second.get(), this, project_,
                                  diagnostics);
   }
 }

--- a/verilog/analysis/verilog_project.cc
+++ b/verilog/analysis/verilog_project.cc
@@ -95,11 +95,11 @@ absl::StatusOr<VerilogSourceFile*> VerilogProject::OpenFile(
     absl::string_view referenced_filename, absl::string_view resolved_filename,
     absl::string_view corpus) {
   const auto inserted = files_.emplace(
-      referenced_filename,
-      VerilogSourceFile(referenced_filename, resolved_filename, corpus));
+      referenced_filename, absl::make_unique<VerilogSourceFile>(
+                               referenced_filename, resolved_filename, corpus));
   CHECK(inserted.second);  // otherwise, would have already returned above
   const auto file_iter = inserted.first;
-  VerilogSourceFile& file(file_iter->second);
+  VerilogSourceFile& file(*file_iter->second);
 
   // Read the file's contents.
   const absl::Status status = file.Open();
@@ -125,9 +125,9 @@ absl::StatusOr<VerilogSourceFile*> VerilogProject::OpenTranslationUnit(
   {
     const auto found = files_.find(referenced_filename);
     if (found != files_.end()) {
-      const auto status = found->second.Status();
+      const auto status = found->second->Status();
       if (!status.ok()) return status;
-      return &found->second;
+      return found->second.get();
     }
   }
 
@@ -144,7 +144,6 @@ absl::Status VerilogProject::IncludeFileNotFoundError(
       "Unable to find '", referenced_filename,
       "' among the included paths: ", absl::StrJoin(include_paths_, ", ")));
 }
-
 absl::StatusOr<VerilogSourceFile*> VerilogProject::OpenIncludedFile(
     absl::string_view referenced_filename) {
   VLOG(1) << __FUNCTION__ << ", referenced: " << referenced_filename;
@@ -152,9 +151,9 @@ absl::StatusOr<VerilogSourceFile*> VerilogProject::OpenIncludedFile(
   {
     const auto found = files_.find(referenced_filename);
     if (found != files_.end()) {
-      const auto status = found->second.Status();
+      const auto status = found->second->Status();
       if (!status.ok()) return status;
-      return &found->second;
+      return found->second.get();
     }
   }
 
@@ -172,16 +171,34 @@ absl::StatusOr<VerilogSourceFile*> VerilogProject::OpenIncludedFile(
   // Not found in any path.  Cache this status.
   const auto inserted = files_.emplace(
       referenced_filename,
-      VerilogSourceFile(referenced_filename,
-                        IncludeFileNotFoundError(referenced_filename)));
+      absl::make_unique<VerilogSourceFile>(
+          referenced_filename, IncludeFileNotFoundError(referenced_filename)));
   CHECK(inserted.second) << "Not-found file should have been recorded as such.";
-  return inserted.first->second.Status();
+  return inserted.first->second->Status();
+}
+
+void VerilogProject::AddVirtualFile(absl::string_view referenced_filename,
+                                    absl::string_view content) {
+  const auto inserted = files_.emplace(
+      referenced_filename, absl::make_unique<InMemoryVerilogSourceFile>(
+                               referenced_filename, content));
+  CHECK(inserted.second);
+  const auto file_iter = inserted.first;
+
+  // Register the file's contents range in string_view_map_.
+  string_view_map_.must_emplace(content);
+
+  // Map the start of the file's contents to its corresponding owner
+  // VerilogSourceFile.
+  const auto map_inserted =
+      buffer_to_analyzer_map_.emplace(content.begin(), file_iter);
+  CHECK(map_inserted.second);
 }
 
 std::vector<absl::Status> VerilogProject::GetErrorStatuses() const {
   std::vector<absl::Status> statuses;
   for (const auto& file : files_) {
-    const auto status = file.second.Status();
+    const auto status = file.second->Status();
     if (!status.ok()) {
       statuses.push_back(status);
     }
@@ -201,7 +218,7 @@ const VerilogSourceFile* VerilogProject::LookupFileOrigin(
   const auto found_file = buffer_to_analyzer_map_.find(buffer_start);
   if (found_file == buffer_to_analyzer_map_.end()) return nullptr;
 
-  const VerilogSourceFile* file = &found_file->second->second;
+  const VerilogSourceFile* file = found_file->second->second.get();
   return file;
 }
 

--- a/verilog/analysis/verilog_project.cc
+++ b/verilog/analysis/verilog_project.cc
@@ -144,6 +144,7 @@ absl::Status VerilogProject::IncludeFileNotFoundError(
       "Unable to find '", referenced_filename,
       "' among the included paths: ", absl::StrJoin(include_paths_, ", ")));
 }
+
 absl::StatusOr<VerilogSourceFile*> VerilogProject::OpenIncludedFile(
     absl::string_view referenced_filename) {
   VLOG(1) << __FUNCTION__ << ", referenced: " << referenced_filename;

--- a/verilog/analysis/verilog_project_test.cc
+++ b/verilog/analysis/verilog_project_test.cc
@@ -364,10 +364,10 @@ TEST(VerilogProjectTest, ValidTranslationUnit) {
 
   // Testing begin/end iteration.
   for (auto& file : project) {
-    EXPECT_TRUE(file.second.Parse().ok());
+    EXPECT_TRUE(file.second->Parse().ok());
   }
   for (const auto& file : project) {
-    EXPECT_TRUE(file.second.Status().ok());
+    EXPECT_TRUE(file.second->Status().ok());
   }
 }
 
@@ -467,6 +467,26 @@ TEST(VerilogProjectTest, IncludeFileNotFound) {
     EXPECT_FALSE(status_or_file.ok());
   }
   EXPECT_EQ(project.GetErrorStatuses().size(), 1);
+}
+
+TEST(VerilogProjecTest, AddVirtualFile) {
+  const auto tempdir = ::testing::TempDir();
+  const std::string sources_dir = JoinPath(tempdir, "srcs");
+  const std::string includes_dir = JoinPath(tempdir, "includes");
+  EXPECT_TRUE(CreateDir(sources_dir).ok());
+  EXPECT_TRUE(CreateDir(includes_dir).ok());
+  VerilogProject project(sources_dir, {includes_dir});
+
+  const std::string file_path = "/some/file";
+  const std::string file_content = "virtual file content";
+  project.AddVirtualFile(file_path, file_content);
+
+  auto* stored_file = project.LookupRegisteredFile(file_path);
+  ASSERT_NE(stored_file, nullptr);
+  EXPECT_TRUE(stored_file->Open().ok());
+  EXPECT_TRUE(stored_file->Status().ok());
+  ASSERT_NE(stored_file->GetTextStructure(), nullptr);
+  EXPECT_EQ(stored_file->GetTextStructure()->Contents(), file_content);
 }
 
 }  // namespace

--- a/verilog/tools/kythe/BUILD
+++ b/verilog/tools/kythe/BUILD
@@ -91,6 +91,7 @@ cc_library(
         "//verilog/analysis:verilog_project",
         "@com_google_absl//absl/memory",
         "@com_google_absl//absl/strings",
+        "@io_kythe//kythe/cxx/common/indexing:output",
     ],
 )
 

--- a/verilog/tools/kythe/kythe_facts_extractor.cc
+++ b/verilog/tools/kythe/kythe_facts_extractor.cc
@@ -14,6 +14,7 @@
 
 #include "verilog/tools/kythe/kythe_facts_extractor.h"
 
+#include <deque>
 #include <iostream>
 #include <map>
 #include <memory>
@@ -26,6 +27,7 @@
 #include "absl/strings/str_cat.h"
 #include "common/strings/compare.h"
 #include "common/util/logging.h"
+#include "kythe/cxx/common/indexing/KytheOutputStream.h"
 #include "verilog/tools/kythe/kythe_schema_constants.h"
 #include "verilog/tools/kythe/scope_resolver.h"
 #include "verilog/tools/kythe/verilog_extractor_indexing_fact_type.h"
@@ -34,6 +36,10 @@ namespace verilog {
 namespace kythe {
 
 namespace {
+
+using ::kythe::EdgeRef;
+using ::kythe::FactRef;
+using ::kythe::VNameRef;
 
 // Returns the file path of the file from the given indexing facts tree node
 // tagged with kFile.
@@ -68,7 +74,46 @@ std::vector<absl::string_view> ConcatenateReferences(
   return references;
 }
 
+// Returns VNameRef based on Verible's VName.
+VNameRef ConvertToVnameRef(const VName& vname,
+                           std::deque<std::string>* signatures) {
+  VNameRef vname_ref;
+  signatures->push_back(vname.signature.ToString());
+  vname_ref.set_signature(signatures->back());
+  vname_ref.set_corpus(vname.corpus);
+  vname_ref.set_root(vname.root);
+  vname_ref.set_path(vname.path);
+  vname_ref.set_language(vname.language);
+  return vname_ref;
+}
+
 }  // namespace
+
+void StreamKytheFactsProtoEntries(::kythe::KytheOutputStream* kythe_output,
+                                  const IndexingFactNode& file_list_facts_tree,
+                                  const VerilogProject& project) {
+  const auto indexing_data = ExtractKytheFacts(file_list_facts_tree, project);
+  // Keep signatures alive. VNameRef takes a view. Note that we need pointer
+  // stability, can't use a vector here!
+  std::deque<std::string> signatures;
+  for (const Fact& fact : indexing_data.facts) {
+    FactRef fact_ref;
+    VNameRef source = ConvertToVnameRef(fact.node_vname, &signatures);
+    fact_ref.fact_name = fact.fact_name;
+    fact_ref.fact_value = fact.fact_value;
+    fact_ref.source = &source;
+    kythe_output->Emit(fact_ref);
+  }
+  for (const Edge& edge : indexing_data.edges) {
+    EdgeRef edge_ref;
+    VNameRef source = ConvertToVnameRef(edge.source_node, &signatures);
+    VNameRef target = ConvertToVnameRef(edge.target_node, &signatures);
+    edge_ref.edge_kind = edge.edge_name;
+    edge_ref.source = &source;
+    edge_ref.target = &target;
+    kythe_output->Emit(edge_ref);
+  }
+}
 
 // KytheFactsExtractor processes indexing facts for a single file.
 // Responsible for traversing IndexingFactsTree and processing its different
@@ -290,7 +335,7 @@ KytheIndexingData ExtractKytheFacts(const IndexingFactNode& file_list,
   std::map<absl::string_view, absl::string_view, verible::StringViewCompare>
       file_path_reverse_map;
   for (const auto& file_entry : project) {
-    const VerilogSourceFile& source(file_entry.second);
+    const VerilogSourceFile& source(*file_entry.second);
     if (source.Status().ok()) {
       file_path_reverse_map[source.ResolvedPath()] = file_entry.first;
     }

--- a/verilog/tools/kythe/kythe_facts_extractor.h
+++ b/verilog/tools/kythe/kythe_facts_extractor.h
@@ -18,12 +18,18 @@
 #include <iosfwd>
 #include <set>
 
+#include "kythe/cxx/common/indexing/KytheOutputStream.h"
 #include "verilog/analysis/verilog_project.h"
 #include "verilog/tools/kythe/indexing_facts_tree.h"
 #include "verilog/tools/kythe/kythe_facts.h"
 
 namespace verilog {
 namespace kythe {
+
+// Populate the Kythe output stream with Kythe facts in proto format.
+void StreamKytheFactsProtoEntries(::kythe::KytheOutputStream* kythe_output,
+                                  const IndexingFactNode& file_list_facts_tree,
+                                  const VerilogProject& project);
 
 // Streamable printing class for kythe facts.
 // Usage: stream << KytheFactsPrinter(IndexingFactNode);


### PR DESCRIPTION
Virtual file: file for which we have the path & content, but not the physical file. This is required for running the indexing server