### PR TITLE
Upgrade to latest absl.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -5,9 +5,9 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 http_archive(
     name = "com_google_absl",
-    sha256 = "6622893ab117501fc23268a2936e0d46ee6cb0319dcf2275e33a708cd9634ea6",
-    strip_prefix = "abseil-cpp-20200923.3",
-    urls = ["https://github.com/abseil/abseil-cpp/archive/20200923.3.zip"],
+    sha256 = "11d6eea257cc9322cc49924cf9584dbe61922bfffe3e7c42e2bce3abc1694a1a",
+    strip_prefix = "abseil-cpp-20210324.0",
+    urls = ["https://github.com/abseil/abseil-cpp/archive/20210324.0.zip"],
 )
 
 http_archive(

--- a/verilog/CST/numbers.cc
+++ b/verilog/CST/numbers.cc
@@ -20,6 +20,7 @@
 #include <iterator>
 #include <string>
 
+#include "absl/strings/match.h"
 #include "absl/strings/string_view.h"
 #include "absl/strings/strip.h"
 #include "common/util/logging.h"
@@ -50,7 +51,7 @@ BasedNumber::BasedNumber(absl::string_view base_sign, absl::string_view digits)
   CHECK_EQ(base_sign.length(), 1);
   base = std::tolower(base_sign[0]);
   static const absl::string_view valid_bases("bdho");
-  if (valid_bases.find(base) == absl::string_view::npos) return;
+  if (!absl::StrContains(valid_bases, base)) return;
 
   // Filter out underscores.
   literal.reserve(digits.length());


### PR DESCRIPTION
And use absl::StrContains() with a char, that wasn't available
before.

Signed-off-by: Henner Zeller <h.zeller@acm.org>