### PR TITLE
verilog/analysis: Add ParsedVerilogSourceFile class

### DIFF
--- a/verilog/analysis/verilog_project.cc
+++ b/verilog/analysis/verilog_project.cc
@@ -91,6 +91,23 @@ absl::Status InMemoryVerilogSourceFile::Open() {
   return status_;
 }
 
+absl::Status ParsedVerilogSourceFile::Open() {
+  state_ = State::kOpened;
+  status_ = absl::OkStatus();
+  return status_;
+}
+
+absl::Status ParsedVerilogSourceFile::Parse() {
+  state_ = State::kParsed;
+  status_ = absl::OkStatus();
+  return status_;
+}
+
+const verible::TextStructureView* ParsedVerilogSourceFile::GetTextStructure()
+    const {
+  return text_structure_;
+}
+
 absl::StatusOr<VerilogSourceFile*> VerilogProject::OpenFile(
     absl::string_view referenced_filename, absl::string_view resolved_filename,
     absl::string_view corpus) {

--- a/verilog/analysis/verilog_project.h
+++ b/verilog/analysis/verilog_project.h
@@ -149,7 +149,7 @@ std::ostream& operator<<(std::ostream&, const VerilogSourceFile&);
 
 // An in-memory source file that doesn't require file-system access,
 // nor create temporary files.
-class InMemoryVerilogSourceFile : public VerilogSourceFile {
+class InMemoryVerilogSourceFile final : public VerilogSourceFile {
  public:
   // filename can be fake, it is not used to open any file.
   InMemoryVerilogSourceFile(absl::string_view filename,


### PR DESCRIPTION
This class is an extended version of InMemoryVerilogSourceFile.
It wraps a TextStructureView object and allows to skip loading and
parsing phase.