### PR TITLE
Improve error message when reading files.

### DIFF
--- a/common/util/file_util.cc
+++ b/common/util/file_util.cc
@@ -128,9 +128,9 @@ absl::Status UpwardFileSearch(absl::string_view start,
 absl::Status FileExists(const std::string &filename) {
   struct stat file_info;
   if (stat(filename.c_str(), &file_info) != 0) {
-    return absl::NotFoundError(absl::StrCat(filename, ": file does not exist"));
+    return absl::NotFoundError(absl::StrCat(filename, ": No such file."));
   }
-  if (S_ISREG(file_info.st_mode)) {
+  if (S_ISREG(file_info.st_mode) || S_ISFIFO(file_info.st_mode)) {
     return absl::OkStatus();
   }
   if (S_ISDIR(file_info.st_mode)) {

--- a/common/util/file_util.cc
+++ b/common/util/file_util.cc
@@ -127,11 +127,18 @@ absl::Status UpwardFileSearch(absl::string_view start,
 
 absl::Status FileExists(const std::string &filename) {
   struct stat file_info;
-  if (stat(filename.c_str(), &file_info) == 0 && S_ISREG(file_info.st_mode)) {
+  if (stat(filename.c_str(), &file_info) != 0) {
+    return absl::NotFoundError(absl::StrCat(filename, ": file does not exist"));
+  }
+  if (S_ISREG(file_info.st_mode)) {
     return absl::OkStatus();
   }
-  return absl::NotFoundError(
-      absl::StrCat("file : ", filename, " does not exist"));
+  if (S_ISDIR(file_info.st_mode)) {
+    return absl::InvalidArgumentError(
+        absl::StrCat(filename, ": is a directory, not a file"));
+  }
+  return absl::InvalidArgumentError(
+      absl::StrCat(filename, ": not a regular file."));
 }
 
 absl::Status GetContents(absl::string_view filename, std::string *content) {
@@ -143,7 +150,10 @@ absl::Status GetContents(absl::string_view filename, std::string *content) {
     stream = &std::cin;
     if (isatty(0)) std::cerr << "Enter input (terminate with Ctrl-D):\n";
   } else {
-    fs.open(std::string(filename).c_str());
+    const std::string filename_str = std::string(filename);
+    absl::Status usable_file = FileExists(filename_str);
+    if (!usable_file.ok()) return usable_file;  // Bail
+    fs.open(filename_str.c_str());
     stream = &fs;
   }
   if (!stream->good()) return CreateErrorStatusFromErrno("can't read");

--- a/common/util/file_util.h
+++ b/common/util/file_util.h
@@ -59,7 +59,7 @@ absl::string_view Stem(absl::string_view filename);
 absl::Status UpwardFileSearch(absl::string_view start,
                               absl::string_view filename, std::string* result);
 
-// Determines whether the given filename exists or not.
+// Determines whether the given filename exists and is a regular file.
 absl::Status FileExists(const std::string& filename);
 
 // Read file "filename" and store its content in "content"

--- a/common/util/file_util.h
+++ b/common/util/file_util.h
@@ -59,7 +59,7 @@ absl::string_view Stem(absl::string_view filename);
 absl::Status UpwardFileSearch(absl::string_view start,
                               absl::string_view filename, std::string* result);
 
-// Determines whether the given filename exists and is a regular file.
+// Determines whether the given filename exists and is a regular file or pipe.
 absl::Status FileExists(const std::string& filename);
 
 // Read file "filename" and store its content in "content"

--- a/common/util/file_util_test.cc
+++ b/common/util/file_util_test.cc
@@ -20,7 +20,10 @@
 
 #include "absl/status/status.h"
 #include "absl/strings/string_view.h"
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
+
+using testing::HasSubstr;
 
 #undef EXPECT_OK
 #define EXPECT_OK(value) EXPECT_TRUE((value).ok())
@@ -140,6 +143,13 @@ TEST(FileUtil, ScopedTestFileEmplace) {
   for (const auto& name : names) {
     EXPECT_FALSE(file::FileExists(name).ok());
   }
+}
+
+TEST(FileUtil, FileExistsDirectoryErrorMessage) {
+  absl::Status s;
+  s = file::FileExists(testing::TempDir());
+  EXPECT_FALSE(s.ok());
+  EXPECT_THAT(s.message(), HasSubstr("is a directory"));
 }
 
 TEST(FileUtil, ReadEmptyDirectory) {


### PR DESCRIPTION
Files that are directories are now reported in a readable
way.

Issues #743

Signed-off-by: Henner Zeller <h.zeller@acm.org>