### PR TITLE
Bump version number of used bazel to 4.0.0

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -19,7 +19,8 @@ test:linux --cxxopt=-std=c++17 --host_cxxopt=-std=c++17 --client_env=BAZEL_CXXOP
 
 build:macos --cxxopt=-std=c++17 --host_cxxopt=-std=c++17 --client_env=BAZEL_CXXOPTS=-std=c++17
 run:macos --cxxopt=-std=c++17 --host_cxxopt=-std=c++17 --client_env=BAZEL_CXXOPTS=-std=c++17
-test:macos --cxxopt=-std=c++17 --host_cxxopt=-std=c++17 --client_env=BAZEL_CXXOPTS=-std=c++17
+# https://github.com/bazelbuild/bazel/issues/4341#issuecomment-758361769
+test:macos --features=-supports_dynamic_linker --cxxopt=-std=c++17 --host_cxxopt=-std=c++17 --client_env=BAZEL_CXXOPTS=-std=c++17
 
 # Force the use clang-cl on Windows instead of MSVC. MSVC has some issues with
 # the codebase, so we focus the effort for now is to have a Windows Verible

--- a/.github/settings.sh
+++ b/.github/settings.sh
@@ -33,7 +33,7 @@ export BAZEL_CXXOPTS="-std=c++17"
 # Reduce the verbosity of progress output on CI
 export BAZEL_OPTS="-c opt --show_progress_rate_limit=10.0"
 
-export BAZEL_VERSION=3.7.0
+export BAZEL_VERSION=4.0.0
 # Without following environment variable set, Bazel updates itself to the
 # latest version
 export USE_BAZEL_VERSION=$BAZEL_VERSION


### PR DESCRIPTION
After a couple of months transition period, this is now
the dominant version of bazel used.

Signed-off-by: Henner Zeller <h.zeller@acm.org>