### PR TITLE
formatter: Fix constraint block expansion

### DIFF
--- a/verilog/formatting/formatter_test.cc
+++ b/verilog/formatting/formatter_test.cc
@@ -9240,8 +9240,24 @@ TEST(FormatterEndToEndTest, ConstraintExpressions) {
       {"constraint only_vec_instr_c {soft only_vec_instr == 0;}",
        "constraint only_vec_instr_c {soft only_vec_instr == 0;}\n"},
 
-      {"constraint\nnum_trans_c\n\n\n{\n\n\nnum_trans inside{[800:1000]};}",
-       "constraint num_trans_c {num_trans inside {[800 : 1000]};}\n"},
+      // constraint with brackets inside block item list
+      {"constraint\nnum_trans_c\n\n\n{num_trans inside{[800:1000]};}",
+       "constraint num_trans_c {\n"
+       "  num_trans inside {[800 : 1000]};\n"
+       "}\n"},
+
+      {"constraint data_size_c {data.size() inside {[1 : 65536]};}",
+       "constraint data_size_c {\n"
+       "  data.size() inside {[1 : 65536]};\n"
+       "}\n"},
+
+      {"constraint data_size_c {data.size() inside {[1 : 65536]};a==b;"
+       "num_trans inside{[800:1000]};}\n",
+       "constraint data_size_c {\n"
+       "  data.size() inside {[1 : 65536]};\n"
+       "  a == b;\n"
+       "  num_trans inside {[800 : 1000]};\n"
+       "}\n"},
 
       // if-vs-concatenation expression
       {"constraint c_operation{  if(fixed_operation_en){"
@@ -9279,6 +9295,15 @@ TEST(FormatterEndToEndTest, ConstraintExpressions) {
        "  aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa == "
        "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb;\n"
        "  ccccccccccccccccccccccc == dddddddddddddddddddddd;\n"
+       "}\n"},
+
+      // FIXME: Find-out why formatter is preserving those newlines in
+      // constraint block
+      {"constraint\nnum_trans_c\n\n\n{\n\n\nnum_trans inside{[800:1000]};}",
+       "constraint num_trans_c {\n"
+       "\n"
+       "\n"
+       "  num_trans inside {[800 : 1000]};\n"
        "}\n"},
   };
   FormatStyle style;

--- a/verilog/formatting/tree_unwrapper.cc
+++ b/verilog/formatting/tree_unwrapper.cc
@@ -1680,6 +1680,17 @@ void TreeUnwrapper::ReshapeTokenPartitions(
         if (PartitionIsCloseBrace(last)) {
           verible::MergeLeafIntoPreviousLeaf(&last);
         }
+      } else if (partition.Children().size() == 3) {
+        // Propagate partition expansion on flattened partitions
+        const auto& block_partition = partition.Children()[1];
+        const auto block_partition_policy =
+            block_partition.Value().PartitionPolicy();
+
+        if (block_partition.Children().size() == 0 &&
+            block_partition_policy == PartitionPolicyEnum::kAlwaysExpand) {
+          auto& uwline = partition.Value();
+          uwline.SetPartitionPolicy(PartitionPolicyEnum::kAlwaysExpand);
+        }
       }
       break;
     }


### PR DESCRIPTION
Fix expansion of constraint declarations with flattened constraint blocks:
```
{ ([<auto>], policy: always-expand) @{}
  { ([<auto>], policy: fit-else-expand) @{25}, (origin: "constraint ... : 1000]};}")
    { ([constraint num_trans_c {], policy: fit-else-expand) }
    { (>>[num_trans inside { [ 800 : 1000 ] } ;], policy: always-expand, (origin: "num_trans i...0 : 1000]};")) }
    { ([}], policy: uninitialized) }
  }
}
```
by propagation of partition policy:
```
{ ([<auto>], policy: always-expand) @{}
  { ([<auto>], policy: always-expand) @{25}, (origin: "constraint ... : 1000]};}")
    { ([constraint num_trans_c {], policy: fit-else-expand) }
    { (>>[num_trans inside { [ 800 : 1000 ] } ;], policy: always-expand, (origin: "num_trans i...0 : 1000]};")) }
    { ([}], policy: uninitialized) }
  }
}
```