### PR TITLE
[kythe] Remove the dependency on linked Kythe verification binary and

### DIFF
--- a/.github/bin/verify-kythe-extraction.sh
+++ b/.github/bin/verify-kythe-extraction.sh
@@ -15,9 +15,8 @@
 
 set -e
 
-KYTHE_DIRNAME="kythe-${KYTHE_VERSION}"
-KYTHE_DIR_ABS="$(readlink -f "kythe-bin/${KYTHE_DIRNAME}")"
-
 # Verify that Verilog Kythe indexer produces the expected Kythe indexing facts.
 # Note: verifier tool path assumes it came with the release pre-built.
+KYTHE_DIRNAME="kythe-${KYTHE_VERSION}"
+KYTHE_DIR_ABS="$(readlink -f "kythe-bin/${KYTHE_DIRNAME}")"
 bazel test --test_arg="$KYTHE_DIR_ABS/tools/verifier" verilog/tools/kythe:verification_test

--- a/.github/bin/verify-kythe-extraction.sh
+++ b/.github/bin/verify-kythe-extraction.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Copyright 2020 The Verible Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+KYTHE_DIRNAME="kythe-${KYTHE_VERSION}"
+KYTHE_DIR_ABS="$(readlink -f "kythe-bin/${KYTHE_DIRNAME}")"
+
+# Verify that Verilog Kythe indexer produces the expected Kythe indexing facts.
+# Note: verifier tool path assumes it came with the release pre-built.
+bazel test --test_arg="$KYTHE_DIR_ABS/tools/verifier" verilog/tools/kythe:verification_test

--- a/.github/workflows/verible-ci.yml
+++ b/.github/workflows/verible-ci.yml
@@ -127,6 +127,7 @@ jobs:
     - name: Run Kythe
       run: |
         source ./.github/settings.sh
+        ./.github/bin/verify-kythe-extraction.sh
         ./.github/bin/run-kythe.sh
 
     - name: 📤 Upload Kythe output

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -82,27 +82,32 @@ all_content = """filegroup(name = "all", srcs = glob(["**"]), visibility = ["//v
 
 http_archive(
     name = "rules_m4",
-    urls = ["https://github.com/jmillikin/rules_m4/releases/download/v0.2/rules_m4-v0.2.tar.xz"],
     sha256 = "c67fa9891bb19e9e6c1050003ba648d35383b8cb3c9572f397ad24040fb7f0eb",
+    urls = ["https://github.com/jmillikin/rules_m4/releases/download/v0.2/rules_m4-v0.2.tar.xz"],
 )
 
 load("@rules_m4//m4:m4.bzl", "m4_register_toolchains")
+
 m4_register_toolchains()
 
 http_archive(
     name = "rules_flex",
-    urls = ["https://github.com/jmillikin/rules_flex/releases/download/v0.2/rules_flex-v0.2.tar.xz"],
     sha256 = "f1685512937c2e33a7ebc4d5c6cf38ed282c2ce3b7a9c7c0b542db7e5db59d52",
+    urls = ["https://github.com/jmillikin/rules_flex/releases/download/v0.2/rules_flex-v0.2.tar.xz"],
 )
+
 load("@rules_flex//flex:flex.bzl", "flex_register_toolchains")
+
 flex_register_toolchains()
 
 http_archive(
     name = "rules_bison",
-    urls = ["https://github.com/jmillikin/rules_bison/releases/download/v0.2/rules_bison-v0.2.tar.xz"],
     sha256 = "6ee9b396f450ca9753c3283944f9a6015b61227f8386893fb59d593455141481",
+    urls = ["https://github.com/jmillikin/rules_bison/releases/download/v0.2/rules_bison-v0.2.tar.xz"],
 )
+
 load("@rules_bison//bison:bison.bzl", "bison_register_toolchains")
+
 bison_register_toolchains()
 
 http_archive(
@@ -112,18 +117,6 @@ http_archive(
     urls = [
         "https://github.com/bazelbuild/bazel-toolchains/releases/download/3.4.0/bazel-toolchains-3.4.0.tar.gz",
         "https://mirror.bazel.build/github.com/bazelbuild/bazel-toolchains/releases/download/3.4.0/bazel-toolchains-3.4.0.tar.gz",
-    ],
-)
-
-# TODO(ikr): This is a huge dependency pulled in only for bash unit test
-# framework. Find a smaller alternative that works both internally and
-# externally.
-http_archive(
-    name = "io_bazel",
-    sha256 = "4822ac0f365210932803d324d1b0e08dbd451242720017c5b7f70716c2e3e059",
-    strip_prefix = "bazel-3.7.0",
-    urls = [
-        "https://github.com/bazelbuild/bazel/archive/3.7.0.tar.gz",
     ],
 )
 
@@ -158,8 +151,8 @@ kythe_dependencies()
 
 http_archive(
     name = "jsoncpp_git",
-    sha256 = "77a402fb577b2e0e5d0bdc1cf9c65278915cdb25171e3452c68b6da8a561f8f0",
     build_file = "//bazel:jsoncpp.BUILD",
+    sha256 = "77a402fb577b2e0e5d0bdc1cf9c65278915cdb25171e3452c68b6da8a561f8f0",
     strip_prefix = "jsoncpp-1.9.2",
     urls = [
         "https://github.com/open-source-parsers/jsoncpp/archive/1.9.2.tar.gz",
@@ -168,8 +161,8 @@ http_archive(
 
 http_archive(
     name = "python_six",
-    sha256 = "30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259",
     build_file = "//bazel:python_six.BUILD",
+    sha256 = "30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259",
     strip_prefix = "six-1.15.0",
     urls = [
         "https://files.pythonhosted.org/packages/6b/34/415834bfdafca3c5f451532e8a8d9ba89a21c9743a0c59fbd0205c7f9426/six-1.15.0.tar.gz",
@@ -178,8 +171,8 @@ http_archive(
 
 http_archive(
     name = "python_anytree",
-    sha256 = "79ee0cc74456950003287b0b5c7b76b7d09435563a31d9e553da484325043e1f",
     build_file = "//bazel:python_anytree.BUILD",
+    sha256 = "79ee0cc74456950003287b0b5c7b76b7d09435563a31d9e553da484325043e1f",
     strip_prefix = "anytree-2.8.0",
     urls = [
         "https://github.com/c0fec0de/anytree/archive/2.8.0.tar.gz",

--- a/verilog/tools/kythe/BUILD
+++ b/verilog/tools/kythe/BUILD
@@ -236,11 +236,9 @@ sh_test(
         "testdata/**",
     ]) + [
         ":verible-verilog-kythe-extractor",
-        "@io_kythe//kythe/cxx/verifier",
     ],
-    shard_count = 4,
+    tags = ["manual"],
     deps = [
         "@bazel_tools//tools/bash/runfiles",
-        "@io_bazel//src/test/shell:bashunit",
     ],
 )

--- a/verilog/tools/kythe/verification_test.sh
+++ b/verilog/tools/kythe/verification_test.sh
@@ -29,11 +29,6 @@ else
 fi
 # --- end runfiles.bash initialization ---
 
-source "$(rlocation "io_bazel/src/test/shell/unittest.bash")" ||
-  {
-    echo "unittest.bash not found!" >&2
-    exit 1
-  }
 TESTS_DIR="$(rlocation "com_google_verible/verilog/tools/kythe/testdata")" ||
   {
     echo "Can't load the test data!" >&2
@@ -44,91 +39,102 @@ VERIBLE_EXTRACTOR_BIN="$(rlocation "com_google_verible/verilog/tools/kythe/verib
     echo "Can't load the extractor binary!" >&2
     exit 1
   }
-KYTHE_VERIFIER_BIN="$(rlocation "io_kythe/kythe/cxx/verifier/verifier")" ||
+KYTHE_VERIFIER_BIN="$(rlocation "$1")" ||
   {
     echo "Can't load the verifier binary!" >&2
     exit 1
   }
 
-function test_single_files() {
-  test_count=0
-  for verilog_file in $(ls -d "${TESTS_DIR}"/*); do
-    if [[ -d "${verilog_file}" ]]; then
-      continue
-    fi
-    test_filename="$(basename "${verilog_file}")"
-    test_dir="${TEST_TMPDIR}/${test_filename%.*}"
-    mkdir "${test_dir}"
-    cp "${verilog_file}" "${test_dir}"
-    filelist_path="${test_dir}/filelist"
-    echo "${test_filename}" > "${filelist_path}"
-
-    echo "Running Kythe verification test for ${test_filename}" >> "$TEST_log"
-    "${VERIBLE_EXTRACTOR_BIN}" --file_list_path "${filelist_path}" --file_list_root "${test_dir}" --print_kythe_facts proto  > "${test_dir}/entries" ||
-      fail "Failed to extract Kythe facts"
-    echo "Extracted.  Now verifying." >> "$TEST_log"
-    cat "${test_dir}/entries" | "${KYTHE_VERIFIER_BIN}" --nocheck_for_singletons "${test_dir}/${test_filename}" >> "$TEST_log" ||
-      fail "Verification failed for ${test_filename}"
-    test_count=$((${test_count} + 1))
-  done
-  [[ ${test_count} -gt 0 ]] || fail "No tests are executed!"
+function fail {
+  echo "[ERROR] $1"
+  exit 1
 }
 
-function test_multi_files() {
-  test_case_dir="${TESTS_DIR}/multi_file_test"
-  test_name="$(basename "${test_case_dir}")"
-  test_dir="${TEST_TMPDIR}/${test_name}"
-  mkdir "${test_dir}"
-  cp "${test_case_dir}"/* "${test_dir}/"
+function new_test {
+  echo "=== Test '$1'."
+  rm -rf "${TEST_TMPDIR}/*"
+}
+
+################################################################################
+new_test "single files"
+test_count=0
+for verilog_file in $(ls -d "${TESTS_DIR}"/*); do
+  if [[ -d "${verilog_file}" ]]; then
+    continue
+  fi
+  test_filename="$(basename "${verilog_file}")"
+  test_dir="${TEST_TMPDIR}/${test_filename%.*}"
+  mkdir -p "${test_dir}"
+  cp "${verilog_file}" "${test_dir}"
   filelist_path="${test_dir}/filelist"
-  ls "${test_case_dir}" > "${filelist_path}"
-  # Note: file_list.txt from the original test_case_dir seems unused.
-  echo "Running Kythe verification 'multi file' test for ${test_name}" >> "$TEST_log"
+  echo "${test_filename}" > "${filelist_path}"
+
+  echo "Running Kythe verification test for ${test_filename}"
   "${VERIBLE_EXTRACTOR_BIN}" --file_list_path "${filelist_path}" --file_list_root "${test_dir}" --print_kythe_facts proto  > "${test_dir}/entries" ||
-      fail "Failed to extract Kythe facts"
-  echo "Extracted.  Now verifying." >> "$TEST_log"
-  cat "${test_dir}/entries" | "${KYTHE_VERIFIER_BIN}" "${test_dir}"/*.sv >> "$TEST_log" ||
-    fail "Verification failed for ${test_name}"
-}
+    fail "Failed to extract Kythe facts"
+  echo "Extracted.  Now verifying."
+  cat "${test_dir}/entries" | "${KYTHE_VERIFIER_BIN}" --nocheck_for_singletons "${test_dir}/${test_filename}" ||
+    fail "Verification failed for ${test_filename}"
+  test_count=$((${test_count} + 1))
+done
+[[ ${test_count} -gt 0 ]] || fail "No tests are executed!"
 
-function test_multi_files_with_include() {
-  test_case_dir="${TESTS_DIR}/include_file_test"
-  test_name="$(basename "${test_case_dir}")"
-  test_dir="${TEST_TMPDIR}/${test_name}"
-  mkdir "${test_dir}"
-  cp "${test_case_dir}"/* "${test_dir}/"
-  filelist_path="${test_dir}/file_list.txt"
-  echo "Running Kythe verification 'multi file with include' test for ${test_name}" >> "$TEST_log"
-  "${VERIBLE_EXTRACTOR_BIN}" --include_dir_paths "${test_dir}" --file_list_path "${filelist_path}" --file_list_root "${test_dir}" --print_kythe_facts proto > "${test_dir}/entries" ||
-      fail "Failed to extract Kythe facts"
-  echo "Extracted.  Now verifying." >> "$TEST_log"
-  cat "${test_dir}/entries" | "${KYTHE_VERIFIER_BIN}" "${test_dir}"/*.sv* >> "$TEST_log" ||
-    fail "Verification failed for ${test_name}"
-}
 
-function test_multi_files_with_include_dir() {
-  test_case_dir="${TESTS_DIR}/include_with_dir_test"
-  test_name="$(basename "${test_case_dir}")"
-  test_dir="${TEST_TMPDIR}/${test_name}"
-  mkdir "${test_dir}"
-  cp -r "${test_case_dir}"/* "${test_dir}/"
-  filelist_path="${test_dir}/file_list.txt"
+################################################################################
+new_test "multi files"
+test_case_dir="${TESTS_DIR}/multi_file_test"
+test_name="$(basename "${test_case_dir}")"
+test_dir="${TEST_TMPDIR}/${test_name}"
+mkdir -p "${test_dir}"
+cp "${test_case_dir}"/* "${test_dir}/"
+filelist_path="${test_dir}/filelist"
+ls "${test_case_dir}" > "${filelist_path}"
+# Note: file_list.txt from the original test_case_dir seems unused.
+echo "Running Kythe verification 'multi file' test for ${test_name}"
+"${VERIBLE_EXTRACTOR_BIN}" --file_list_path "${filelist_path}" --file_list_root "${test_dir}" --print_kythe_facts proto  > "${test_dir}/entries" ||
+    fail "Failed to extract Kythe facts"
+echo "Extracted.  Now verifying."
+cat "${test_dir}/entries" | "${KYTHE_VERIFIER_BIN}" "${test_dir}"/*.sv ||
+  fail "Verification failed for ${test_name}"
 
-  first_included="${TESTS_DIR}/include_file_test"
-  first_included_name="$(basename "${first_included}")"
-  first_include_dir="${TEST_TMPDIR}/${first_included_name}"
-  mkdir "${first_include_dir}"
-  cp "${first_included}"/* "${first_include_dir}/"
 
-  second_include_dir="${test_dir}/include_dir"
-  VERILOG_INCLUDE_DIR_TEST_FILES="${test_dir}/*.sv ${first_include_dir}/A.svh ${first_include_dir}/B.svh ${second_include_dir}/*.svh"
+################################################################################
+new_test "multi files with include"
+test_case_dir="${TESTS_DIR}/include_file_test"
+test_name="$(basename "${test_case_dir}")"
+test_dir="${TEST_TMPDIR}/${test_name}"
+mkdir -p "${test_dir}"
+cp "${test_case_dir}"/* "${test_dir}/"
+filelist_path="${test_dir}/file_list.txt"
+echo "Running Kythe verification 'multi file with include' test for ${test_name}"
+"${VERIBLE_EXTRACTOR_BIN}" --include_dir_paths "${test_dir}" --file_list_path "${filelist_path}" --file_list_root "${test_dir}" --print_kythe_facts proto > "${test_dir}/entries" ||
+    fail "Failed to extract Kythe facts"
+echo "Extracted.  Now verifying."
+cat "${test_dir}/entries" | "${KYTHE_VERIFIER_BIN}" "${test_dir}"/*.sv* ||
+  fail "Verification failed for ${test_name}"
 
-  echo "Running Kythe verification 'multi file with include dir' test for ${test_name}" >> "$TEST_log"
-  "${VERIBLE_EXTRACTOR_BIN}" --include_dir_paths "${first_include_dir},${second_include_dir}" --file_list_path "${filelist_path}" --file_list_root "${test_dir}" --print_kythe_facts proto > "${test_dir}/entries" ||
-      fail "Failed to extract Kythe facts"
-  echo "Extracted.  Now verifying." >> "$TEST_log"
-  cat "${test_dir}/entries" | "${KYTHE_VERIFIER_BIN}" ${VERILOG_INCLUDE_DIR_TEST_FILES} >> "$TEST_log" ||
-    fail "Verification failed for ${test_name}"
-}
 
-run_suite "kythe verification tests"
+################################################################################
+new_test "multi files with include dir"
+test_case_dir="${TESTS_DIR}/include_with_dir_test"
+test_name="$(basename "${test_case_dir}")"
+test_dir="${TEST_TMPDIR}/${test_name}"
+mkdir -p "${test_dir}"
+cp -r "${test_case_dir}"/* "${test_dir}/"
+filelist_path="${test_dir}/file_list.txt"
+
+first_included="${TESTS_DIR}/include_file_test"
+first_included_name="$(basename "${first_included}")"
+first_include_dir="${TEST_TMPDIR}/${first_included_name}"
+mkdir -p "${first_include_dir}"
+cp "${first_included}"/* "${first_include_dir}/"
+
+second_include_dir="${test_dir}/include_dir"
+VERILOG_INCLUDE_DIR_TEST_FILES="${test_dir}/*.sv ${first_include_dir}/A.svh ${first_include_dir}/B.svh ${second_include_dir}/*.svh"
+
+echo "Running Kythe verification 'multi file with include dir' test for ${test_name}"
+"${VERIBLE_EXTRACTOR_BIN}" --include_dir_paths "${first_include_dir},${second_include_dir}" --file_list_path "${filelist_path}" --file_list_root "${test_dir}" --print_kythe_facts proto > "${test_dir}/entries" ||
+    fail "Failed to extract Kythe facts"
+echo "Extracted.  Now verifying."
+cat "${test_dir}/entries" | "${KYTHE_VERIFIER_BIN}" ${VERILOG_INCLUDE_DIR_TEST_FILES} ||
+  fail "Verification failed for ${test_name}"


### PR DESCRIPTION
io_bazel.

Instead of linking the Kythe verification binary, use precompiled one
from Github Workflow.
Remove Kythe verification test from the general list of tests and
introduce it as an explicit Github workflow step.

Replace bash unit test library from io_bazel with poor man's simple test
suite (remove large dependency -- if we need bash xUnit test framework,
there are smaller ones available).

Related to #760