### PR TITLE
Avoid unnecessary copy in range loop.

### DIFF
--- a/verilog/CST/identifier_test.cc
+++ b/verilog/CST/identifier_test.cc
@@ -50,7 +50,7 @@ TEST(IdIsQualifiedTest, VariousIds) {
       {"task goo(); endtask", 0 /* goo */},
       {"task fff::goo(); endtask", 1 /* fff::goo */},
   };
-  for (const auto test : kTestCases) {
+  for (const auto& test : kTestCases) {
     VerilogAnalyzer analyzer(test.first, "");
     ASSERT_OK(analyzer.Analyze());
     const auto& root = analyzer.Data().SyntaxTree();

--- a/verilog/CST/tasks_test.cc
+++ b/verilog/CST/tasks_test.cc
@@ -331,7 +331,7 @@ TEST(GetTaskIdTest, QualifiedIds) {
           for (const auto& decl : task_declarations) {
             const auto& task_node = verible::SymbolCastToNode(*decl.match);
             const auto* task_id = GetTaskId(task_node);
-            for (const auto id : FindAllQualifiedIds(*task_id)) {
+            for (const auto& id : FindAllQualifiedIds(*task_id)) {
               ids.push_back(id);
             }
           }


### PR DESCRIPTION
Signed-off-by: Henner Zeller <h.zeller@acm.org>