### PR TITLE
Rename 'script.sh' to 'build-and-test.sh'

### DIFF
--- a/.github/bin/build-and-test.sh
+++ b/.github/bin/build-and-test.sh
@@ -62,7 +62,7 @@ compile|clean)
     ;;
 
 *)
-    echo "script.sh: Unknown mode $MODE"
+    echo "$0: Unknown value in MODE environment variable: $MODE"
     exit 1
     ;;
 esac

--- a/.github/workflows/verible-ci.yml
+++ b/.github/workflows/verible-ci.yml
@@ -84,7 +84,7 @@ jobs:
         ./.github/bin/install-python.sh
 
     - name: ${{ matrix.env.mode }} Verible
-      run: ./.github/bin/script.sh
+      run: ./.github/bin/build-and-test.sh
 
     - name: Set up things for GitHub Pages deployment
       if: matrix.mode == 'compile'


### PR DESCRIPTION
script.sh was from a very early stage of our github actions
when this was all we did. These days, the name does not make
sense anymore.

Signed-off-by: Henner Zeller <h.zeller@acm.org>