### PR TITLE
Remove unused use_parser_directive_comments VerilogAnalyzer option.

### DIFF
--- a/verilog/analysis/verilog_analyzer.h
+++ b/verilog/analysis/verilog_analyzer.h
@@ -31,11 +31,9 @@ namespace verilog {
 // VerilogAnalyzer analyzes Verilog and SystemVerilog code syntax.
 class VerilogAnalyzer : public verible::FileAnalyzer {
  public:
-  VerilogAnalyzer(absl::string_view text, absl::string_view name,
-                  bool use_parser_directive_comments = true)
+  VerilogAnalyzer(absl::string_view text, absl::string_view name)
       : verible::FileAnalyzer(text, name),
-        max_used_stack_size_(0),
-        use_parser_directive_comments_(use_parser_directive_comments) {}
+        max_used_stack_size_(0) {}
 
   // Lex-es the input text into tokens.
   absl::Status Tokenize() override;
@@ -98,9 +96,6 @@ class VerilogAnalyzer : public verible::FileAnalyzer {
 
   // Preprocessor.
   VerilogPreprocessData preprocessor_data_;
-
-  // If true, let comments control the parsing mode.
-  bool use_parser_directive_comments_ = true;
 
   // Status of lexing.
   absl::Status lex_status_;

--- a/verilog/analysis/verilog_excerpt_parse.cc
+++ b/verilog/analysis/verilog_excerpt_parse.cc
@@ -48,9 +48,8 @@ static std::unique_ptr<VerilogAnalyzer> AnalyzeVerilogConstruct(
   const std::string analyze_text = absl::StrCat(prolog, text, epilog);
   // Disable parser directive comments because a specific parser
   // is already being selected.
-  auto analyzer_ptr = absl::make_unique<VerilogAnalyzer>(
-      analyze_text, filename,
-      /* use_parser_directive_comments_ */ false);
+  auto analyzer_ptr =
+      absl::make_unique<VerilogAnalyzer>(analyze_text, filename);
 
   if (!ABSL_DIE_IF_NULL(analyzer_ptr)->Analyze().ok()) {
     VLOG(2) << __FUNCTION__ << ": Analyze() failed.  code:\n" << analyze_text;

--- a/verilog/parser/verilog_lexical_context_test.cc
+++ b/verilog/parser/verilog_lexical_context_test.cc
@@ -97,7 +97,7 @@ void ExpectStateMachineTokenSequence(
 
 // Tests for null state of state machine.
 TEST(KeywordLabelStateMachineTest, NoKeywords) {
-  VerilogAnalyzer analyzer("1, 2; 3;", "", false);
+  VerilogAnalyzer analyzer("1, 2; 3;", "");
   EXPECT_OK(analyzer.Tokenize());
   analyzer.FilterTokensForSyntaxTree();
   const auto& tokens_view = analyzer.Data().GetTokenStreamView();
@@ -116,8 +116,7 @@ TEST(KeywordLabelStateMachineTest, NoKeywords) {
 
 // Test for state transitions of state machine, no labels.
 TEST(KeywordLabelStateMachineTest, KeywordsWithoutLabels) {
-  VerilogAnalyzer analyzer("1 2 begin end begin end 3 begin 4 5 end 6", "",
-                           false);
+  VerilogAnalyzer analyzer("1 2 begin end begin end 3 begin 4 5 end 6", "");
   const std::array<bool, 13> expect_item_may_start{
       {false, false, true, true, true, true, true, true, true, false, true,
        true, false}};
@@ -141,7 +140,7 @@ TEST(KeywordLabelStateMachineTest, KeywordsWithoutLabels) {
 
 // Test for state transitions of state machine, with labels.
 TEST(KeywordLabelStateMachineTest, KeywordsWithLabels) {
-  VerilogAnalyzer analyzer("1 begin:a end:a begin:b end:b 2", "", false);
+  VerilogAnalyzer analyzer("1 begin:a end:a begin:b end:b 2", "");
   const std::array<bool, 15> expect_item_may_start{
       {false, true, false, true, true, false, true, true, false, true, true,
        false, true, false, false}};
@@ -165,7 +164,7 @@ TEST(KeywordLabelStateMachineTest, KeywordsWithLabels) {
 
 // Test for state transitions of state machine, with some labels, some items.
 TEST(KeywordLabelStateMachineTest, ItemsInsideBlocks) {
-  VerilogAnalyzer analyzer("begin:a 1 end:a 2 begin 3 end", "", false);
+  VerilogAnalyzer analyzer("begin:a 1 end:a 2 begin 3 end", "");
   const std::array<bool, 12> expect_item_may_start{{true, false, true, false,
                                                     true, false, true, false,
                                                     true, true, true, true}};
@@ -316,7 +315,7 @@ TEST_F(LastSemicolonStateMachineTest, LifeCycleFinalSemicolon) {
 struct StateMachineTestBase : public ::testing::Test {
   // Lexes code and initializes token_iter to point to the first token.
   void Tokenize(const std::string& code) {
-    analyzer = absl::make_unique<VerilogAnalyzer>(code, "", false);
+    analyzer = absl::make_unique<VerilogAnalyzer>(code, "");
     EXPECT_OK(analyzer->Tokenize());
     analyzer->FilterTokensForSyntaxTree();
     token_iter = analyzer->Data().GetTokenStreamView().cbegin();
@@ -1214,7 +1213,7 @@ class LexicalContextTest : public ::testing::Test, public LexicalContext {
 
   // Lexes code and initializes token_iter to point to the first token.
   void Tokenize(const std::string& code) {
-    analyzer_ = absl::make_unique<VerilogAnalyzer>(code, "", false);
+    analyzer_ = absl::make_unique<VerilogAnalyzer>(code, "");
     EXPECT_OK(analyzer_->Tokenize());
     analyzer_->FilterTokensForSyntaxTree();
     token_refs_ = analyzer_->MutableData().MakeTokenStreamReferenceView();


### PR DESCRIPTION
It was set and never used. Remove for now to reduce clutter; if
the need ever arises to have something like that, we should
implement it then.

Signed-off-by: Henner Zeller <h.zeller@acm.org>