### PR TITLE
Added support for win_flex_bison on Windows

### DIFF
--- a/.github/workflows/windows-compile.yml
+++ b/.github/workflows/windows-compile.yml
@@ -28,8 +28,8 @@ jobs:
     # fully compiled on Windows (yet!)
     - name: Build flex/bison files
       run: |
-        $env:FLEX = 'C:/ProgramData/Chocolatey/lib/winflexbison/tools/win_flex.exe'
-        $env:BISON = 'C:/ProgramData/Chocolatey/lib/winflexbison/tools/win_bison.exe'
+        $env:FLEX = ($env:ChocolateyInstall + '/lib/winflexbison/tools/win_flex.exe') -replace '\\', '/'
+        $env:BISON = ($env:ChocolateyInstall + '/lib/winflexbison/tools/win_bison.exe') -replace '\\', '/'
         bazel build //common/analysis:command_file_lex
         bazel build //verilog/parser:verilog_y
         bazel build //verilog/parser:verilog_lex

--- a/.github/workflows/windows-compile.yml
+++ b/.github/workflows/windows-compile.yml
@@ -24,6 +24,8 @@ jobs:
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
+    # Only check flex/bison targets at the moment, since Verible cannot be
+    # fully compiled on Windows (yet!)
     - name: Build flex/bison files
       run: |
         $env:FLEX = 'C:/ProgramData/Chocolatey/lib/winflexbison/tools/win_flex.exe'

--- a/.github/workflows/windows-compile.yml
+++ b/.github/workflows/windows-compile.yml
@@ -1,0 +1,33 @@
+# Platform specific Windows test. See verible-ci for main continuous integration.
+name: windows-compile
+
+on:
+  push:
+    branches:
+    - master
+    - main
+  pull_request:
+    branches:
+    - master
+    - main
+
+jobs:
+  WindowsBuild:
+    runs-on: windows-latest
+    steps:
+    # Need winflexbison for Kythe, bazel fails if environment
+    # FLEX/BISON is not set to a valid program
+    - name: Install deps
+      run: |
+        choco install winflexbison
+    - name: Checkout code
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Build flex/bison files
+      run: |
+        $env:FLEX = 'C:/ProgramData/Chocolatey/lib/winflexbison/tools/win_flex.exe'
+        $env:BISON = 'C:/ProgramData/Chocolatey/lib/winflexbison/tools/win_bison.exe'
+        bazel build //common/analysis:command_file_lex
+        bazel build //verilog/parser:verilog_y
+        bazel build //verilog/parser:verilog_lex

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -78,7 +78,15 @@ load("@com_github_google_rules_install//:setup.bzl", "install_rules_setup")
 
 install_rules_setup()
 
-all_content = """filegroup(name = "all", srcs = glob(["**"]), visibility = ["//visibility:public"])"""
+# Need to load before rules_flex/rules_bison to make sure
+# win_flex_bison is the chosen toolchain on Windows
+load("//bazel:win_flex_bison.bzl", "win_flex_configure")
+
+win_flex_configure(
+    name = "win_flex_bison",
+    sha256 = "39c6086ce211d5415500acc5ed2d8939861ca1696aee48909c7f6daf5122b505",
+    url = "https://github.com/lexxmark/winflexbison/releases/download/v2.5.24/win_flex_bison-2.5.24.zip",
+)
 
 http_archive(
     name = "rules_m4",

--- a/bazel/bison.bzl
+++ b/bazel/bison.bzl
@@ -1,5 +1,5 @@
 # -*- Python -*-
-# Copyright 2017-2020 The Verible Authors.
+# Copyright 2017-2021 The Verible Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -30,9 +30,15 @@ def genyacc(
         name = name,
         srcs = [src],
         outs = [header_out, source_out] + extra_outs,
-        cmd = "M4=$(M4) $(BISON) --defines=$(location " + header_out + ") --output-file=$(location " + source_out + ") " + " ".join(extra_options) + " $<",
-        toolchains = [
-            "@rules_bison//bison:current_bison_toolchain",
-            "@rules_m4//m4:current_m4_toolchain",
-        ],
+        cmd = select({
+            "@platforms//os:windows": "$(BISON) --defines=$(location " + header_out + ") --output-file=$(location " + source_out + ") " + " ".join(extra_options) + " $<",
+            "//conditions:default": "M4=$(M4) $(BISON) --defines=$(location " + header_out + ") --output-file=$(location " + source_out + ") " + " ".join(extra_options) + " $<",
+        }),
+        toolchains = select({
+            "@platforms//os:windows": ["@rules_bison//bison:current_bison_toolchain"],
+            "//conditions:default": [
+                "@rules_bison//bison:current_bison_toolchain",
+                "@rules_m4//m4:current_m4_toolchain",
+            ],
+        }),
     )

--- a/bazel/flex.bzl
+++ b/bazel/flex.bzl
@@ -1,5 +1,5 @@
 # -*- Python -*-
-# Copyright 2017-2020 The Verible Authors.
+# Copyright 2017-2021 The Verible Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -24,9 +24,15 @@ def genlex(name, src, out):
         name = name,
         srcs = [src],
         outs = [out],
-        cmd = "M4=$(M4) $(FLEX) --outfile=$@ $<",
-        toolchains = [
-            "@rules_flex//flex:current_flex_toolchain",
-            "@rules_m4//m4:current_m4_toolchain",
-        ],
+        cmd = select({
+            "@platforms//os:windows": "$(FLEX) --outfile=$@ $<",
+            "//conditions:default": "M4=$(M4) $(FLEX) --outfile=$@ $<",
+        }),
+        toolchains = select({
+            "@platforms//os:windows": ["@rules_flex//flex:current_flex_toolchain"],
+            "//conditions:default": [
+                "@rules_flex//flex:current_flex_toolchain",
+                "@rules_m4//m4:current_m4_toolchain",
+            ],
+        }),
     )

--- a/bazel/win_flex_bison.BUILD
+++ b/bazel/win_flex_bison.BUILD
@@ -1,0 +1,48 @@
+load("@com_google_verible//bazel:win_flex_bison.bzl", "win_bison_toolchain", "win_flex_toolchain")
+
+filegroup(
+    name = "win_flex",
+    srcs = ["win_flex.exe"],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "flex_lexer_h",
+    srcs = ["FlexLexer.h"],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "win_bison",
+    srcs = ["win_bison.exe"],
+    visibility = ["//visibility:public"],
+)
+
+win_flex_toolchain(
+    name = "flex",
+    flex_lexer_h = ":flex_lexer_h",
+    flex_tool = ":win_flex",
+    visibility = ["//visibility:public"],
+)
+
+toolchain(
+    name = "flex_toolchain",
+    exec_compatible_with = ["@platforms//os:windows"],
+    target_compatible_with = ["@platforms//os:windows"],
+    toolchain = ":flex",
+    toolchain_type = "@rules_flex//flex:toolchain_type",
+)
+
+win_bison_toolchain(
+    name = "bison",
+    bison_tool = ":win_bison",
+    visibility = ["//visibility:public"],
+)
+
+toolchain(
+    name = "bison_toolchain",
+    exec_compatible_with = ["@platforms//os:windows"],
+    target_compatible_with = ["@platforms//os:windows"],
+    toolchain = ":bison",
+    toolchain_type = "@rules_bison//bison:toolchain_type",
+)

--- a/bazel/win_flex_bison.bzl
+++ b/bazel/win_flex_bison.bzl
@@ -1,0 +1,119 @@
+# -*- Python -*-
+# Copyright 2021 The Verible Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Bazel rule to run flex/bison on Windows
+"""
+
+# buildifier: disable=provider-params
+FlexToolchainInfo = provider(
+    fields = [
+        "all_files",
+        "flex_tool",
+        "flex_lexer_h",
+    ],
+)
+
+def _win_flex_toolchain_impl(ctx):
+    flex_runfiles = ctx.attr.flex_tool[DefaultInfo].default_runfiles.files
+
+    return platform_common.ToolchainInfo(
+        flex_toolchain = FlexToolchainInfo(
+            all_files = depset(
+                direct = [ctx.executable.flex_tool],
+                transitive = [flex_runfiles],
+            ),
+            flex_tool = ctx.attr.flex_tool.files_to_run,
+            flex_lexer_h = ctx.file.flex_lexer_h,
+        ),
+    )
+
+win_flex_toolchain = rule(
+    _win_flex_toolchain_impl,
+    attrs = {
+        "flex_tool": attr.label(
+            mandatory = True,
+            executable = True,
+            cfg = "host",
+        ),
+        "flex_lexer_h": attr.label(
+            mandatory = True,
+            allow_single_file = [".h"],
+        ),
+    },
+)
+
+# buildifier: disable=provider-params
+BisonToolchainInfo = provider(
+    fields = [
+        "all_files",
+        "bison_tool",
+    ],
+)
+
+def _win_bison_toolchain_impl(ctx):
+    bison_runfiles = ctx.attr.bison_tool[DefaultInfo].default_runfiles.files
+
+    return platform_common.ToolchainInfo(
+        bison_toolchain = BisonToolchainInfo(
+            all_files = depset(
+                direct = [ctx.executable.bison_tool],
+                transitive = [bison_runfiles],
+            ),
+            bison_tool = ctx.attr.bison_tool.files_to_run,
+        ),
+    )
+
+win_bison_toolchain = rule(
+    _win_bison_toolchain_impl,
+    attrs = {
+        "bison_tool": attr.label(
+            mandatory = True,
+            executable = True,
+            cfg = "host",
+        ),
+    },
+)
+
+def _remote_win_flex_bison(repository_ctx):
+    repository_ctx.download_and_extract(
+        url = repository_ctx.attr.url,
+        sha256 = repository_ctx.attr.sha256,
+    )
+
+    repository_ctx.symlink(
+        Label("@com_google_verible//bazel:win_flex_bison.BUILD"),
+        "BUILD.bazel",
+    )
+
+remote_win_flex_bison = repository_rule(
+    implementation = _remote_win_flex_bison,
+    local = True,
+    attrs = {
+        "url": attr.string(mandatory = True),
+        "sha256": attr.string(default = ""),
+    },
+)
+
+def win_flex_configure(name, url, sha256 = ""):
+    remote_win_flex_bison(
+        name = name,
+        url = url,
+        sha256 = sha256,
+    )
+
+    native.register_toolchains(
+        "@" + name + "//:flex_toolchain",
+        "@" + name + "//:bison_toolchain",
+    )


### PR DESCRIPTION
As a first step towards compiling on Windows (#307), use [WinFlexBison](https://github.com/lexxmark/winflexbison) on Windows instead of compiling m4/flex/bison (which doesn't work)