### PR TITLE
CI: don't use system installed flex/bison anymore.

### DIFF
--- a/.github/workflows/macos-compile.yml
+++ b/.github/workflows/macos-compile.yml
@@ -15,15 +15,10 @@ jobs:
   MacOsBuild:
     runs-on: macos-latest
     steps:
-    - name: Install deps
-      run: |
-        brew install flex bison
     - name: Checkout code
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
     - name: Build
       run: |
-        export PATH=$(brew --prefix flex)/bin:$PATH
-        export PATH=$(brew --prefix bison)/bin:$PATH
         bazel test --cxxopt=-Wno-range-loop-analysis ...

--- a/.github/workflows/windows-compile.yml
+++ b/.github/workflows/windows-compile.yml
@@ -15,11 +15,6 @@ jobs:
   WindowsBuild:
     runs-on: windows-latest
     steps:
-    # Need winflexbison for Kythe, bazel fails if environment
-    # FLEX/BISON is not set to a valid program
-    - name: Install deps
-      run: |
-        choco install winflexbison
     - name: Checkout code
       uses: actions/checkout@v2
       with:
@@ -28,8 +23,6 @@ jobs:
     # fully compiled on Windows (yet!)
     - name: Build flex/bison files
       run: |
-        $env:FLEX = ($env:ChocolateyInstall + '/lib/winflexbison/tools/win_flex.exe') -replace '\\', '/'
-        $env:BISON = ($env:ChocolateyInstall + '/lib/winflexbison/tools/win_bison.exe') -replace '\\', '/'
         bazel build //common/analysis:command_file_lex
         bazel build //verilog/parser:verilog_y
         bazel build //verilog/parser:verilog_lex


### PR DESCRIPTION
After #772, we don't need to build Kythe in its entirety
anymore. It required a system installed flex/bison, don't
need that anymore now.

Signed-off-by: Henner Zeller <h.zeller@acm.org>