### PR TITLE
Remove flex/bison requirements while building releases.

### DIFF
--- a/.github/workflows/verible-ci.yml
+++ b/.github/workflows/verible-ci.yml
@@ -155,7 +155,7 @@ jobs:
     runs-on: ubuntu-20.04
     # Github actions resources are limited; don't build artifacts for all
     # platforms on every pull request, only on push.
-    if: ${{github.event_name == 'push'}}
+    #if: ${{github.event_name == 'push'}}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/verible-ci.yml
+++ b/.github/workflows/verible-ci.yml
@@ -155,7 +155,7 @@ jobs:
     runs-on: ubuntu-20.04
     # Github actions resources are limited; don't build artifacts for all
     # platforms on every pull request, only on push.
-    #if: ${{github.event_name == 'push'}}
+    if: ${{github.event_name == 'push'}}
     strategy:
       fail-fast: false
       matrix:

--- a/releasing/centos/8/compiler.dockerstage
+++ b/releasing/centos/8/compiler.dockerstage
@@ -2,7 +2,5 @@
 RUN yum -y group install --nogpgcheck "Development Tools" || \
     yum -y groupinstall --nogpgcheck "Development Tools"
 
-RUN yum install -y bison flex
-
 RUN gcc --version
 RUN g++ --version

--- a/releasing/centos/common/compiler.dockerstage
+++ b/releasing/centos/common/compiler.dockerstage
@@ -7,17 +7,4 @@ ENV BAZEL_LINKLIBS "-l%:libstdc++.a"
 RUN yum install -y --nogpgcheck centos-release-scl
 RUN yum install -y --nogpgcheck devtoolset-8
 
-RUN yum install -y bison flex
-
-# Build a newer version of flex
-RUN wget --no-verbose "https://github.com/westes/flex/files/981163/flex-2.6.4.tar.gz" \
- && tar -xvf flex-2.6.4.tar.gz \
- && cd flex-2.6.4 \
- && ./configure --prefix=/usr \
- && make -j \
- && make install \
- && cd .. \
- && rm -rf flex-*
-RUN flex --version
-
 SHELL [ "scl", "enable", "devtoolset-8" ]

--- a/releasing/ubuntu/common/compiler.dockerstage
+++ b/releasing/ubuntu/common/compiler.dockerstage
@@ -1,7 +1,5 @@
 # Install compiler
 RUN apt-get install -y  \
-    bison               \
     build-essential     \
-    flex                \
     g++                 \
     gcc

--- a/releasing/ubuntu/xenial/compiler.dockerstage
+++ b/releasing/ubuntu/xenial/compiler.dockerstage
@@ -1,9 +1,6 @@
-# Get a newer GCC and flex version
 RUN add-apt-repository ppa:ubuntu-toolchain-r/test; apt-get update
 RUN apt-get install -y  \
-    bison               \
     build-essential     \
-    flex                \
     g++-7               \
     gcc-7
 


### PR DESCRIPTION
These are not needed anymore.

WIP: In this first change in the pull request, the
building of the release artefacts is enabled to
see if they run through. Next step: put verible-ci.yml
back into original state.

Signed-off-by: Henner Zeller <h.zeller@acm.org>