### PR TITLE
Fix verilog_treebuilder_utils_test on Windows

### DIFF
--- a/.github/workflows/windows-compile.yml
+++ b/.github/workflows/windows-compile.yml
@@ -150,31 +150,7 @@ jobs:
                     //verilog/analysis/checkers:uvm_macro_semicolon_rule_test `
                     //verilog/analysis/checkers:v2001_generate_begin_rule_test `
                     //verilog/analysis/checkers:void_cast_rule_test `
-                    //verilog/CST:DPI_test `
-                    //verilog/CST:class_test `
-                    //verilog/CST:constraints_test `
-                    //verilog/CST:context_functions_test `
-                    //verilog/CST:data_test `
-                    //verilog/CST:declaration_test `
-                    //verilog/CST:dimensions_test `
-                    //verilog/CST:expression_test `
-                    //verilog/CST:functions_test `
-                    //verilog/CST:identifier_test `
-                    //verilog/CST:macro_test `
-                    //verilog/CST:module_test `
-                    //verilog/CST:net_test `
-                    //verilog/CST:numbers_test `
-                    //verilog/CST:package_test `
-                    //verilog/CST:parameters_test `
-                    //verilog/CST:port_test `
-                    //verilog/CST:seq_block_test `
-                    //verilog/CST:statement_test `
-                    //verilog/CST:tasks_test `
-                    //verilog/CST:type_test `
-                    //verilog/CST:verilog_matchers_test `
-                    //verilog/CST:verilog_nonterminals_test `
-                    //verilog/CST:verilog_tree_json_test `
-                    //verilog/CST:verilog_tree_print_test `
+                    //verilog/CST/... `
                     //verilog/formatting:comment_controls_test `
                     //verilog/formatting:verilog_token_test `
                     //verilog/parser/... `

--- a/verilog/CST/verilog_treebuilder_utils_test.cc
+++ b/verilog/CST/verilog_treebuilder_utils_test.cc
@@ -52,7 +52,7 @@ TEST(MakeParenGroupTest, WrongOpen) {
 
 TEST(MakeParenGroupTest, WrongClose) {
   EXPECT_DEATH(MakeParenGroup(Leaf('(', "("), Leaf(1, "1"), Leaf('}', "}")),
-               "}");
+               "\\}");
 }
 
 }  // namespace


### PR DESCRIPTION
The `WrongClose` test was failing on Windows with

```
external/com_google_googletest/googletest/src/gtest-port.cc(865): error: Failed
Syntax error at index 0 in simple regular expression "}": '}' is unsupported.
Stack trace:
  00007FF780051A8F: testing::internal::RE::Init
  00007FF78002BC9F: testing::internal::RE::RE
  00007FF78002BAAC: testing::ContainsRegex<const char *>
  00007FF78002B72C: testing::internal::MakeDeathTestMatcher
  00007FF780023CF7: verilog::`anonymous namespace'::MakeParenGroupTest_WrongClose_Test::TestBody
  00007FF78009B000: testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test,void>
  00007FF780085E3F: testing::internal::HandleExceptionsInMethodIfSupported<testing::Test,void>
  00007FF78006C8B9: testing::Test::Run
  00007FF78006D58C: testing::TestInfo::Run
  00007FF78006DF09: testing::TestSuite::Run
... Google Test internal frames ...

Running main() from gmock_main.cc
verilog/CST/verilog_treebuilder_utils_test.cc(55): error: Death test: MakeParenGroup(Leaf('(', "("), Leaf(1, "1"), Leaf('}', "}"))
    Result: died but not with expected error.
  Expected: contains regular expression "}"
```

Escaping the `}` fixes the issue. Note that this error is the same as if [line 50](https://github.com/google/verible/blob/fc4574ee582438800d7b9328cbe4dd99cfc84171/verilog/CST/verilog_treebuilder_utils_test.cc#L50) is not escaped. I could not figure out why the test passed on Linux, but now it passes on every platform.