### PR TITLE
Fixed common/formatting/align.cc on Windows

### DIFF
--- a/.github/workflows/windows-compile.yml
+++ b/.github/workflows/windows-compile.yml
@@ -45,15 +45,7 @@ jobs:
                     //common/analysis/matcher:descent_path_test `
                     //common/analysis/matcher:matcher_builders_test `
                     //common/analysis/matcher:matcher_test `
-                    //common/formatting:basic_format_style_test `
-                    //common/formatting:format_token_test `
-                    //common/formatting:line_wrap_searcher_test `
-                    //common/formatting:state_node_test `
-                    //common/formatting:token_partition_tree_test `
-                    //common/formatting:tree_annotator_test `
-                    //common/formatting:tree_unwrapper_test `
-                    //common/formatting:unwrapped_line_test `
-                    //common/formatting:verification_test `
+                    //common/formatting/... `
                     //common/lexer/... `
                     //common/parser/... `
                     //common/strings:comment_utils_test `

--- a/common/formatting/align.cc
+++ b/common/formatting/align.cc
@@ -595,7 +595,7 @@ AlignablePartitionGroup::CalculateAlignmentSpacings(
   {
     // Total width does not include initial left-indentation.
     // Assume indentation is the same for all partitions in each group.
-    const int indentation = rows.front().base()->Value().IndentationSpaces();
+    const int indentation = rows.front()->Value().IndentationSpaces();
     const int total_column_width = std::accumulate(
         column_configs.begin(), column_configs.end(), indentation,
         [](int total_width, const AlignedColumnConfiguration& c) {


### PR DESCRIPTION
Please verify if the `.base()` has a purpose. On Windows, compilation failed with:

```
common/formatting/align.cc(598,42): error: no member named 'base' in 'std::_Vector_iterator<std::_Vector_val<std::_Simple_types<verible::VectorTree<verible::UnwrappedLine>>>>'
    const int indentation = rows.front().base()->Value().IndentationSpaces();
                            ~~~~~~~~~~~~ ^
```