### PR TITLE
Compiling on Windows

### DIFF
--- a/.github/workflows/windows-compile.yml
+++ b/.github/workflows/windows-compile.yml
@@ -39,5 +39,6 @@ jobs:
                     //verilog/formatting/... `
                     //verilog/parser/... `
                     //verilog/preprocessor/... `
+                    //verilog/tools/diff/... `
                     //verilog/tools/kythe/... `
                     //verilog/transform/...

--- a/.github/workflows/windows-compile.yml
+++ b/.github/workflows/windows-compile.yml
@@ -21,13 +21,9 @@ jobs:
         fetch-depth: 0
     - name: Install dependencies
       run: choco install llvm
-    # Only check flex/bison targets at the moment, since Verible cannot be
-    # fully compiled on Windows (yet!)
-    - name: Build flex/bison files
+    - name: Build Verible
       run: |
-        bazel build //common/analysis:command_file_lex
-        bazel build //verilog/parser:verilog_y
-        bazel build //verilog/parser:verilog_lex
+        bazel build -c opt //...
     # Windows support is in progress, only run "working" tests
     - name: Run known-to-work tests
       run: |

--- a/.github/workflows/windows-compile.yml
+++ b/.github/workflows/windows-compile.yml
@@ -32,49 +32,7 @@ jobs:
     - name: Run known-to-work tests
       run: |
         bazel test  --test_output=errors `
-                    //common/util:file_util_test `
-                    //common/analysis:command_file_lexer_test `
-                    //common/analysis:file_analyzer_test `
-                    //common/analysis:line_linter_test `
-                    //common/analysis:lint_rule_status_test `
-                    //common/analysis:linter_test_utils_test `
-                    //common/analysis:syntax_tree_linter_test `
-                    //common/analysis:syntax_tree_search_test `
-                    //common/analysis:syntax_tree_search_test_utils_test `
-                    //common/analysis:text_structure_linter_test `
-                    //common/analysis:token_stream_linter_test `
-                    //common/analysis/matcher:core_matchers_test `
-                    //common/analysis/matcher:descent_path_test `
-                    //common/analysis/matcher:matcher_builders_test `
-                    //common/analysis/matcher:matcher_test `
-                    //common/formatting/... `
-                    //common/lexer/... `
-                    //common/parser/... `
-                    //common/strings/... `
-                    //common/text/... `
-                    //common/tools:patch_tool_test
-                    //common/util:algorithm_test `
-                    //common/util:auto_iterator_test `
-                    //common/util:auto_pop_stack_test `
-                    //common/util:bijective_map_test `
-                    //common/util:container_iterator_range_test `
-                    //common/util:enum_flags_test `
-                    //common/util:expandable_tree_view_test `
-                    //common/util:forward_test `
-                    //common/util:interval_map_test `
-                    //common/util:interval_set_test `
-                    //common/util:interval_test `
-                    //common/util:iterator_adaptors_test `
-                    //common/util:iterator_range_test `
-                    //common/util:map_tree_test `
-                    //common/util:range_test `
-                    //common/util:spacer_test `
-                    //common/util:subcommand_test `
-                    //common/util:top_n_test `
-                    //common/util:type_traits_test `
-                    //common/util:value_saver_test `
-                    //common/util:vector_tree_test `
-                    //common/util:with_reason_test `
+                    //common/... `
                     //external_libs:editscript_test `
                     //verilog/analysis:descriptions_test `
                     //verilog/analysis:extractors_test `

--- a/.github/workflows/windows-compile.yml
+++ b/.github/workflows/windows-compile.yml
@@ -50,20 +50,7 @@ jobs:
                     //common/formatting/... `
                     //common/lexer/... `
                     //common/parser/... `
-                    //common/strings:comment_utils_test `
-                    //common/strings:compare_test `
-                    //common/strings:diff_test `
-                    //common/strings:display_utils_test `
-                    //common/strings:line_column_map_test `
-                    //common/strings:naming_utils_test `
-                    //common/strings:obfuscator_test `
-                    //common/strings:position_test `
-                    //common/strings:random_test `
-                    //common/strings:range_test `
-                    //common/strings:rebase_test `
-                    //common/strings:split_test `
-                    //common/strings:string_memory_map_test `
-                    //common/strings:utf8_test `
+                    //common/strings/... `
                     //common/text/... `
                     //common/util:algorithm_test `
                     //common/util:auto_iterator_test `

--- a/.github/workflows/windows-compile.yml
+++ b/.github/workflows/windows-compile.yml
@@ -34,13 +34,7 @@ jobs:
         bazel test  --test_output=errors `
                     //common/... `
                     //external_libs/... `
-                    //verilog/analysis:descriptions_test `
-                    //verilog/analysis:extractors_test `
-                    //verilog/analysis:json_diagnostics_test `
-                    //verilog/analysis:lint_rule_registry_test `
-                    //verilog/analysis:verilog_analyzer_test `
-                    //verilog/analysis:verilog_equivalence_test `
-                    //verilog/analysis/checkers/... `
+                    //verilog/analysis/... `
                     //verilog/CST/... `
                     //verilog/formatting/... `
                     //verilog/parser/... `

--- a/.github/workflows/windows-compile.yml
+++ b/.github/workflows/windows-compile.yml
@@ -40,5 +40,6 @@ jobs:
                     //verilog/parser/... `
                     //verilog/preprocessor/... `
                     //verilog/tools/diff/... `
+                    //verilog/tools/formatter/... `
                     //verilog/tools/kythe/... `
                     //verilog/transform/...

--- a/.github/workflows/windows-compile.yml
+++ b/.github/workflows/windows-compile.yml
@@ -52,6 +52,7 @@ jobs:
                     //common/parser/... `
                     //common/strings/... `
                     //common/text/... `
+                    //common/tools:patch_tool_test
                     //common/util:algorithm_test `
                     //common/util:auto_iterator_test `
                     //common/util:auto_pop_stack_test `

--- a/.github/workflows/windows-compile.yml
+++ b/.github/workflows/windows-compile.yml
@@ -39,7 +39,5 @@ jobs:
                     //verilog/formatting/... `
                     //verilog/parser/... `
                     //verilog/preprocessor/... `
-                    //verilog/tools/kythe:indexing_facts_tree_test `
-                    //verilog/tools/kythe:kythe_facts_test `
-                    //verilog/tools/kythe:scope_resolver_test `
+                    //verilog/tools/kythe/... `
                     //verilog/transform/...

--- a/.github/workflows/windows-compile.yml
+++ b/.github/workflows/windows-compile.yml
@@ -33,66 +33,16 @@ jobs:
       run: |
         bazel test  --test_output=errors `
                     //common/... `
-                    //external_libs:editscript_test `
+                    //external_libs/... `
                     //verilog/analysis:descriptions_test `
                     //verilog/analysis:extractors_test `
                     //verilog/analysis:json_diagnostics_test `
                     //verilog/analysis:lint_rule_registry_test `
                     //verilog/analysis:verilog_analyzer_test `
                     //verilog/analysis:verilog_equivalence_test `
-                    //verilog/analysis/checkers:always_comb_blocking_rule_test `
-                    //verilog/analysis/checkers:always_comb_rule_test `
-                    //verilog/analysis/checkers:always_ff_non_blocking_rule_test `
-                    //verilog/analysis/checkers:banned_declared_name_patterns_rule_test `
-                    //verilog/analysis/checkers:case_missing_default_rule_test `
-                    //verilog/analysis/checkers:constraint_name_style_rule_test `
-                    //verilog/analysis/checkers:create_object_name_match_rule_test `
-                    //verilog/analysis/checkers:endif_comment_rule_test `
-                    //verilog/analysis/checkers:enum_name_style_rule_test `
-                    //verilog/analysis/checkers:explicit_function_lifetime_rule_test `
-                    //verilog/analysis/checkers:explicit_function_task_parameter_type_rule_test `
-                    //verilog/analysis/checkers:explicit_parameter_storage_type_rule_test `
-                    //verilog/analysis/checkers:explicit_task_lifetime_rule_test `
-                    //verilog/analysis/checkers:forbid_consecutive_null_statements_rule_test `
-                    //verilog/analysis/checkers:forbid_defparam_rule_test `
-                    //verilog/analysis/checkers:forbidden_anonymous_enums_rule_test `
-                    //verilog/analysis/checkers:forbidden_anonymous_structs_unions_rule_test `
-                    //verilog/analysis/checkers:forbidden_macro_rule_test `
-                    //verilog/analysis/checkers:forbidden_symbol_rule_test `
-                    //verilog/analysis/checkers:generate_label_prefix_rule_test `
-                    //verilog/analysis/checkers:generate_label_rule_test `
-                    //verilog/analysis/checkers:interface_name_style_rule_test `
-                    //verilog/analysis/checkers:legacy_generate_region_rule_test `
-                    //verilog/analysis/checkers:legacy_genvar_declaration_rule_test `
-                    //verilog/analysis/checkers:line_length_rule_test `
-                    //verilog/analysis/checkers:macro_name_style_rule_test `
-                    //verilog/analysis/checkers:macro_string_concatenation_rule_test `
-                    //verilog/analysis/checkers:mismatched_labels_rule_test `
-                    //verilog/analysis/checkers:module_begin_block_rule_test `
-                    //verilog/analysis/checkers:module_instantiation_rules_test `
-                    //verilog/analysis/checkers:no_tabs_rule_test `
-                    //verilog/analysis/checkers:no_trailing_spaces_rule_test `
-                    //verilog/analysis/checkers:numeric_format_string_style_rule_test `
-                    //verilog/analysis/checkers:packed_dimensions_rule_test `
-                    //verilog/analysis/checkers:parameter_name_style_rule_test `
-                    //verilog/analysis/checkers:parameter_type_name_style_rule_test `
-                    //verilog/analysis/checkers:plusarg_assignment_rule_test `
-                    //verilog/analysis/checkers:port_name_suffix_rule_test `
-                    //verilog/analysis/checkers:positive_meaning_parameter_name_rule_test `
-                    //verilog/analysis/checkers:posix_eof_rule_test `
-                    //verilog/analysis/checkers:proper_parameter_declaration_rule_test `
-                    //verilog/analysis/checkers:signal_name_style_rule_test `
-                    //verilog/analysis/checkers:struct_union_name_style_rule_test `
-                    //verilog/analysis/checkers:suggest_parentheses_rule_test `
-                    //verilog/analysis/checkers:token_stream_lint_rule_test `
-                    //verilog/analysis/checkers:undersized_binary_literal_rule_test `
-                    //verilog/analysis/checkers:unpacked_dimensions_rule_test `
-                    //verilog/analysis/checkers:uvm_macro_semicolon_rule_test `
-                    //verilog/analysis/checkers:v2001_generate_begin_rule_test `
-                    //verilog/analysis/checkers:void_cast_rule_test `
+                    //verilog/analysis/checkers/... `
                     //verilog/CST/... `
-                    //verilog/formatting:comment_controls_test `
-                    //verilog/formatting:verilog_token_test `
+                    //verilog/formatting/... `
                     //verilog/parser/... `
                     //verilog/preprocessor/... `
                     //verilog/tools/kythe:indexing_facts_tree_test `

--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -20,4 +20,6 @@ cc_library(
 exports_files([
     "bison.bzl",
     "flex.bzl",
+    "sh_test_with_runfiles_lib.bzl",
+    "sh_test_with_runfiles_lib.sh",
 ])

--- a/bazel/sh_test_with_runfiles_lib.bzl
+++ b/bazel/sh_test_with_runfiles_lib.bzl
@@ -1,0 +1,57 @@
+# -*- Python -*-
+# Copyright 2021 The Verible Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Bazel rule to wrap sh_test with a wrapper loading runfiles library prior to execution
+"""
+
+def sh_test_with_runfiles_lib(name, srcs, size, args, data, deps = []):
+    """sh_test wrapper that loads bazel's runfiles library before calling the test.
+
+    This is necessary because on Windows, runfiles are not symlinked like on Unix and
+    are thus not available from the path returned by $(location Label). The runfiles
+    library provide the rlocation function, which converts a runfile path (from $location)
+    to the fullpath of the file.
+
+    Args:
+        name: sh_test's name
+        srcs: sh_test's srcs, must be an array of a single file
+        size: sh_test's size
+        args: sh_test's args
+        data: sh_test's data
+        deps: sh_test's deps
+    """
+
+    if len(srcs) > 1:
+        fail("you must specify exactly one file in 'srcs'")
+
+    # Add the runfiles library to dependencies
+    if len(deps) == 0:
+        deps = ["@bazel_tools//tools/bash/runfiles"]
+    else:
+        deps.append("@bazel_tools//tools/bash/runfiles")
+
+    # Replace first arguments with location of the main script to run
+    # and add script to run to sh_test's data
+    args = ["$(location " + srcs[0] + ")"] + args
+    data += srcs
+
+    native.sh_test(
+        name = name,
+        srcs = ["//bazel:sh_test_with_runfiles_lib.sh"],
+        size = size,
+        args = args,
+        data = data,
+        deps = deps,
+    )

--- a/bazel/sh_test_with_runfiles_lib.sh
+++ b/bazel/sh_test_with_runfiles_lib.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Copyright 2017-2020 The Verible Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Test wrapper to load bazel runfiles library before running script
+
+# --- begin runfiles.bash initialization v2 ---
+# Copy-pasted from the Bazel Bash runfiles library v2.
+set -uo pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$0.runfiles/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
+# --- end runfiles.bash initialization v2 ---
+
+# Remove exit on failure set by runfiles.bash...
+set +e
+
+source "$(rlocation ${TEST_WORKSPACE}/${1})" "${@:2}"

--- a/common/strings/patch.cc
+++ b/common/strings/patch.cc
@@ -14,7 +14,13 @@
 
 #include "common/strings/patch.h"
 
-#include <unistd.h>
+#ifndef _WIN32
+#include <unistd.h>  // for isatty
+#else
+#include <io.h>
+// MSVC recommends to use _isatty...
+#define isatty _isatty
+#endif
 
 #include <deque>
 #include <iostream>

--- a/common/tools/BUILD
+++ b/common/tools/BUILD
@@ -46,5 +46,5 @@ sh_test(
         ":verible-patch-tool",
         ":verible-transform-interactive",
     ],
-    deps = [],
+    deps = ["@bazel_tools//tools/bash/runfiles"],
 )

--- a/common/tools/BUILD
+++ b/common/tools/BUILD
@@ -1,5 +1,7 @@
 """This package contains language-agnostic tools in the Verible project."""
 
+load("//bazel:sh_test_with_runfiles_lib.bzl", "sh_test_with_runfiles_lib")
+
 licenses(["notice"])
 
 cc_binary(
@@ -17,13 +19,13 @@ cc_binary(
     ],
 )
 
-sh_test(
+sh_test_with_runfiles_lib(
     name = "patch_tool_test",
     size = "small",
     srcs = ["patch_tool_test.sh"],
     args = ["$(location :verible-patch-tool)"],
     data = [":verible-patch-tool"],
-    deps = ["@bazel_tools//tools/bash/runfiles"],
+    deps = [],
 )
 
 # This script is intended to run post-install and expect to be co-located with:
@@ -34,7 +36,7 @@ filegroup(
     visibility = ["//:__pkg__"],  # for release
 )
 
-sh_test(
+sh_test_with_runfiles_lib(
     name = "verible-transform-interactive-test",
     size = "small",
     srcs = ["verible-transform-interactive-test.sh"],
@@ -46,5 +48,5 @@ sh_test(
         ":verible-patch-tool",
         ":verible-transform-interactive",
     ],
-    deps = ["@bazel_tools//tools/bash/runfiles"],
+    deps = [],
 )

--- a/common/tools/BUILD
+++ b/common/tools/BUILD
@@ -23,7 +23,7 @@ sh_test(
     srcs = ["patch_tool_test.sh"],
     args = ["$(location :verible-patch-tool)"],
     data = [":verible-patch-tool"],
-    deps = [],
+    deps = ["@bazel_tools//tools/bash/runfiles"],
 )
 
 # This script is intended to run post-install and expect to be co-located with:

--- a/common/tools/patch_tool.cc
+++ b/common/tools/patch_tool.cc
@@ -12,7 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#ifndef _WIN32
 #include <unistd.h>  // for isatty
+#else
+#include <io.h>
+// MSVC recommends to use _isatty...
+#define isatty _isatty
+#endif
 
 #include <functional>
 #include <iostream>

--- a/common/tools/patch_tool_test.sh
+++ b/common/tools/patch_tool_test.sh
@@ -13,6 +13,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# --- begin runfiles.bash initialization v2 ---
+# Copy-pasted from the Bazel Bash runfiles library v2.
+set -uo pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$0.runfiles/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
+# --- end runfiles.bash initialization v2 ---
+
+# Remove exit on failure set by runfiles.bash...
+set +e
+
 # Find input files
 MY_INPUT_FILE="${TEST_TMPDIR}/myinput.txt"
 readonly MY_INPUT_FILE
@@ -26,7 +40,12 @@ readonly MY_EXPECT_FILE
   echo "Expecting 1 positional argument, verible-patch-tool path."
   exit 1
 }
-patch_tool="$1"
+
+# On Windows, runfiles are not symlinked (unless --enable_runfiles is active,
+# which causes other issues on bazel 3.7.0), so use rlocation to find the path
+# to the executable. On Unix, you could simply use $1, but using rlocation
+# works too
+patch_tool="$(rlocation ${TEST_WORKSPACE}/${1})"
 
 ################################################################################
 # Test no command.
@@ -123,7 +142,7 @@ status="$?"
   exit 1
 }
 
-diff -u "$MY_EXPECT_FILE" "$MY_OUTPUT_FILE" || {
+diff -u --strip-trailing-cr "$MY_EXPECT_FILE" "$MY_OUTPUT_FILE" || {
   exit 1
 }
 
@@ -137,7 +156,7 @@ status="$?"
   exit 1
 }
 
-diff -u "$MY_EXPECT_FILE" "$MY_OUTPUT_FILE" || {
+diff -u --strip-trailing-cr "$MY_EXPECT_FILE" "$MY_OUTPUT_FILE" || {
   exit 1
 }
 
@@ -372,7 +391,7 @@ status="$?"
   exit 1
 }
 
-diff -u "$MY_INPUT_FILE".bkp "$MY_INPUT_FILE".orig || {
+diff -u --strip-trailing-cr "$MY_INPUT_FILE".bkp "$MY_INPUT_FILE".orig || {
   echo "Expected these files to match, but got the above diff."
   exit 1
 }
@@ -389,7 +408,7 @@ status="$?"
   exit 1
 }
 
-diff -u "$MY_INPUT_FILE".bkp "$MY_INPUT_FILE".orig || {
+diff -u --strip-trailing-cr "$MY_INPUT_FILE".bkp "$MY_INPUT_FILE".orig || {
   echo "Expected these files to match, but got the above diff."
   exit 1
 }
@@ -421,7 +440,7 @@ h
 EOF
 
 # Expect original file to have been modified in-place.
-diff -u "$MY_EXPECT_FILE" "$MY_INPUT_FILE".orig || {
+diff -u --strip-trailing-cr "$MY_EXPECT_FILE" "$MY_INPUT_FILE".orig || {
   echo "Expected these files to match, but got the above diff."
   exit 1
 }
@@ -456,7 +475,7 @@ h
 EOF
 
 # Expect original file to have been modified in-place.
-diff -u "$MY_EXPECT_FILE" "$MY_INPUT_FILE".orig || {
+diff -u --strip-trailing-cr "$MY_EXPECT_FILE" "$MY_INPUT_FILE".orig || {
   echo "Expected these files to match, but got the above diff."
   exit 1
 }
@@ -490,7 +509,7 @@ h
 EOF
 
 # Expect original file to have been modified in-place.
-diff -u "$MY_EXPECT_FILE" "$MY_INPUT_FILE".orig || {
+diff -u --strip-trailing-cr "$MY_EXPECT_FILE" "$MY_INPUT_FILE".orig || {
   echo "Expected these files to match, but got the above diff."
   exit 1
 }

--- a/common/tools/patch_tool_test.sh
+++ b/common/tools/patch_tool_test.sh
@@ -13,20 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# --- begin runfiles.bash initialization v2 ---
-# Copy-pasted from the Bazel Bash runfiles library v2.
-set -uo pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
-source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$0.runfiles/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
-# --- end runfiles.bash initialization v2 ---
-
-# Remove exit on failure set by runfiles.bash...
-set +e
-
 # Find input files
 MY_INPUT_FILE="${TEST_TMPDIR}/myinput.txt"
 readonly MY_INPUT_FILE
@@ -40,11 +26,6 @@ readonly MY_EXPECT_FILE
   echo "Expecting 1 positional argument, verible-patch-tool path."
   exit 1
 }
-
-# On Windows, runfiles are not symlinked (unless --enable_runfiles is active,
-# which causes other issues on bazel 3.7.0), so use rlocation to find the path
-# to the executable. On Unix, you could simply use $1, but using rlocation
-# works too
 patch_tool="$(rlocation ${TEST_WORKSPACE}/${1})"
 
 ################################################################################

--- a/common/tools/verible-transform-interactive-test.sh
+++ b/common/tools/verible-transform-interactive-test.sh
@@ -13,20 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# --- begin runfiles.bash initialization v2 ---
-# Copy-pasted from the Bazel Bash runfiles library v2.
-set -uo pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
-source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$0.runfiles/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
-# --- end runfiles.bash initialization v2 ---
-
-# Remove exit on failure set by runfiles.bash...
-set +e
-
 # Find input files
 MY_INPUT_FILE="${TEST_TMPDIR}/myinput.txt"
 readonly MY_INPUT_FILE
@@ -42,11 +28,6 @@ readonly MY_EXPECT_FILE
   echo "  verible-patch-tool"
   exit 1
 }
-
-# On Windows, runfiles are not symlinked (unless --enable_runfiles is active,
-# which causes other issues on bazel 3.7.0), so use rlocation to find the path
-# to the executable. On Unix, you could simply use $1/$2, but using rlocation
-# works too
 transform_interactive="$(rlocation ${TEST_WORKSPACE}/${1})"
 patch_tool="$(rlocation ${TEST_WORKSPACE}/${2})"
 

--- a/common/tools/verible-transform-interactive-test.sh
+++ b/common/tools/verible-transform-interactive-test.sh
@@ -13,6 +13,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# --- begin runfiles.bash initialization v2 ---
+# Copy-pasted from the Bazel Bash runfiles library v2.
+set -uo pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$0.runfiles/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
+# --- end runfiles.bash initialization v2 ---
+
+# Remove exit on failure set by runfiles.bash...
+set +e
+
 # Find input files
 MY_INPUT_FILE="${TEST_TMPDIR}/myinput.txt"
 readonly MY_INPUT_FILE
@@ -28,8 +42,13 @@ readonly MY_EXPECT_FILE
   echo "  verible-patch-tool"
   exit 1
 }
-transform_interactive="$1"
-patch_tool="$2"
+
+# On Windows, runfiles are not symlinked (unless --enable_runfiles is active,
+# which causes other issues on bazel 3.7.0), so use rlocation to find the path
+# to the executable. On Unix, you could simply use $1/$2, but using rlocation
+# works too
+transform_interactive="$(rlocation ${TEST_WORKSPACE}/${1})"
+patch_tool="$(rlocation ${TEST_WORKSPACE}/${2})"
 
 transform_command=("$transform_interactive" --patch-tool="$patch_tool")
 
@@ -75,12 +94,12 @@ EOF
 # Run 'interactive' patcher.
 "${transform_command[@]}" -- grep -v ccc -- "$MY_INPUT_FILE".test*.txt < "$MY_INPUT_FILE".user-input
 
-diff -u "$MY_EXPECT_FILE".test1.txt "$MY_INPUT_FILE".test1.txt || {
+diff -u --strip-trailing-cr "$MY_EXPECT_FILE".test1.txt "$MY_INPUT_FILE".test1.txt || {
   echo "Expected these files to match, but got the above diff."
   exit 1
 }
 
-diff -u "$MY_EXPECT_FILE".test2.txt "$MY_INPUT_FILE".test2.txt || {
+diff -u --strip-trailing-cr "$MY_EXPECT_FILE".test2.txt "$MY_INPUT_FILE".test2.txt || {
   echo "Expected these files to match, but got the above diff."
   exit 1
 }

--- a/verilog/analysis/symbol_table_test.cc
+++ b/verilog/analysis/symbol_table_test.cc
@@ -7597,12 +7597,7 @@ TEST(BuildSymbolTableTest, ModuleInstancesFromProjectMissingFile) {
   symbol_table.BuildSingleTranslationUnit("file/not/found.txt",
                                           &build_diagnostics);
   ASSERT_FALSE(build_diagnostics.empty());
-#ifdef _WIN32
-  EXPECT_THAT(build_diagnostics.front().message(),
-              HasSubstr("The system cannot find the path specified."));
-#else
-  EXPECT_THAT(build_diagnostics.front().message(), HasSubstr("No such file"));
-#endif
+  EXPECT_THAT(build_diagnostics.front().code(), absl::StatusCode::kNotFound);
 }
 
 TEST(BuildSymbolTableTest, ModuleInstancesFromProjectFilesGood) {

--- a/verilog/analysis/symbol_table_test.cc
+++ b/verilog/analysis/symbol_table_test.cc
@@ -7598,7 +7598,8 @@ TEST(BuildSymbolTableTest, ModuleInstancesFromProjectMissingFile) {
                                           &build_diagnostics);
   ASSERT_FALSE(build_diagnostics.empty());
 #ifdef _WIN32
-  EXPECT_THAT(build_diagnostics.front().message(), HasSubstr("The system cannot find the path specified."));
+  EXPECT_THAT(build_diagnostics.front().message(),
+              HasSubstr("The system cannot find the path specified."));
 #else
   EXPECT_THAT(build_diagnostics.front().message(), HasSubstr("No such file"));
 #endif

--- a/verilog/analysis/symbol_table_test.cc
+++ b/verilog/analysis/symbol_table_test.cc
@@ -7597,7 +7597,11 @@ TEST(BuildSymbolTableTest, ModuleInstancesFromProjectMissingFile) {
   symbol_table.BuildSingleTranslationUnit("file/not/found.txt",
                                           &build_diagnostics);
   ASSERT_FALSE(build_diagnostics.empty());
+#ifdef _WIN32
+  EXPECT_THAT(build_diagnostics.front().message(), HasSubstr("The system cannot find the path specified."));
+#else
   EXPECT_THAT(build_diagnostics.front().message(), HasSubstr("No such file"));
+#endif
 }
 
 TEST(BuildSymbolTableTest, ModuleInstancesFromProjectFilesGood) {

--- a/verilog/tools/diff/BUILD
+++ b/verilog/tools/diff/BUILD
@@ -25,6 +25,7 @@ sh_test(
     srcs = ["diff_user_errors_test.sh"],
     args = ["$(location :verible-verilog-diff)"],
     data = [":verible-verilog-diff"],
+    deps = ["@bazel_tools//tools/bash/runfiles"],
 )
 
 sh_test(
@@ -33,6 +34,7 @@ sh_test(
     srcs = ["diff_format_match_test.sh"],
     args = ["$(location :verible-verilog-diff)"],
     data = [":verible-verilog-diff"],
+    deps = ["@bazel_tools//tools/bash/runfiles"],
 )
 
 sh_test(
@@ -41,6 +43,7 @@ sh_test(
     srcs = ["diff_format_mismatch_test.sh"],
     args = ["$(location :verible-verilog-diff)"],
     data = [":verible-verilog-diff"],
+    deps = ["@bazel_tools//tools/bash/runfiles"],
 )
 
 sh_test(
@@ -49,6 +52,7 @@ sh_test(
     srcs = ["diff_format_lex_error_test.sh"],
     args = ["$(location :verible-verilog-diff)"],
     data = [":verible-verilog-diff"],
+    deps = ["@bazel_tools//tools/bash/runfiles"],
 )
 
 sh_test(
@@ -57,6 +61,7 @@ sh_test(
     srcs = ["diff_obfuscate_match_test.sh"],
     args = ["$(location :verible-verilog-diff)"],
     data = [":verible-verilog-diff"],
+    deps = ["@bazel_tools//tools/bash/runfiles"],
 )
 
 sh_test(
@@ -65,4 +70,5 @@ sh_test(
     srcs = ["diff_obfuscate_mismatch_test.sh"],
     args = ["$(location :verible-verilog-diff)"],
     data = [":verible-verilog-diff"],
+    deps = ["@bazel_tools//tools/bash/runfiles"],
 )

--- a/verilog/tools/diff/BUILD
+++ b/verilog/tools/diff/BUILD
@@ -1,6 +1,8 @@
 """Tool for comparing Verilog source code.
 """
 
+load("//bazel:sh_test_with_runfiles_lib.bzl", "sh_test_with_runfiles_lib")
+
 licenses(["notice"])
 
 cc_binary(
@@ -19,56 +21,50 @@ cc_binary(
     ],
 )
 
-sh_test(
+sh_test_with_runfiles_lib(
     name = "diff_user_errors_test",
     size = "small",
     srcs = ["diff_user_errors_test.sh"],
     args = ["$(location :verible-verilog-diff)"],
     data = [":verible-verilog-diff"],
-    deps = ["@bazel_tools//tools/bash/runfiles"],
 )
 
-sh_test(
+sh_test_with_runfiles_lib(
     name = "diff_format_match_test",
     size = "small",
     srcs = ["diff_format_match_test.sh"],
     args = ["$(location :verible-verilog-diff)"],
     data = [":verible-verilog-diff"],
-    deps = ["@bazel_tools//tools/bash/runfiles"],
 )
 
-sh_test(
+sh_test_with_runfiles_lib(
     name = "diff_format_mismatch_test",
     size = "small",
     srcs = ["diff_format_mismatch_test.sh"],
     args = ["$(location :verible-verilog-diff)"],
     data = [":verible-verilog-diff"],
-    deps = ["@bazel_tools//tools/bash/runfiles"],
 )
 
-sh_test(
+sh_test_with_runfiles_lib(
     name = "diff_format_lex_error_test",
     size = "small",
     srcs = ["diff_format_lex_error_test.sh"],
     args = ["$(location :verible-verilog-diff)"],
     data = [":verible-verilog-diff"],
-    deps = ["@bazel_tools//tools/bash/runfiles"],
 )
 
-sh_test(
+sh_test_with_runfiles_lib(
     name = "diff_obfuscate_match_test",
     size = "small",
     srcs = ["diff_obfuscate_match_test.sh"],
     args = ["$(location :verible-verilog-diff)"],
     data = [":verible-verilog-diff"],
-    deps = ["@bazel_tools//tools/bash/runfiles"],
 )
 
-sh_test(
+sh_test_with_runfiles_lib(
     name = "diff_obfuscate_mismatch_test",
     size = "small",
     srcs = ["diff_obfuscate_mismatch_test.sh"],
     args = ["$(location :verible-verilog-diff)"],
     data = [":verible-verilog-diff"],
-    deps = ["@bazel_tools//tools/bash/runfiles"],
 )

--- a/verilog/tools/diff/diff_format_lex_error_test.sh
+++ b/verilog/tools/diff/diff_format_lex_error_test.sh
@@ -15,6 +15,20 @@
 
 # Tests verible-verilog-diff --mode=format
 
+# --- begin runfiles.bash initialization v2 ---
+# Copy-pasted from the Bazel Bash runfiles library v2.
+set -uo pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$0.runfiles/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
+# --- end runfiles.bash initialization v2 ---
+
+# Remove exit on failure set by runfiles.bash...
+set +e
+
 declare -r MY_INPUT_FILE1="${TEST_TMPDIR}/myinput1.txt"
 declare -r MY_INPUT_FILE2="${TEST_TMPDIR}/myinput2.txt"
 
@@ -23,7 +37,11 @@ declare -r MY_INPUT_FILE2="${TEST_TMPDIR}/myinput2.txt"
   echo "Expecting 1 positional argument, verible-verilog-diff path."
   exit 1
 }
-difftool="$1"
+# On Windows, runfiles are not symlinked (unless --enable_runfiles is active,
+# which causes other issues on bazel 3.7.0), so use rlocation to find the path
+# to the executable. On Unix, you could simply use $1, but using rlocation
+# works too
+difftool="$(rlocation ${TEST_WORKSPACE}/${1})"
 
 # contains lexical error token "1mm"
 cat >${MY_INPUT_FILE1} <<EOF
@@ -47,4 +65,3 @@ EOF
 [[ $? -eq 1 ]] || exit 2
 
 echo "PASS"
-

--- a/verilog/tools/diff/diff_format_lex_error_test.sh
+++ b/verilog/tools/diff/diff_format_lex_error_test.sh
@@ -15,20 +15,6 @@
 
 # Tests verible-verilog-diff --mode=format
 
-# --- begin runfiles.bash initialization v2 ---
-# Copy-pasted from the Bazel Bash runfiles library v2.
-set -uo pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
-source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$0.runfiles/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
-# --- end runfiles.bash initialization v2 ---
-
-# Remove exit on failure set by runfiles.bash...
-set +e
-
 declare -r MY_INPUT_FILE1="${TEST_TMPDIR}/myinput1.txt"
 declare -r MY_INPUT_FILE2="${TEST_TMPDIR}/myinput2.txt"
 
@@ -37,10 +23,6 @@ declare -r MY_INPUT_FILE2="${TEST_TMPDIR}/myinput2.txt"
   echo "Expecting 1 positional argument, verible-verilog-diff path."
   exit 1
 }
-# On Windows, runfiles are not symlinked (unless --enable_runfiles is active,
-# which causes other issues on bazel 3.7.0), so use rlocation to find the path
-# to the executable. On Unix, you could simply use $1, but using rlocation
-# works too
 difftool="$(rlocation ${TEST_WORKSPACE}/${1})"
 
 # contains lexical error token "1mm"

--- a/verilog/tools/diff/diff_format_match_test.sh
+++ b/verilog/tools/diff/diff_format_match_test.sh
@@ -15,6 +15,20 @@
 
 # Tests verible-verilog-diff --mode=format
 
+# --- begin runfiles.bash initialization v2 ---
+# Copy-pasted from the Bazel Bash runfiles library v2.
+set -uo pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$0.runfiles/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
+# --- end runfiles.bash initialization v2 ---
+
+# Remove exit on failure set by runfiles.bash...
+set +e
+
 declare -r MY_INPUT_FILE1="${TEST_TMPDIR}/myinput1.txt"
 declare -r MY_INPUT_FILE2="${TEST_TMPDIR}/myinput2.txt"
 
@@ -23,7 +37,11 @@ declare -r MY_INPUT_FILE2="${TEST_TMPDIR}/myinput2.txt"
   echo "Expecting 1 positional argument, verible-verilog-diff path."
   exit 1
 }
-difftool="$1"
+# On Windows, runfiles are not symlinked (unless --enable_runfiles is active,
+# which causes other issues on bazel 3.7.0), so use rlocation to find the path
+# to the executable. On Unix, you could simply use $1, but using rlocation
+# works too
+difftool="$(rlocation ${TEST_WORKSPACE}/${1})"
 
 cat >${MY_INPUT_FILE1} <<EOF
   module    m   ;endmodule
@@ -46,4 +64,3 @@ EOF
 [[ $? -eq 0 ]] || exit 2
 
 echo "PASS"
-

--- a/verilog/tools/diff/diff_format_match_test.sh
+++ b/verilog/tools/diff/diff_format_match_test.sh
@@ -15,20 +15,6 @@
 
 # Tests verible-verilog-diff --mode=format
 
-# --- begin runfiles.bash initialization v2 ---
-# Copy-pasted from the Bazel Bash runfiles library v2.
-set -uo pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
-source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$0.runfiles/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
-# --- end runfiles.bash initialization v2 ---
-
-# Remove exit on failure set by runfiles.bash...
-set +e
-
 declare -r MY_INPUT_FILE1="${TEST_TMPDIR}/myinput1.txt"
 declare -r MY_INPUT_FILE2="${TEST_TMPDIR}/myinput2.txt"
 
@@ -37,10 +23,6 @@ declare -r MY_INPUT_FILE2="${TEST_TMPDIR}/myinput2.txt"
   echo "Expecting 1 positional argument, verible-verilog-diff path."
   exit 1
 }
-# On Windows, runfiles are not symlinked (unless --enable_runfiles is active,
-# which causes other issues on bazel 3.7.0), so use rlocation to find the path
-# to the executable. On Unix, you could simply use $1, but using rlocation
-# works too
 difftool="$(rlocation ${TEST_WORKSPACE}/${1})"
 
 cat >${MY_INPUT_FILE1} <<EOF

--- a/verilog/tools/diff/diff_format_mismatch_test.sh
+++ b/verilog/tools/diff/diff_format_mismatch_test.sh
@@ -15,6 +15,20 @@
 
 # Tests verible-verilog-diff --mode=format
 
+# --- begin runfiles.bash initialization v2 ---
+# Copy-pasted from the Bazel Bash runfiles library v2.
+set -uo pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$0.runfiles/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
+# --- end runfiles.bash initialization v2 ---
+
+# Remove exit on failure set by runfiles.bash...
+set +e
+
 declare -r MY_INPUT_FILE1="${TEST_TMPDIR}/myinput1.txt"
 declare -r MY_INPUT_FILE2="${TEST_TMPDIR}/myinput2.txt"
 
@@ -23,7 +37,11 @@ declare -r MY_INPUT_FILE2="${TEST_TMPDIR}/myinput2.txt"
   echo "Expecting 1 positional argument, verible-verilog-diff path."
   exit 1
 }
-difftool="$1"
+# On Windows, runfiles are not symlinked (unless --enable_runfiles is active,
+# which causes other issues on bazel 3.7.0), so use rlocation to find the path
+# to the executable. On Unix, you could simply use $1, but using rlocation
+# works too
+difftool="$(rlocation ${TEST_WORKSPACE}/${1})"
 
 cat >${MY_INPUT_FILE1} <<EOF
   module    m   ;endmodule
@@ -46,4 +64,3 @@ EOF
 [[ $? -eq 1 ]] || exit 2
 
 echo "PASS"
-

--- a/verilog/tools/diff/diff_format_mismatch_test.sh
+++ b/verilog/tools/diff/diff_format_mismatch_test.sh
@@ -15,20 +15,6 @@
 
 # Tests verible-verilog-diff --mode=format
 
-# --- begin runfiles.bash initialization v2 ---
-# Copy-pasted from the Bazel Bash runfiles library v2.
-set -uo pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
-source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$0.runfiles/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
-# --- end runfiles.bash initialization v2 ---
-
-# Remove exit on failure set by runfiles.bash...
-set +e
-
 declare -r MY_INPUT_FILE1="${TEST_TMPDIR}/myinput1.txt"
 declare -r MY_INPUT_FILE2="${TEST_TMPDIR}/myinput2.txt"
 
@@ -37,10 +23,6 @@ declare -r MY_INPUT_FILE2="${TEST_TMPDIR}/myinput2.txt"
   echo "Expecting 1 positional argument, verible-verilog-diff path."
   exit 1
 }
-# On Windows, runfiles are not symlinked (unless --enable_runfiles is active,
-# which causes other issues on bazel 3.7.0), so use rlocation to find the path
-# to the executable. On Unix, you could simply use $1, but using rlocation
-# works too
 difftool="$(rlocation ${TEST_WORKSPACE}/${1})"
 
 cat >${MY_INPUT_FILE1} <<EOF

--- a/verilog/tools/diff/diff_obfuscate_match_test.sh
+++ b/verilog/tools/diff/diff_obfuscate_match_test.sh
@@ -15,20 +15,6 @@
 
 # Tests verible-verilog-diff --mode=obfuscate
 
-# --- begin runfiles.bash initialization v2 ---
-# Copy-pasted from the Bazel Bash runfiles library v2.
-set -uo pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
-source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$0.runfiles/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
-# --- end runfiles.bash initialization v2 ---
-
-# Remove exit on failure set by runfiles.bash...
-set +e
-
 declare -r MY_INPUT_FILE1="${TEST_TMPDIR}/myinput1.txt"
 declare -r MY_INPUT_FILE2="${TEST_TMPDIR}/myinput2.txt"
 
@@ -37,10 +23,6 @@ declare -r MY_INPUT_FILE2="${TEST_TMPDIR}/myinput2.txt"
   echo "Expecting 1 positional argument, verible-verilog-diff path."
   exit 1
 }
-# On Windows, runfiles are not symlinked (unless --enable_runfiles is active,
-# which causes other issues on bazel 3.7.0), so use rlocation to find the path
-# to the executable. On Unix, you could simply use $1, but using rlocation
-# works too
 difftool="$(rlocation ${TEST_WORKSPACE}/${1})"
 
 cat >${MY_INPUT_FILE1} <<EOF

--- a/verilog/tools/diff/diff_obfuscate_match_test.sh
+++ b/verilog/tools/diff/diff_obfuscate_match_test.sh
@@ -15,6 +15,20 @@
 
 # Tests verible-verilog-diff --mode=obfuscate
 
+# --- begin runfiles.bash initialization v2 ---
+# Copy-pasted from the Bazel Bash runfiles library v2.
+set -uo pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$0.runfiles/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
+# --- end runfiles.bash initialization v2 ---
+
+# Remove exit on failure set by runfiles.bash...
+set +e
+
 declare -r MY_INPUT_FILE1="${TEST_TMPDIR}/myinput1.txt"
 declare -r MY_INPUT_FILE2="${TEST_TMPDIR}/myinput2.txt"
 
@@ -23,7 +37,11 @@ declare -r MY_INPUT_FILE2="${TEST_TMPDIR}/myinput2.txt"
   echo "Expecting 1 positional argument, verible-verilog-diff path."
   exit 1
 }
-difftool="$1"
+# On Windows, runfiles are not symlinked (unless --enable_runfiles is active,
+# which causes other issues on bazel 3.7.0), so use rlocation to find the path
+# to the executable. On Unix, you could simply use $1, but using rlocation
+# works too
+difftool="$(rlocation ${TEST_WORKSPACE}/${1})"
 
 cat >${MY_INPUT_FILE1} <<EOF
   module    kjasdfASKJdsa18k   ;endmodule
@@ -42,4 +60,3 @@ EOF
 [[ $? -eq 0 ]] || exit 2
 
 echo "PASS"
-

--- a/verilog/tools/diff/diff_obfuscate_mismatch_test.sh
+++ b/verilog/tools/diff/diff_obfuscate_mismatch_test.sh
@@ -15,20 +15,6 @@
 
 # Tests verible-verilog-diff --mode=obfuscate
 
-# --- begin runfiles.bash initialization v2 ---
-# Copy-pasted from the Bazel Bash runfiles library v2.
-set -uo pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
-source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$0.runfiles/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
-# --- end runfiles.bash initialization v2 ---
-
-# Remove exit on failure set by runfiles.bash...
-set +e
-
 declare -r MY_INPUT_FILE1="${TEST_TMPDIR}/myinput1.txt"
 declare -r MY_INPUT_FILE2="${TEST_TMPDIR}/myinput2.txt"
 
@@ -37,10 +23,6 @@ declare -r MY_INPUT_FILE2="${TEST_TMPDIR}/myinput2.txt"
   echo "Expecting 1 positional argument, verible-verilog-diff path."
   exit 1
 }
-# On Windows, runfiles are not symlinked (unless --enable_runfiles is active,
-# which causes other issues on bazel 3.7.0), so use rlocation to find the path
-# to the executable. On Unix, you could simply use $1, but using rlocation
-# works too
 difftool="$(rlocation ${TEST_WORKSPACE}/${1})"
 
 # different spacing or token length counts as mismatch

--- a/verilog/tools/diff/diff_obfuscate_mismatch_test.sh
+++ b/verilog/tools/diff/diff_obfuscate_mismatch_test.sh
@@ -15,6 +15,20 @@
 
 # Tests verible-verilog-diff --mode=obfuscate
 
+# --- begin runfiles.bash initialization v2 ---
+# Copy-pasted from the Bazel Bash runfiles library v2.
+set -uo pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$0.runfiles/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
+# --- end runfiles.bash initialization v2 ---
+
+# Remove exit on failure set by runfiles.bash...
+set +e
+
 declare -r MY_INPUT_FILE1="${TEST_TMPDIR}/myinput1.txt"
 declare -r MY_INPUT_FILE2="${TEST_TMPDIR}/myinput2.txt"
 
@@ -23,7 +37,11 @@ declare -r MY_INPUT_FILE2="${TEST_TMPDIR}/myinput2.txt"
   echo "Expecting 1 positional argument, verible-verilog-diff path."
   exit 1
 }
-difftool="$1"
+# On Windows, runfiles are not symlinked (unless --enable_runfiles is active,
+# which causes other issues on bazel 3.7.0), so use rlocation to find the path
+# to the executable. On Unix, you could simply use $1, but using rlocation
+# works too
+difftool="$(rlocation ${TEST_WORKSPACE}/${1})"
 
 # different spacing or token length counts as mismatch
 cat >${MY_INPUT_FILE1} <<EOF
@@ -43,4 +61,3 @@ EOF
 [[ $? -eq 1 ]] || exit 2
 
 echo "PASS"
-

--- a/verilog/tools/diff/diff_user_errors_test.sh
+++ b/verilog/tools/diff/diff_user_errors_test.sh
@@ -15,6 +15,20 @@
 
 # Tests verible-verilog-diff --mode=format
 
+# --- begin runfiles.bash initialization v2 ---
+# Copy-pasted from the Bazel Bash runfiles library v2.
+set -uo pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$0.runfiles/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
+# --- end runfiles.bash initialization v2 ---
+
+# Remove exit on failure set by runfiles.bash...
+set +e
+
 declare -r MY_INPUT_FILE1="${TEST_TMPDIR}/myinput1.txt"
 declare -r MY_INPUT_FILE2="${TEST_TMPDIR}/does_not_exist.txt"
 
@@ -23,7 +37,11 @@ declare -r MY_INPUT_FILE2="${TEST_TMPDIR}/does_not_exist.txt"
   echo "Expecting 1 positional argument, verible-verilog-diff path."
   exit 1
 }
-difftool="$1"
+# On Windows, runfiles are not symlinked (unless --enable_runfiles is active,
+# which causes other issues on bazel 3.7.0), so use rlocation to find the path
+# to the executable. On Unix, you could simply use $1, but using rlocation
+# works too
+difftool="$(rlocation ${TEST_WORKSPACE}/${1})"
 
 cat >${MY_INPUT_FILE1} <<EOF
   module    m   ;endmodule
@@ -43,4 +61,3 @@ EOF
 [[ $? -eq 2 ]] || exit 3
 
 echo "PASS"
-

--- a/verilog/tools/diff/diff_user_errors_test.sh
+++ b/verilog/tools/diff/diff_user_errors_test.sh
@@ -15,20 +15,6 @@
 
 # Tests verible-verilog-diff --mode=format
 
-# --- begin runfiles.bash initialization v2 ---
-# Copy-pasted from the Bazel Bash runfiles library v2.
-set -uo pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
-source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$0.runfiles/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
-# --- end runfiles.bash initialization v2 ---
-
-# Remove exit on failure set by runfiles.bash...
-set +e
-
 declare -r MY_INPUT_FILE1="${TEST_TMPDIR}/myinput1.txt"
 declare -r MY_INPUT_FILE2="${TEST_TMPDIR}/does_not_exist.txt"
 
@@ -37,10 +23,6 @@ declare -r MY_INPUT_FILE2="${TEST_TMPDIR}/does_not_exist.txt"
   echo "Expecting 1 positional argument, verible-verilog-diff path."
   exit 1
 }
-# On Windows, runfiles are not symlinked (unless --enable_runfiles is active,
-# which causes other issues on bazel 3.7.0), so use rlocation to find the path
-# to the executable. On Unix, you could simply use $1, but using rlocation
-# works too
 difftool="$(rlocation ${TEST_WORKSPACE}/${1})"
 
 cat >${MY_INPUT_FILE1} <<EOF

--- a/verilog/tools/formatter/BUILD
+++ b/verilog/tools/formatter/BUILD
@@ -1,6 +1,8 @@
 # 'verilog_format' is a SystemVerilog source code formatter.
 #
 
+load("//bazel:sh_test_with_runfiles_lib.bzl", "sh_test_with_runfiles_lib")
+
 licenses(["notice"])
 
 cc_binary(
@@ -52,74 +54,66 @@ sh_binary(
     srcs = ["triage_formatter.sh"],
 )
 
-sh_test(
+sh_test_with_runfiles_lib(
     name = "format_file_test",
     size = "small",
     srcs = ["format_file_test.sh"],
     args = ["$(location :verible-verilog-format)"],
     data = [":verible-verilog-format"],
-    deps = ["@bazel_tools//tools/bash/runfiles"],
 )
 
-sh_test(
+sh_test_with_runfiles_lib(
     name = "format_file_lex_error_test",
     size = "small",
     srcs = ["format_file_lex_error_test.sh"],
     args = ["$(location :verible-verilog-format)"],
     data = [":verible-verilog-format"],
-    deps = ["@bazel_tools//tools/bash/runfiles"],
 )
 
-sh_test(
+sh_test_with_runfiles_lib(
     name = "format_file_syntax_error_test",
     size = "small",
     srcs = ["format_file_syntax_error_test.sh"],
     args = ["$(location :verible-verilog-format)"],
     data = [":verible-verilog-format"],
-    deps = ["@bazel_tools//tools/bash/runfiles"],
 )
 
-sh_test(
+sh_test_with_runfiles_lib(
     name = "format_file_lines_test",
     size = "small",
     srcs = ["format_file_lines_test.sh"],
     args = ["$(location :verible-verilog-format)"],
     data = [":verible-verilog-format"],
-    deps = ["@bazel_tools//tools/bash/runfiles"],
 )
 
-sh_test(
+sh_test_with_runfiles_lib(
     name = "format_file_badlines_test",
     size = "small",
     srcs = ["format_file_badlines_test.sh"],
     args = ["$(location :verible-verilog-format)"],
     data = [":verible-verilog-format"],
-    deps = ["@bazel_tools//tools/bash/runfiles"],
 )
 
-sh_test(
+sh_test_with_runfiles_lib(
     name = "format_inplace_test",
     size = "small",
     srcs = ["format_inplace_test.sh"],
     args = ["$(location :verible-verilog-format)"],
     data = [":verible-verilog-format"],
-    deps = ["@bazel_tools//tools/bash/runfiles"],
 )
 
-sh_test(
+sh_test_with_runfiles_lib(
     name = "format_stdin_test",
     size = "small",
     srcs = ["format_stdin_test.sh"],
     args = ["$(location :verible-verilog-format)"],
     data = [":verible-verilog-format"],
-    deps = ["@bazel_tools//tools/bash/runfiles"],
 )
 
-sh_test(
+sh_test_with_runfiles_lib(
     name = "format_stdin_inplace_test",
     size = "small",
     srcs = ["format_stdin_inplace_test.sh"],
     args = ["$(location :verible-verilog-format)"],
     data = [":verible-verilog-format"],
-    deps = ["@bazel_tools//tools/bash/runfiles"],
 )

--- a/verilog/tools/formatter/BUILD
+++ b/verilog/tools/formatter/BUILD
@@ -58,6 +58,7 @@ sh_test(
     srcs = ["format_file_test.sh"],
     args = ["$(location :verible-verilog-format)"],
     data = [":verible-verilog-format"],
+    deps = ["@bazel_tools//tools/bash/runfiles"],
 )
 
 sh_test(
@@ -66,6 +67,7 @@ sh_test(
     srcs = ["format_file_lex_error_test.sh"],
     args = ["$(location :verible-verilog-format)"],
     data = [":verible-verilog-format"],
+    deps = ["@bazel_tools//tools/bash/runfiles"],
 )
 
 sh_test(
@@ -74,6 +76,7 @@ sh_test(
     srcs = ["format_file_syntax_error_test.sh"],
     args = ["$(location :verible-verilog-format)"],
     data = [":verible-verilog-format"],
+    deps = ["@bazel_tools//tools/bash/runfiles"],
 )
 
 sh_test(
@@ -82,6 +85,7 @@ sh_test(
     srcs = ["format_file_lines_test.sh"],
     args = ["$(location :verible-verilog-format)"],
     data = [":verible-verilog-format"],
+    deps = ["@bazel_tools//tools/bash/runfiles"],
 )
 
 sh_test(
@@ -90,6 +94,7 @@ sh_test(
     srcs = ["format_file_badlines_test.sh"],
     args = ["$(location :verible-verilog-format)"],
     data = [":verible-verilog-format"],
+    deps = ["@bazel_tools//tools/bash/runfiles"],
 )
 
 sh_test(
@@ -98,6 +103,7 @@ sh_test(
     srcs = ["format_inplace_test.sh"],
     args = ["$(location :verible-verilog-format)"],
     data = [":verible-verilog-format"],
+    deps = ["@bazel_tools//tools/bash/runfiles"],
 )
 
 sh_test(
@@ -106,6 +112,7 @@ sh_test(
     srcs = ["format_stdin_test.sh"],
     args = ["$(location :verible-verilog-format)"],
     data = [":verible-verilog-format"],
+    deps = ["@bazel_tools//tools/bash/runfiles"],
 )
 
 sh_test(
@@ -114,4 +121,5 @@ sh_test(
     srcs = ["format_stdin_inplace_test.sh"],
     args = ["$(location :verible-verilog-format)"],
     data = [":verible-verilog-format"],
+    deps = ["@bazel_tools//tools/bash/runfiles"],
 )

--- a/verilog/tools/formatter/format_file_badlines_test.sh
+++ b/verilog/tools/formatter/format_file_badlines_test.sh
@@ -15,6 +15,20 @@
 
 # Tests verible-verilog-format reading from a file, with malformed --lines.
 
+# --- begin runfiles.bash initialization v2 ---
+# Copy-pasted from the Bazel Bash runfiles library v2.
+set -uo pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$0.runfiles/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
+# --- end runfiles.bash initialization v2 ---
+
+# Remove exit on failure set by runfiles.bash...
+set +e
+
 declare -r MY_INPUT_FILE="${TEST_TMPDIR}/myinput.txt"
 declare -r MY_OUTPUT_FILE="${TEST_TMPDIR}/myoutput.txt"
 
@@ -23,7 +37,11 @@ declare -r MY_OUTPUT_FILE="${TEST_TMPDIR}/myoutput.txt"
   echo "Expecting 1 positional argument, verible-verilog-format path."
   exit 1
 }
-formatter="$1"
+# On Windows, runfiles are not symlinked (unless --enable_runfiles is active,
+# which causes other issues on bazel 3.7.0), so use rlocation to find the path
+# to the executable. On Unix, you could simply use $1, but using rlocation
+# works too
+formatter="$(rlocation ${TEST_WORKSPACE}/${1})"
 
 cat >${MY_INPUT_FILE} <<EOF
    parameter   int  var_line_1  =  1  ;

--- a/verilog/tools/formatter/format_file_badlines_test.sh
+++ b/verilog/tools/formatter/format_file_badlines_test.sh
@@ -15,20 +15,6 @@
 
 # Tests verible-verilog-format reading from a file, with malformed --lines.
 
-# --- begin runfiles.bash initialization v2 ---
-# Copy-pasted from the Bazel Bash runfiles library v2.
-set -uo pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
-source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$0.runfiles/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
-# --- end runfiles.bash initialization v2 ---
-
-# Remove exit on failure set by runfiles.bash...
-set +e
-
 declare -r MY_INPUT_FILE="${TEST_TMPDIR}/myinput.txt"
 declare -r MY_OUTPUT_FILE="${TEST_TMPDIR}/myoutput.txt"
 
@@ -37,10 +23,6 @@ declare -r MY_OUTPUT_FILE="${TEST_TMPDIR}/myoutput.txt"
   echo "Expecting 1 positional argument, verible-verilog-format path."
   exit 1
 }
-# On Windows, runfiles are not symlinked (unless --enable_runfiles is active,
-# which causes other issues on bazel 3.7.0), so use rlocation to find the path
-# to the executable. On Unix, you could simply use $1, but using rlocation
-# works too
 formatter="$(rlocation ${TEST_WORKSPACE}/${1})"
 
 cat >${MY_INPUT_FILE} <<EOF

--- a/verilog/tools/formatter/format_file_lex_error_test.sh
+++ b/verilog/tools/formatter/format_file_lex_error_test.sh
@@ -16,6 +16,20 @@
 # Tests verible-verilog-format reading from a file, printing to stdout.
 # File contains a syntax error.
 
+# --- begin runfiles.bash initialization v2 ---
+# Copy-pasted from the Bazel Bash runfiles library v2.
+set -uo pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$0.runfiles/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
+# --- end runfiles.bash initialization v2 ---
+
+# Remove exit on failure set by runfiles.bash...
+set +e
+
 declare -r MY_INPUT_FILE="${TEST_TMPDIR}/myinput.txt"
 declare -r MY_OUTPUT_FILE="${TEST_TMPDIR}/myoutput.txt"
 
@@ -24,7 +38,11 @@ declare -r MY_OUTPUT_FILE="${TEST_TMPDIR}/myoutput.txt"
   echo "Expecting 1 positional argument, verible-verilog-format path."
   exit 1
 }
-formatter="$1"
+# On Windows, runfiles are not symlinked (unless --enable_runfiles is active,
+# which causes other issues on bazel 3.7.0), so use rlocation to find the path
+# to the executable. On Unix, you could simply use $1, but using rlocation
+# works too
+formatter="$(rlocation ${TEST_WORKSPACE}/${1})"
 
 cat >${MY_INPUT_FILE} <<EOF
   module    777m   endmodule
@@ -33,16 +51,16 @@ EOF
 # Run formatter.  Expect error, but that redirected output matches input.
 "${formatter}" --nofailsafe_success "${MY_INPUT_FILE}" > "${MY_OUTPUT_FILE}"
 [[ "$?" -eq 1 ]] || exit 1
-diff "${MY_OUTPUT_FILE}" "${MY_INPUT_FILE}" || exit 2
+diff --strip-trailing-cr "${MY_OUTPUT_FILE}" "${MY_INPUT_FILE}" || exit 2
 
 # Want 0 exit code, even on input error.
 "${formatter}" --failsafe_success "${MY_INPUT_FILE}" > "${MY_OUTPUT_FILE}"
 [[ "$?" -eq 0 ]] || exit 3
-diff "${MY_OUTPUT_FILE}" "${MY_INPUT_FILE}" || exit 4
+diff --strip-trailing-cr "${MY_OUTPUT_FILE}" "${MY_INPUT_FILE}" || exit 4
 
 # Default is failsafe_success=true.
 "${formatter}" "${MY_INPUT_FILE}" > "${MY_OUTPUT_FILE}"
 [[ "$?" -eq 0 ]] || exit 5
-diff "${MY_OUTPUT_FILE}" "${MY_INPUT_FILE}" || exit 6
+diff --strip-trailing-cr "${MY_OUTPUT_FILE}" "${MY_INPUT_FILE}" || exit 6
 
 echo "PASS"

--- a/verilog/tools/formatter/format_file_lex_error_test.sh
+++ b/verilog/tools/formatter/format_file_lex_error_test.sh
@@ -16,20 +16,6 @@
 # Tests verible-verilog-format reading from a file, printing to stdout.
 # File contains a syntax error.
 
-# --- begin runfiles.bash initialization v2 ---
-# Copy-pasted from the Bazel Bash runfiles library v2.
-set -uo pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
-source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$0.runfiles/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
-# --- end runfiles.bash initialization v2 ---
-
-# Remove exit on failure set by runfiles.bash...
-set +e
-
 declare -r MY_INPUT_FILE="${TEST_TMPDIR}/myinput.txt"
 declare -r MY_OUTPUT_FILE="${TEST_TMPDIR}/myoutput.txt"
 
@@ -38,10 +24,6 @@ declare -r MY_OUTPUT_FILE="${TEST_TMPDIR}/myoutput.txt"
   echo "Expecting 1 positional argument, verible-verilog-format path."
   exit 1
 }
-# On Windows, runfiles are not symlinked (unless --enable_runfiles is active,
-# which causes other issues on bazel 3.7.0), so use rlocation to find the path
-# to the executable. On Unix, you could simply use $1, but using rlocation
-# works too
 formatter="$(rlocation ${TEST_WORKSPACE}/${1})"
 
 cat >${MY_INPUT_FILE} <<EOF

--- a/verilog/tools/formatter/format_file_lines_test.sh
+++ b/verilog/tools/formatter/format_file_lines_test.sh
@@ -15,6 +15,20 @@
 
 # Tests verible-verilog-format reading from a file, selecting --lines.
 
+# --- begin runfiles.bash initialization v2 ---
+# Copy-pasted from the Bazel Bash runfiles library v2.
+set -uo pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$0.runfiles/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
+# --- end runfiles.bash initialization v2 ---
+
+# Remove exit on failure set by runfiles.bash...
+set +e
+
 declare -r MY_INPUT_FILE="${TEST_TMPDIR}/myinput.txt"
 declare -r MY_OUTPUT_FILE="${TEST_TMPDIR}/myoutput.txt"
 declare -r MY_EXPECT_FILE="${TEST_TMPDIR}/myexpect.txt"
@@ -24,7 +38,11 @@ declare -r MY_EXPECT_FILE="${TEST_TMPDIR}/myexpect.txt"
   echo "Expecting 1 positional argument, verible-verilog-format path."
   exit 1
 }
-formatter="$1"
+# On Windows, runfiles are not symlinked (unless --enable_runfiles is active,
+# which causes other issues on bazel 3.7.0), so use rlocation to find the path
+# to the executable. On Unix, you could simply use $1, but using rlocation
+# works too
+formatter="$(rlocation ${TEST_WORKSPACE}/${1})"
 
 cat >${MY_INPUT_FILE} <<EOF
    parameter   int  var_line_1  =  1  ;
@@ -69,6 +87,6 @@ EOF
 # Run formatter.
 ${formatter} --lines 4-9 --lines 12-13,15,16 ${MY_INPUT_FILE} \
   > ${MY_OUTPUT_FILE} || exit 1
-diff "${MY_OUTPUT_FILE}" "${MY_EXPECT_FILE}" || exit 2
+diff --strip-trailing-cr "${MY_OUTPUT_FILE}" "${MY_EXPECT_FILE}" || exit 2
 
 echo "PASS"

--- a/verilog/tools/formatter/format_file_lines_test.sh
+++ b/verilog/tools/formatter/format_file_lines_test.sh
@@ -15,20 +15,6 @@
 
 # Tests verible-verilog-format reading from a file, selecting --lines.
 
-# --- begin runfiles.bash initialization v2 ---
-# Copy-pasted from the Bazel Bash runfiles library v2.
-set -uo pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
-source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$0.runfiles/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
-# --- end runfiles.bash initialization v2 ---
-
-# Remove exit on failure set by runfiles.bash...
-set +e
-
 declare -r MY_INPUT_FILE="${TEST_TMPDIR}/myinput.txt"
 declare -r MY_OUTPUT_FILE="${TEST_TMPDIR}/myoutput.txt"
 declare -r MY_EXPECT_FILE="${TEST_TMPDIR}/myexpect.txt"
@@ -38,10 +24,6 @@ declare -r MY_EXPECT_FILE="${TEST_TMPDIR}/myexpect.txt"
   echo "Expecting 1 positional argument, verible-verilog-format path."
   exit 1
 }
-# On Windows, runfiles are not symlinked (unless --enable_runfiles is active,
-# which causes other issues on bazel 3.7.0), so use rlocation to find the path
-# to the executable. On Unix, you could simply use $1, but using rlocation
-# works too
 formatter="$(rlocation ${TEST_WORKSPACE}/${1})"
 
 cat >${MY_INPUT_FILE} <<EOF

--- a/verilog/tools/formatter/format_file_syntax_error_test.sh
+++ b/verilog/tools/formatter/format_file_syntax_error_test.sh
@@ -16,20 +16,6 @@
 # Tests verible-verilog-format reading from a file, printing to stdout.
 # File contains a syntax error.
 
-# --- begin runfiles.bash initialization v2 ---
-# Copy-pasted from the Bazel Bash runfiles library v2.
-set -uo pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
-source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$0.runfiles/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
-# --- end runfiles.bash initialization v2 ---
-
-# Remove exit on failure set by runfiles.bash...
-set +e
-
 declare -r MY_INPUT_FILE="${TEST_TMPDIR}/myinput.txt"
 declare -r MY_OUTPUT_FILE="${TEST_TMPDIR}/myoutput.txt"
 
@@ -38,10 +24,6 @@ declare -r MY_OUTPUT_FILE="${TEST_TMPDIR}/myoutput.txt"
   echo "Expecting 1 positional argument, verible-verilog-format path."
   exit 1
 }
-# On Windows, runfiles are not symlinked (unless --enable_runfiles is active,
-# which causes other issues on bazel 3.7.0), so use rlocation to find the path
-# to the executable. On Unix, you could simply use $1, but using rlocation
-# works too
 formatter="$(rlocation ${TEST_WORKSPACE}/${1})"
 
 # syntax error: missing ';' or ports after 'm'

--- a/verilog/tools/formatter/format_file_test.sh
+++ b/verilog/tools/formatter/format_file_test.sh
@@ -15,6 +15,20 @@
 
 # Tests verible-verilog-format reading from a file, printing to stdout.
 
+# --- begin runfiles.bash initialization v2 ---
+# Copy-pasted from the Bazel Bash runfiles library v2.
+set -uo pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$0.runfiles/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
+# --- end runfiles.bash initialization v2 ---
+
+# Remove exit on failure set by runfiles.bash...
+set +e
+
 declare -r MY_INPUT_FILE="${TEST_TMPDIR}/myinput.txt"
 declare -r MY_OUTPUT_FILE="${TEST_TMPDIR}/myoutput.txt"
 declare -r MY_EXPECT_FILE="${TEST_TMPDIR}/myexpect.txt"
@@ -24,7 +38,11 @@ declare -r MY_EXPECT_FILE="${TEST_TMPDIR}/myexpect.txt"
   echo "Expecting 1 positional argument, verible-verilog-format path."
   exit 1
 }
-formatter="$1"
+# On Windows, runfiles are not symlinked (unless --enable_runfiles is active,
+# which causes other issues on bazel 3.7.0), so use rlocation to find the path
+# to the executable. On Unix, you could simply use $1, but using rlocation
+# works too
+formatter="$(rlocation ${TEST_WORKSPACE}/${1})"
 
 cat >${MY_INPUT_FILE} <<EOF
   module    m   ;endmodule
@@ -37,6 +55,6 @@ EOF
 
 # Run formatter.
 ${formatter} ${MY_INPUT_FILE} > ${MY_OUTPUT_FILE} || exit 1
-diff "${MY_OUTPUT_FILE}" "${MY_EXPECT_FILE}" || exit 2
+diff --strip-trailing-cr "${MY_OUTPUT_FILE}" "${MY_EXPECT_FILE}" || exit 2
 
 echo "PASS"

--- a/verilog/tools/formatter/format_file_test.sh
+++ b/verilog/tools/formatter/format_file_test.sh
@@ -15,20 +15,6 @@
 
 # Tests verible-verilog-format reading from a file, printing to stdout.
 
-# --- begin runfiles.bash initialization v2 ---
-# Copy-pasted from the Bazel Bash runfiles library v2.
-set -uo pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
-source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$0.runfiles/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
-# --- end runfiles.bash initialization v2 ---
-
-# Remove exit on failure set by runfiles.bash...
-set +e
-
 declare -r MY_INPUT_FILE="${TEST_TMPDIR}/myinput.txt"
 declare -r MY_OUTPUT_FILE="${TEST_TMPDIR}/myoutput.txt"
 declare -r MY_EXPECT_FILE="${TEST_TMPDIR}/myexpect.txt"
@@ -38,10 +24,6 @@ declare -r MY_EXPECT_FILE="${TEST_TMPDIR}/myexpect.txt"
   echo "Expecting 1 positional argument, verible-verilog-format path."
   exit 1
 }
-# On Windows, runfiles are not symlinked (unless --enable_runfiles is active,
-# which causes other issues on bazel 3.7.0), so use rlocation to find the path
-# to the executable. On Unix, you could simply use $1, but using rlocation
-# works too
 formatter="$(rlocation ${TEST_WORKSPACE}/${1})"
 
 cat >${MY_INPUT_FILE} <<EOF

--- a/verilog/tools/formatter/format_inplace_test.sh
+++ b/verilog/tools/formatter/format_inplace_test.sh
@@ -15,6 +15,20 @@
 
 # Tests the --inplace flag of verible-verilog-format.
 
+# --- begin runfiles.bash initialization v2 ---
+# Copy-pasted from the Bazel Bash runfiles library v2.
+set -uo pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$0.runfiles/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
+# --- end runfiles.bash initialization v2 ---
+
+# Remove exit on failure set by runfiles.bash...
+set +e
+
 declare -r MY_OUTPUT_FILE="${TEST_TMPDIR}/myoutput.txt"
 declare -r MY_EXPECT_FILE="${TEST_TMPDIR}/myexpect.txt"
 
@@ -23,7 +37,11 @@ declare -r MY_EXPECT_FILE="${TEST_TMPDIR}/myexpect.txt"
   echo "Expecting 1 positional argument, verible-verilog-format path."
   exit 1
 }
-formatter="$1"
+# On Windows, runfiles are not symlinked (unless --enable_runfiles is active,
+# which causes other issues on bazel 3.7.0), so use rlocation to find the path
+# to the executable. On Unix, you could simply use $1, but using rlocation
+# works too
+formatter="$(rlocation ${TEST_WORKSPACE}/${1})"
 
 # Will overwrite this file in-place.
 cat >${MY_OUTPUT_FILE} <<EOF
@@ -37,6 +55,6 @@ EOF
 
 # Run formatter.
 ${formatter} --inplace ${MY_OUTPUT_FILE} || exit 1
-diff "${MY_OUTPUT_FILE}" "${MY_EXPECT_FILE}" || exit 2
+diff --strip-trailing-cr "${MY_OUTPUT_FILE}" "${MY_EXPECT_FILE}" || exit 2
 
 echo "PASS"

--- a/verilog/tools/formatter/format_inplace_test.sh
+++ b/verilog/tools/formatter/format_inplace_test.sh
@@ -15,20 +15,6 @@
 
 # Tests the --inplace flag of verible-verilog-format.
 
-# --- begin runfiles.bash initialization v2 ---
-# Copy-pasted from the Bazel Bash runfiles library v2.
-set -uo pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
-source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$0.runfiles/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
-# --- end runfiles.bash initialization v2 ---
-
-# Remove exit on failure set by runfiles.bash...
-set +e
-
 declare -r MY_OUTPUT_FILE="${TEST_TMPDIR}/myoutput.txt"
 declare -r MY_EXPECT_FILE="${TEST_TMPDIR}/myexpect.txt"
 
@@ -37,11 +23,7 @@ declare -r MY_EXPECT_FILE="${TEST_TMPDIR}/myexpect.txt"
   echo "Expecting 1 positional argument, verible-verilog-format path."
   exit 1
 }
-# On Windows, runfiles are not symlinked (unless --enable_runfiles is active,
-# which causes other issues on bazel 3.7.0), so use rlocation to find the path
-# to the executable. On Unix, you could simply use $1, but using rlocation
-# works too
-formatter="$(rlocation ${TEST_WORKSPACE}/${1})"
+formatter="$(rlocation ${TEST_WORKSPACE}/$1)"
 
 # Will overwrite this file in-place.
 cat >${MY_OUTPUT_FILE} <<EOF

--- a/verilog/tools/formatter/format_stdin_inplace_test.sh
+++ b/verilog/tools/formatter/format_stdin_inplace_test.sh
@@ -15,20 +15,6 @@
 
 # Tests - as stdin for verible-verilog-format, ignoring --inplace.
 
-# --- begin runfiles.bash initialization v2 ---
-# Copy-pasted from the Bazel Bash runfiles library v2.
-set -uo pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
-source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$0.runfiles/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
-# --- end runfiles.bash initialization v2 ---
-
-# Remove exit on failure set by runfiles.bash...
-set +e
-
 declare -r MY_INPUT_FILE="${TEST_TMPDIR}/myinput.txt"
 declare -r MY_OUTPUT_FILE="${TEST_TMPDIR}/myoutput.txt"
 declare -r MY_EXPECT_FILE="${TEST_TMPDIR}/myexpect.txt"
@@ -38,10 +24,6 @@ declare -r MY_EXPECT_FILE="${TEST_TMPDIR}/myexpect.txt"
   echo "Expecting 1 positional argument, verible-verilog-format path."
   exit 1
 }
-# On Windows, runfiles are not symlinked (unless --enable_runfiles is active,
-# which causes other issues on bazel 3.7.0), so use rlocation to find the path
-# to the executable. On Unix, you could simply use $1, but using rlocation
-# works too
 formatter="$(rlocation ${TEST_WORKSPACE}/${1})"
 
 # Will overwrite this file in-place.

--- a/verilog/tools/formatter/format_stdin_inplace_test.sh
+++ b/verilog/tools/formatter/format_stdin_inplace_test.sh
@@ -15,6 +15,20 @@
 
 # Tests - as stdin for verible-verilog-format, ignoring --inplace.
 
+# --- begin runfiles.bash initialization v2 ---
+# Copy-pasted from the Bazel Bash runfiles library v2.
+set -uo pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$0.runfiles/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
+# --- end runfiles.bash initialization v2 ---
+
+# Remove exit on failure set by runfiles.bash...
+set +e
+
 declare -r MY_INPUT_FILE="${TEST_TMPDIR}/myinput.txt"
 declare -r MY_OUTPUT_FILE="${TEST_TMPDIR}/myoutput.txt"
 declare -r MY_EXPECT_FILE="${TEST_TMPDIR}/myexpect.txt"
@@ -24,7 +38,11 @@ declare -r MY_EXPECT_FILE="${TEST_TMPDIR}/myexpect.txt"
   echo "Expecting 1 positional argument, verible-verilog-format path."
   exit 1
 }
-formatter="$1"
+# On Windows, runfiles are not symlinked (unless --enable_runfiles is active,
+# which causes other issues on bazel 3.7.0), so use rlocation to find the path
+# to the executable. On Unix, you could simply use $1, but using rlocation
+# works too
+formatter="$(rlocation ${TEST_WORKSPACE}/${1})"
 
 # Will overwrite this file in-place.
 cat >${MY_INPUT_FILE} <<EOF
@@ -38,6 +56,6 @@ EOF
 
 # Pipe text through formatter.
 cat ${MY_INPUT_FILE} | ${formatter} --inplace - > ${MY_OUTPUT_FILE} || exit 1
-diff "${MY_OUTPUT_FILE}" "${MY_EXPECT_FILE}" || exit 2
+diff --strip-trailing-cr "${MY_OUTPUT_FILE}" "${MY_EXPECT_FILE}" || exit 2
 
 echo "PASS"

--- a/verilog/tools/formatter/format_stdin_test.sh
+++ b/verilog/tools/formatter/format_stdin_test.sh
@@ -15,6 +15,20 @@
 
 # Tests - as stdin for verible-verilog-format.
 
+# --- begin runfiles.bash initialization v2 ---
+# Copy-pasted from the Bazel Bash runfiles library v2.
+set -uo pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$0.runfiles/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
+# --- end runfiles.bash initialization v2 ---
+
+# Remove exit on failure set by runfiles.bash...
+set +e
+
 declare -r MY_INPUT_FILE="${TEST_TMPDIR}/myinput.txt"
 declare -r MY_OUTPUT_FILE="${TEST_TMPDIR}/myoutput.txt"
 declare -r MY_EXPECT_FILE="${TEST_TMPDIR}/myexpect.txt"
@@ -24,7 +38,11 @@ declare -r MY_EXPECT_FILE="${TEST_TMPDIR}/myexpect.txt"
   echo "Expecting 1 positional argument, verible-verilog-format path."
   exit 1
 }
-formatter="$1"
+# On Windows, runfiles are not symlinked (unless --enable_runfiles is active,
+# which causes other issues on bazel 3.7.0), so use rlocation to find the path
+# to the executable. On Unix, you could simply use $1, but using rlocation
+# works too
+formatter="$(rlocation ${TEST_WORKSPACE}/${1})"
 
 # Will overwrite this file in-place.
 cat >${MY_INPUT_FILE} <<EOF
@@ -38,6 +56,6 @@ EOF
 
 # Pipe text through formatter.
 cat "${MY_INPUT_FILE}" | ${formatter} - > ${MY_OUTPUT_FILE} || exit 1
-diff "${MY_OUTPUT_FILE}" "${MY_EXPECT_FILE}" || exit 2
+diff --strip-trailing-cr "${MY_OUTPUT_FILE}" "${MY_EXPECT_FILE}" || exit 2
 
 echo "PASS"

--- a/verilog/tools/formatter/format_stdin_test.sh
+++ b/verilog/tools/formatter/format_stdin_test.sh
@@ -15,20 +15,6 @@
 
 # Tests - as stdin for verible-verilog-format.
 
-# --- begin runfiles.bash initialization v2 ---
-# Copy-pasted from the Bazel Bash runfiles library v2.
-set -uo pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
-source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$0.runfiles/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
-# --- end runfiles.bash initialization v2 ---
-
-# Remove exit on failure set by runfiles.bash...
-set +e
-
 declare -r MY_INPUT_FILE="${TEST_TMPDIR}/myinput.txt"
 declare -r MY_OUTPUT_FILE="${TEST_TMPDIR}/myoutput.txt"
 declare -r MY_EXPECT_FILE="${TEST_TMPDIR}/myexpect.txt"
@@ -38,10 +24,6 @@ declare -r MY_EXPECT_FILE="${TEST_TMPDIR}/myexpect.txt"
   echo "Expecting 1 positional argument, verible-verilog-format path."
   exit 1
 }
-# On Windows, runfiles are not symlinked (unless --enable_runfiles is active,
-# which causes other issues on bazel 3.7.0), so use rlocation to find the path
-# to the executable. On Unix, you could simply use $1, but using rlocation
-# works too
 formatter="$(rlocation ${TEST_WORKSPACE}/${1})"
 
 # Will overwrite this file in-place.

--- a/verilog/tools/kythe/BUILD
+++ b/verilog/tools/kythe/BUILD
@@ -235,7 +235,7 @@ sh_test(
     srcs = ["verilog_kythe_extractor_test.sh"],
     args = ["$(location :verible-verilog-kythe-extractor)"],
     data = [":verible-verilog-kythe-extractor"],
-    deps = [],
+    deps = ["@bazel_tools//tools/bash/runfiles"],
 )
 
 sh_test(

--- a/verilog/tools/kythe/BUILD
+++ b/verilog/tools/kythe/BUILD
@@ -1,5 +1,7 @@
 # 'verible-verilog-kythe-extractor' is a program for extracting Verilog/SystemVerilog to kythe facts.
 
+load("//bazel:sh_test_with_runfiles_lib.bzl", "sh_test_with_runfiles_lib")
+
 licenses(["notice"])
 
 package(
@@ -229,13 +231,13 @@ cc_binary(
     ],
 )
 
-sh_test(
+sh_test_with_runfiles_lib(
     name = "verilog_kythe_extractor_test",
     size = "small",
     srcs = ["verilog_kythe_extractor_test.sh"],
     args = ["$(location :verible-verilog-kythe-extractor)"],
     data = [":verible-verilog-kythe-extractor"],
-    deps = ["@bazel_tools//tools/bash/runfiles"],
+    deps = [],
 )
 
 sh_test(

--- a/verilog/tools/kythe/kythe_proto_output.cc
+++ b/verilog/tools/kythe/kythe_proto_output.cc
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "verilog/tools/kythe/kythe_proto_output.h"
+
 #ifndef _WIN32
 #include <unistd.h>  // for STDOUT_FILENO
 #else
@@ -24,7 +26,6 @@
 #include "third_party/proto/kythe/storage.pb.h"
 #include "verilog/tools/kythe/kythe_facts.h"
 #include "verilog/tools/kythe/kythe_facts_extractor.h"
-#include "verilog/tools/kythe/kythe_proto_output.h"
 
 namespace verilog {
 namespace kythe {

--- a/verilog/tools/kythe/kythe_proto_output.cc
+++ b/verilog/tools/kythe/kythe_proto_output.cc
@@ -12,9 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "verilog/tools/kythe/kythe_proto_output.h"
+#ifndef _WIN32
+#include <unistd.h>  // for STDOUT_FILENO
+#else
+#include <stdio.h>
+#define STDOUT_FILENO _fileno(stdout)
+#endif
 
-#include <unistd.h>
+#include "verilog/tools/kythe/kythe_proto_output.h"
 
 #include "google/protobuf/io/coded_stream.h"
 #include "google/protobuf/io/zero_copy_stream_impl.h"

--- a/verilog/tools/kythe/kythe_proto_output.cc
+++ b/verilog/tools/kythe/kythe_proto_output.cc
@@ -19,13 +19,12 @@
 #define STDOUT_FILENO _fileno(stdout)
 #endif
 
-#include "verilog/tools/kythe/kythe_proto_output.h"
-
 #include "google/protobuf/io/coded_stream.h"
 #include "google/protobuf/io/zero_copy_stream_impl.h"
 #include "third_party/proto/kythe/storage.pb.h"
 #include "verilog/tools/kythe/kythe_facts.h"
 #include "verilog/tools/kythe/kythe_facts_extractor.h"
+#include "verilog/tools/kythe/kythe_proto_output.h"
 
 namespace verilog {
 namespace kythe {

--- a/verilog/tools/kythe/verilog_kythe_extractor_test.sh
+++ b/verilog/tools/kythe/verilog_kythe_extractor_test.sh
@@ -13,20 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# --- begin runfiles.bash initialization v2 ---
-# Copy-pasted from the Bazel Bash runfiles library v2.
-set -uo pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
-source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$0.runfiles/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
-# --- end runfiles.bash initialization v2 ---
-
-# Remove exit on failure set by runfiles.bash...
-set +e
-
 # Find input files
 MY_INPUT_FILE="${TEST_TMPDIR}/myinput.txt"
 readonly MY_INPUT_FILE
@@ -40,11 +26,6 @@ readonly MY_EXPECT_FILE
   echo "Expecting 1 positional argument, verible-verilog-kythe-extractor path."
   exit 1
 }
-
-# On Windows, runfiles are not symlinked (unless --enable_runfiles is active,
-# which causes other issues on bazel 3.7.0), so use rlocation to find the path
-# to the executable. On Unix, you could simply use $1, but using rlocation
-# works too
 extractor="$(rlocation ${TEST_WORKSPACE}/${1})"
 
 ################################################################################


### PR DESCRIPTION
Verible now compiles on Windows! Work is not over, as not all test succeeds yet. The changes to make it compile is minimal, only replacing `unistd.h` with the appropriate Windows equivalent.

Making testing works, which is very much a WIP, revolves around 2 cookie-cutter fix that needs review:

1. On Windows, bazel doesn't symlink runfiles by default (you must have a recent Windows and enable developer mode for it) and instead create a `MANIFEST` file with the requested runfiles (refer to this [issue](https://github.com/bazelbuild/bazel/issues/8843)). Using the `--enable_runfiles` flag caused other issues with *very* long path that made some test fail. I couldn't fix that long path issue, it would require renaming some tests that have excessively long names.

    Instead, I modified the `sh_test` targets to include a bazel script allowing to get the fullpath of the desired resource, and modified the script accordingly.

2. The Verible tools output CRLF instead of the test-expected LF. I decided to ignore line endings (thus making test pass) for now. I suggest to open an issue to discuss how to handle line endings and modify/add tests accordingly at a later stage. IMHO, using CRLF on Windows is fine, `git` by default converts line endings with the `core.autocrlf` settings and there is `dos2unix` that can be added to scripts if it is an issue. I think the issue merits more thought, but shouldn't be a blocker to proceed with Windows support.