### PR TITLE
Provide IsInteractiveTerminalSession().

### DIFF
--- a/common/strings/patch.cc
+++ b/common/strings/patch.cc
@@ -14,14 +14,6 @@
 
 #include "common/strings/patch.h"
 
-#ifndef _WIN32
-#include <unistd.h>  // for isatty
-#else
-#include <io.h>
-// MSVC recommends to use _isatty...
-#define isatty _isatty
-#endif
-
 #include <deque>
 #include <iostream>
 #include <iterator>
@@ -378,7 +370,9 @@ LineNumberSet FilePatch::AddedLines() const {
 
 static char PromptHunkAction(std::istream& ins, std::ostream& outs) {
   // Suppress prompt in noninteractive mode.
-  if (isatty(0)) outs << "Apply this hunk? [y,n,a,d,s,q,?] ";
+  if (file::IsInteractiveTerminalSession()) {
+    outs << "Apply this hunk? [y,n,a,d,s,q,?] ";
+  }
   char c;
   ins >> c;  // user will need to hit <enter> after the character
   if (ins.eof()) {

--- a/common/tools/patch_tool.cc
+++ b/common/tools/patch_tool.cc
@@ -12,14 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _WIN32
-#include <unistd.h>  // for isatty
-#else
-#include <io.h>
-// MSVC recommends to use _isatty...
-#define isatty _isatty
-#endif
-
 #include <functional>
 #include <iostream>
 #include <string>
@@ -101,7 +93,7 @@ static absl::Status StdinTest(const SubcommandArgsRange& args,
   for (; file_count < kOpenLimit; ++file_count) {
     outs << "==== file " << file_count << " ====" << std::endl;
     while (ins) {
-      if (isatty(0)) outs << "enter text: ";
+      if (verible::file::IsInteractiveTerminalSession()) outs << "enter text: ";
       std::getline(ins, line);
       outs << "echo: " << line << std::endl;
     }

--- a/common/util/file_util.cc
+++ b/common/util/file_util.cc
@@ -32,6 +32,14 @@
 #include "absl/strings/string_view.h"
 #include "common/util/logging.h"
 
+#ifndef _WIN32
+#include <unistd.h>  // for isatty
+#else
+#include <io.h>
+// MSVC recommends to use _isatty...
+#define isatty _isatty
+#endif
+
 /*
  * We're in the transition to use std::filesystem for all file operations.
  * However some ancient compilers in releasing/ can't handle that yet. Until
@@ -369,6 +377,10 @@ absl::StatusOr<Directory> ListDir(absl::string_view dir) {
   std::sort(d.files.begin(), d.files.end());
   std::sort(d.directories.begin(), d.directories.end());
   return d;
+}
+
+bool IsInteractiveTerminalSession() {
+  return isatty(0);  // Unix: STDIN_FILENO; windows: _fileno( stdin )
 }
 
 namespace testing {

--- a/common/util/file_util.h
+++ b/common/util/file_util.h
@@ -81,6 +81,10 @@ absl::Status CreateDir(absl::string_view dir);
 // TODO (after bump to c++17) rewrite this function to use std::filesystem
 absl::StatusOr<Directory> ListDir(absl::string_view dir);
 
+// Returns if this is likely a terminal session (tests if stdin filedescriptor
+// is a terminal).
+bool IsInteractiveTerminalSession();
+
 namespace testing {
 
 // Generate a random file name (no directory).  This does not create any file.


### PR DESCRIPTION
This encapsulates the isatty() call and the different
includes needed on Unix and Windows.

Issues #307

Signed-off-by: Henner Zeller <h.zeller@acm.org>