### PR TITLE
Make obfuscator save format robust against leading/trailing whitespac…

### DIFF
--- a/common/strings/obfuscator.cc
+++ b/common/strings/obfuscator.cc
@@ -22,6 +22,7 @@
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_split.h"
 #include "absl/strings/string_view.h"
+#include "absl/strings/strip.h"
 #include "common/util/logging.h"
 
 namespace verible {
@@ -46,7 +47,7 @@ constexpr char kPairSeparator = ' ';
 std::string Obfuscator::save() const {
   std::ostringstream stream;
   for (const auto& pair : translator_.forward_view()) {
-    stream << pair.first << kPairSeparator << *pair.second << std::endl;
+    stream << pair.first << kPairSeparator << *pair.second << "\n";
   }
   return stream.str();
 }
@@ -56,7 +57,7 @@ absl::Status Obfuscator::load(absl::string_view mapping) {
       absl::StrSplit(mapping, '\n', absl::SkipEmpty());
   for (const auto& line : lines) {
     const std::vector<absl::string_view> elements =
-        absl::StrSplit(line, kPairSeparator);
+        absl::StrSplit(absl::StripAsciiWhitespace(line), kPairSeparator);
     if (elements.size() < 2) {
       return absl::InvalidArgumentError(
           absl::StrCat("Failed to parse line:\n", line));

--- a/common/strings/obfuscator_test.cc
+++ b/common/strings/obfuscator_test.cc
@@ -146,6 +146,12 @@ TEST(ObfuscatorTest, LoadMap) {
   }
   {
     Obfuscator ob(RotateGenerator);
+    const auto status = ob.load("  cat dog  \r\n");
+    EXPECT_TRUE(status.ok()) << status.message();
+    EXPECT_EQ(ob("cat"), "dog");
+  }
+  {
+    Obfuscator ob(RotateGenerator);
     const auto status = ob.load("cat\n");  // malformed line
     EXPECT_FALSE(status.ok());
     EXPECT_EQ(status.code(), absl::StatusCode::kInvalidArgument);


### PR DESCRIPTION
…e in lines.

In particular on Windows it is possible that we see a file
with \r\n characters.

Issues #307

Signed-off-by: Henner Zeller <h.zeller@acm.org>