### PR TITLE
Use `common` for platform-specific bazel configs:

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -13,20 +13,13 @@ build --enable_platform_specific_config
 
 # Use C++17 (bazel defaults to C++0x (pre-C++11))
 # TODO(b/171679296): Lower the requirement, go back to c++11
-build:linux --cxxopt=-std=c++17 --host_cxxopt=-std=c++17 --client_env=BAZEL_CXXOPTS=-std=c++17
-run:linux --cxxopt=-std=c++17 --host_cxxopt=-std=c++17 --client_env=BAZEL_CXXOPTS=-std=c++17
-test:linux --cxxopt=-std=c++17 --host_cxxopt=-std=c++17 --client_env=BAZEL_CXXOPTS=-std=c++17
-
-build:macos --cxxopt=-std=c++17 --host_cxxopt=-std=c++17 --client_env=BAZEL_CXXOPTS=-std=c++17
-run:macos --cxxopt=-std=c++17 --host_cxxopt=-std=c++17 --client_env=BAZEL_CXXOPTS=-std=c++17
+common:linux --cxxopt=-std=c++17 --host_cxxopt=-std=c++17 --client_env=BAZEL_CXXOPTS=-std=c++17
 
 # https://github.com/abseil/abseil-cpp/issues/848
 # https://github.com/bazelbuild/bazel/issues/4341#issuecomment-758361769
-test:macos --features=-supports_dynamic_linker --cxxopt=-std=c++17 --host_cxxopt=-std=c++17 --client_env=BAZEL_CXXOPTS=-std=c++17
+common:macos --features=-supports_dynamic_linker --cxxopt=-std=c++17 --host_cxxopt=-std=c++17 --client_env=BAZEL_CXXOPTS=-std=c++17
 
 # Force the use clang-cl on Windows instead of MSVC. MSVC has some issues with
 # the codebase, so we focus the effort for now is to have a Windows Verible
 # compiled with clang-cl before fixing the issues unique to MSVC.
-build:windows --compiler=clang-cl --cxxopt=/std:c++17 --host_cxxopt=/std:c++17 --client_env=BAZEL_CXXOPTS=/std:c++17
-run:windows --compiler=clang-cl --cxxopt=/std:c++17 --host_cxxopt=/std:c++17 --client_env=BAZEL_CXXOPTS=/std:c++17
-test:windows --compiler=clang-cl --cxxopt=/std:c++17 --host_cxxopt=/std:c++17 --client_env=BAZEL_CXXOPTS=/std:c++17
+common:windows --compiler=clang-cl --cxxopt=/std:c++17 --host_cxxopt=/std:c++17 --client_env=BAZEL_CXXOPTS=/std:c++17


### PR DESCRIPTION
- Use `common` options instead of separate `build`, `run`, `test` command options.

- Prevents invalidation of bazel cache due to changed compiler options.
  Reduces compile time of consecutive bazel build, test, run commands.

- A single `build` option line per platform works also since `test` and
  `run` command options inherit options from `build`, according to
  https://docs.bazel.build/versions/master/guide.html#bazelrc-syntax-and-semantics

- Extends abseil compile fix (--features=-supports_dynamic_linker) from macos:test to macos:build and macos:run.
