### PR TITLE
Include tokens text in JSON output

### DIFF
--- a/common/text/token_info_json.cc
+++ b/common/text/token_info_json.cc
@@ -22,13 +22,18 @@
 namespace verible {
 
 Json::Value ToJson(const TokenInfo& token_info,
-                   const TokenInfo::Context& context) {
+                   const TokenInfo::Context& context, bool include_text) {
   Json::Value json(Json::objectValue);
   std::ostringstream stream;
   context.token_enum_translator(stream, token_info.token_enum());
   json["start"] = token_info.left(context.base);
   json["end"] = token_info.right(context.base);
   json["tag"] = stream.str();
+
+  if (include_text) {
+    json["text"] = std::string(token_info.text());
+  }
+
   return json;
 }
 

--- a/common/text/token_info_json.h
+++ b/common/text/token_info_json.h
@@ -22,7 +22,8 @@ namespace verible {
 
 // Returns JSON representation of TokenInfo
 Json::Value ToJson(const TokenInfo& token_info,
-                   const TokenInfo::Context& context);
+                   const TokenInfo::Context& context,
+                   bool include_text = false);
 
 }  // namespace verible
 

--- a/common/text/token_info_json_test.cc
+++ b/common/text/token_info_json_test.cc
@@ -38,13 +38,18 @@ TEST(TokenInfoToJsonTest, ToJsonEOF) {
   const TokenInfo::Context context(base);
   const TokenInfo token_info(TK_EOF, base);
 
-  const Json::Value json(ToJson(token_info, context));
-  const Json::Value expected_json = ParseJson(R"({
+  EXPECT_EQ(ToJson(token_info, context), ParseJson(R"({
     "start": 0,
     "end": 0,
     "tag": "0"
-  })");
-  EXPECT_EQ(json, expected_json);
+  })"));
+
+  EXPECT_EQ(ToJson(token_info, context, true), ParseJson(R"({
+    "start": 0,
+    "end": 0,
+    "tag": "0",
+    "text": ""
+  })"));
 }
 
 TEST(TokenInfoToJsonTest, ToJsonWithBase) {
@@ -52,13 +57,18 @@ TEST(TokenInfoToJsonTest, ToJsonWithBase) {
   const TokenInfo::Context context(base);
   const TokenInfo token_info(7, base.substr(9, 3));
 
-  const Json::Value json(ToJson(token_info, context));
-  const Json::Value expected_json = ParseJson(R"({
+  EXPECT_EQ(ToJson(token_info, context), ParseJson(R"({
     "start": 9,
     "end": 12,
     "tag": "7"
-  })");
-  EXPECT_EQ(json, expected_json);
+  })"));
+
+  EXPECT_EQ(ToJson(token_info, context, true), ParseJson(R"({
+    "start": 9,
+    "end": 12,
+    "tag": "7",
+    "text": "cat"
+  })"));
 }
 
 TEST(TokenInfoToJsonTest, ToJsonWithTokenEnumTranslator) {
@@ -68,13 +78,18 @@ TEST(TokenInfoToJsonTest, ToJsonWithTokenEnumTranslator) {
   const verible::TokenInfo::Context context(
       text, [](std::ostream& stream, int e) { stream << "token enum " << e; });
 
-  const Json::Value json(ToJson(token_info, context));
-  const Json::Value expected_json = ParseJson(R"({
+  EXPECT_EQ(ToJson(token_info, context), ParseJson(R"({
     "start": 0,
     "end": 19,
     "tag": "token enum 143"
-  })");
-  EXPECT_EQ(json, expected_json);
+  })"));
+
+  EXPECT_EQ(ToJson(token_info, context, true), ParseJson(R"({
+    "start": 0,
+    "end": 19,
+    "tag": "token enum 143",
+    "text": "string of length 19"
+  })"));
 }
 
 }  // namespace

--- a/verilog/CST/BUILD
+++ b/verilog/CST/BUILD
@@ -908,6 +908,7 @@ cc_library(
         "//common/text:token_info_json",
         "//common/util:value_saver",
         "//verilog/parser:verilog_token",
+        "//verilog/parser:verilog_token_classifications",
         "@com_google_absl//absl/strings",
         "@jsoncpp_git//:jsoncpp",
     ],

--- a/verilog/CST/verilog_tree_json_test.cc
+++ b/verilog/CST/verilog_tree_json_test.cc
@@ -56,7 +56,7 @@ TEST(VerilogTreeJsonTest, GeneratesGoodJsonTree) {
            "children": [
              { "start": 0, "end": 6, "tag": "module" },
              null,
-             { "start": 7, "end": 10, "tag": "SymbolIdentifier" },
+             { "start": 7, "end": 10, "tag": "SymbolIdentifier", "text": "foo" },
              null,
              null,
              null,

--- a/verilog/tools/syntax/BUILD
+++ b/verilog/tools/syntax/BUILD
@@ -27,6 +27,7 @@ cc_binary(
         "//verilog/analysis/checkers:verilog_lint_rules",
         "//verilog/parser:verilog_parser",
         "//verilog/parser:verilog_token",
+        "//verilog/parser:verilog_token_classifications",
         "@com_google_absl//absl/flags:flag",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/strings",

--- a/verilog/tools/syntax/README.md
+++ b/verilog/tools/syntax/README.md
@@ -220,12 +220,13 @@ The tree consist of [Node](#Node-object) and [Token](#Token-object) objects. The
 
 #### Token object
 
-| Key            | Type   | Description                                        |
-|----------------|--------|----------------------------------------------------|
-| `start`, `end` | int    | Byte offset of token's first character and a character just past the symbol in source text. |
-| `tag`          | string | Token tag. See [Possible token tag values](#possible-token-tag-values) below for details. |
+| Key               | Type   | Description                                        |
+|-------------------|--------|----------------------------------------------------|
+| `start`, `end`    | int    | Byte offset of token's first character and a character just past the symbol in source text. |
+| `tag`             | string | Token tag. See [Possible token tag values](#possible-token-tag-values) below for details. |
+| `text` (optional) | string | Token text. Not present in operator and keyword token objects. |
 
-To get token text, read source file from byte `start` (included) to byte `end` (excluded). Example in Python:
+To get token text, either use `text` value (if present), or read source file from byte `start` (included) to byte `end` (excluded). Example in Python:
 
 ```python
 start = token["start"]


### PR DESCRIPTION
Adds `text` field containing token text to all token nodes except those representing operators and keywords.

Closes #743 