### PR TITLE
Use latest gflags, which does not produce a fallthrough-warning.

### DIFF
--- a/.github/bin/build-and-test.sh
+++ b/.github/bin/build-and-test.sh
@@ -33,6 +33,9 @@ BAZEL_OPTS="${BAZEL_OPTS} --cxxopt=-Wall --cxxopt=-Wextra"
 BAZEL_OPTS="${BAZEL_OPTS} --cxxopt=-Wno-unused-parameter"
 BAZEL_OPTS="${BAZEL_OPTS} --cxxopt=-Wno-missing-field-initializers"
 
+# Currently there is a break missing introduced in #802
+BAZEL_OPTS="${BAZEL_OPTS} --cxxopt=-Wno-implicit-fallthrough"
+
 # Warnings in our code-base, that we might consider removing.
 BAZEL_OPTS="${BAZEL_OPTS} --cxxopt=-Wno-redundant-move"
 
@@ -45,7 +48,6 @@ BAZEL_OPTS="${BAZEL_OPTS} --cxxopt=-Wno-array-bounds"
 # tight warnings on for 'our' code-base.
 # TODO(hzeller): Remove after https://github.com/google/verible/issues/747
 #                is figure out
-BAZEL_OPTS="${BAZEL_OPTS} --cxxopt=-Wno-implicit-fallthrough"     # gflags
 BAZEL_OPTS="${BAZEL_OPTS} --cxxopt=-Wno-cast-function-type"       # gflags
 BAZEL_OPTS="${BAZEL_OPTS} --cxxopt=-Wno-deprecated-declarations"  # jsconcpp
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -36,9 +36,9 @@ http_archive(
 # extra dependency.
 http_archive(
     name = "com_github_gflags_gflags",
-    sha256 = "34af2f15cf7367513b352bdcd2493ab14ce43692d2dcd9dfc499492966c64dcf",
-    strip_prefix = "gflags-2.2.2",
-    urls = ["https://github.com/gflags/gflags/archive/v2.2.2.tar.gz"],
+    sha256 = "cfdba0f2f17e8b1ff75c98113d5080d8ec016148426abcc19130864e2952d7bd",
+    strip_prefix = "gflags-827c769e5fc98e0f2a34c47cef953cc6328abced",
+    urls = ["https://github.com/gflags/gflags/archive/827c769e5fc98e0f2a34c47cef953cc6328abced.zip" ],
 )
 
 http_archive(


### PR DESCRIPTION
We still have to keep the fallthrough-warning disabled in our
CI due to another place in our code-base; that will be
addressed separately, then the warning enabled.

Signed-off-by: Henner Zeller <h.zeller@acm.org>