### PR TITLE
formatter: Fix crash caused by an alignment of null statement

### DIFF
--- a/verilog/formatting/formatter_test.cc
+++ b/verilog/formatting/formatter_test.cc
@@ -1297,6 +1297,33 @@ static constexpr FormatterTestCase kFormatterTestCases[] = {
      ");\n"
      "endmodule : foo\n"},
 
+    {// align null-statement (issue #824)
+     "class sample;"
+     "bit a;;"
+     "bit b;"
+     "endclass",
+     "class sample;\n"
+     "  bit a;\n"
+     "  ;\n"
+     "  bit b;\n"
+     "endclass\n"},
+    {"class sample;"
+     "bit a;;"
+     "endclass",
+     "class sample;\n"
+     "  bit a;\n"
+     "  ;\n"
+     "endclass\n"},
+    {"class sample;"
+     "bit a;"
+     "bit b;;"
+     "endclass",
+     "class sample;\n"
+     "  bit a;\n"
+     "  bit b;\n"
+     "  ;\n"
+     "endclass\n"},
+
     {// aligning here just barely fits in the 40col limit
      "module foo(  input int signed x [a:b],"
      "output reg [mm:nn] yy) ;endmodule:foo\n",

--- a/verilog/formatting/tree_unwrapper.cc
+++ b/verilog/formatting/tree_unwrapper.cc
@@ -1923,6 +1923,15 @@ void TreeUnwrapper::Visit(const verible::SyntaxTreeLeaf& leaf) {
   // Should be equivalent to AdvanceNextUnfilteredToken().
   AddTokenToCurrentUnwrappedLine();
 
+  // Make sure that newly extended unwrapped line has origin symbol
+  // FIXME: Pretty sure that this should be handled in an other way,
+  //    e.g. in common/formatting/tree_unwrapper.cc similary
+  //    to StartNewUnwrappedLine()
+  if (CurrentUnwrappedLine().Origin() == nullptr &&
+      CurrentUnwrappedLine().TokensRange().size() == 1) {
+    CurrentUnwrappedLine().SetOrigin(&leaf);
+  }
+
   // Look-ahead to any trailing comments that are associated with this leaf,
   // up to a newline.
   LookAheadBeyondCurrentLeaf();


### PR DESCRIPTION
Fixes #824