### PR TITLE
Fix `workspace_status_command` on Windows

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,13 +1,10 @@
 # Enable support for absl types like string_view in gtest.
 build --define="absl=1"
-run --define="absl=1"
-test --define="absl=1"
-# Cannot use 'common' because 'bazel version' fails with this.
 
 # Gather build version information
-build --workspace_status_command=bazel/build-version.py
-run --workspace_status_command=bazel/build-version.py
-test --workspace_status_command=bazel/build-version.py
+build:linux --workspace_status_command=bazel/build-version.py
+build:macos --workspace_status_command=bazel/build-version.py
+build:windows --workspace_status_command="python bazel/build-version.py"
 
 build --enable_platform_specific_config
 


### PR DESCRIPTION
Seems like `.py` files are not directly (i.e. in `CreateProcess` system function) executable on Windows.

This change has been tested with https://github.com/google/verible/pull/823 (commit/build status before rebase: https://github.com/google/verible/commit/e74e9ed18966217fb1aaffa032019686cfd30863)