### PR TITLE
Make asan clean

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -18,3 +18,13 @@ common:macos --features=-supports_dynamic_linker --cxxopt=-std=c++17 --host_cxxo
 # the codebase, so we focus the effort for now is to have a Windows Verible
 # compiled with clang-cl before fixing the issues unique to MSVC.
 common:windows --compiler=clang-cl --cxxopt=/std:c++17 --host_cxxopt=/std:c++17 --client_env=BAZEL_CXXOPTS=/std:c++17
+
+# Address sanitizer settings.
+build:asan --strip=never
+build:asan --copt -fsanitize=address
+build:asan --copt -DADDRESS_SANITIZER
+build:asan --copt -O1
+build:asan --copt -g
+build:asan --copt -fno-omit-frame-pointer
+build:asan --linkopt -fsanitize=address
+

--- a/.github/bin/build-and-test.sh
+++ b/.github/bin/build-and-test.sh
@@ -53,6 +53,10 @@ test)
     bazel test --test_output=errors $BAZEL_OPTS //...
     ;;
 
+asan)
+    bazel test --config=asan $BAZEL_OPTS //...
+    ;;
+
 compile|clean)
     bazel build $BAZEL_OPTS //...
     ;;

--- a/.github/workflows/verible-ci.yml
+++ b/.github/workflows/verible-ci.yml
@@ -49,6 +49,7 @@ jobs:
       matrix:
         mode:
         - test
+        - asan
         - compile
         - clean
     env:

--- a/common/formatting/align.cc
+++ b/common/formatting/align.cc
@@ -335,10 +335,12 @@ static AlignedFormattingColumnSchema ComputeColumnWidths(
   // must be set to 0
   int longest_cell_before_delimiter = 0;
   bool align_to_last_row = false;
-  for (const auto& row : matrix) {
+  for (const AlignmentRow& row : matrix) {
     auto column_prop_iter = column_properties.begin();
-    for (const auto& cell : row) {
-      if (std::next(column_prop_iter, 1)->contains_delimiter) {
+    for (const AlignmentCell& cell : row) {
+      const auto next_prop = std::next(column_prop_iter, 1);
+      if (next_prop != column_properties.end() &&
+          next_prop->contains_delimiter) {
         if (longest_cell_before_delimiter < cell.TotalWidth()) {
           longest_cell_before_delimiter = cell.TotalWidth();
           if (&row == &matrix.back()) align_to_last_row = true;
@@ -349,10 +351,10 @@ static AlignedFormattingColumnSchema ComputeColumnWidths(
     }
   }
 
-  for (const auto& row : matrix) {
+  for (const AlignmentRow& row : matrix) {
     auto column_iter = column_configs.begin();
     auto column_prop_iter = column_properties.begin();
-    for (const auto& cell : row) {
+    for (const AlignmentCell& cell : row) {
       if (column_prop_iter->contains_delimiter && align_to_last_row) {
         column_iter->width = 0;
         column_iter->left_border = 0;


### PR DESCRIPTION
Compiling with address sanitizer options revealed a memory overrun. Fix the problem and also add address sanitizer compilation to CI.