### PR TITLE
Optionally expand coverpoints

### DIFF
--- a/verilog/formatting/format_style.h
+++ b/verilog/formatting/format_style.h
@@ -95,6 +95,7 @@ struct FormatStyle : public verible::BasicFormatStyle {
   // attempt to do line wrap optimization.  By doing nothing in those cases, we
   // reduce the risk of harming already decent code.
   bool try_wrap_long_lines = true;
+  bool expand_coverpoints = true;
 
   // Compact binary expressions inside indexing / bit selection operators
   bool compact_indexing_and_selections = true;

--- a/verilog/formatting/formatter_test.cc
+++ b/verilog/formatting/formatter_test.cc
@@ -9620,6 +9620,164 @@ TEST(FormatterEndToEndTest, UnfinishedLineWrapSearching) {
   EXPECT_TRUE(absl::StartsWith(status.message(), "***"));
 }
 
+static constexpr FormatterTestCase kOnelineFormatBaselineTestCases[] = {
+    // Reference - following test cases should not be affected by the switch
+    {// Minimal useful case
+     "covergroup c @ (posedge clk); coverpoint a; endgroup\n",
+     "covergroup c @(posedge clk);\n"
+     "  coverpoint a;\n"
+     "endgroup\n"},
+    {// Multiple coverpoints
+     "covergroup foo @(posedge clk); coverpoint a; coverpoint b; "
+     "coverpoint c; coverpoint d; endgroup\n",
+     "covergroup foo @(posedge clk);\n"
+     "  coverpoint a;\n"
+     "  coverpoint b;\n"
+     "  coverpoint c;\n"
+     "  coverpoint d;\n"
+     "endgroup\n"},
+    {// Multiple bins
+     "covergroup memory @ (posedge ce); address  :coverpoint addr {"
+     "bins low={LOW}; bins high={HIGH};} endgroup\n",
+     "covergroup memory @(posedge ce);\n"
+     "  address: coverpoint addr {\n"
+     "    bins low = {LOW};\n"
+     "    bins high = {HIGH};\n"
+     "  }\n"
+     "endgroup\n"},
+    {// Multiple bins with multiple elements
+     "covergroup memory @ (posedge ce); address  :coverpoint addr {"
+     "bins low={0,127}; bins high={128,255};} endgroup\n",
+     "covergroup memory @(posedge ce);\n"
+     "  address: coverpoint addr {\n"
+     "    bins low = {0, 127};\n"
+     "    bins high = {128, 255};\n"
+     "  }\n"
+     "endgroup\n"},
+};
+
+// Tests that constructs that could be formatted as one-liners are formatted
+// correctly. This is the baseline test with default style, test cases should
+// not be affected by the setting.
+TEST(FormatterEndToEndTest, OnelineFormatBaselineTest) {
+  // Use a fixed style.
+  FormatStyle style;
+  style.column_limit = 40;
+  style.indentation_spaces = 2;
+  style.wrap_spaces = 4;
+  style.expand_coverpoints = false;
+  for (const auto& test_case : kOnelineFormatBaselineTestCases) {
+    VLOG(1) << "code-to-format:\n" << test_case.input << "<EOF>";
+    std::ostringstream stream;
+    const auto status =
+        FormatVerilog(test_case.input, "<filename>", style, stream);
+    // Require these test cases to be valid.
+    EXPECT_OK(status) << status.message();
+    EXPECT_EQ(stream.str(), test_case.expected) << "code:\n" << test_case.input;
+  }
+  // Test again with the switch, should not affect formatting
+  style.expand_coverpoints = true;
+  for (const auto& test_case : kOnelineFormatBaselineTestCases) {
+    VLOG(1) << "code-to-format:\n" << test_case.input << "<EOF>";
+    std::ostringstream stream;
+    const auto status =
+        FormatVerilog(test_case.input, "<filename>", style, stream);
+    // Require these test cases to be valid.
+    EXPECT_OK(status) << status.message();
+    EXPECT_EQ(stream.str(), test_case.expected) << "code:\n" << test_case.input;
+  }
+}
+
+// Following two test sets are affected by the expand_coverponits switch
+// They should contain corresponding test cases
+static constexpr FormatterTestCase kOnelineFormatReferenceTestCases[] = {
+    {// Coverpoint that could fit on one line
+     "covergroup memory @ (posedge ce); a :coverpoint d {"
+     "bins l={0};} endgroup\n",
+     "covergroup memory @(posedge ce);\n"
+     "  a: coverpoint d {bins l = {0};}\n"
+     "endgroup\n"},
+    {// Fit with a reference
+     "covergroup memory @ (posedge ce); a :coverpoint d {"
+     "bins l={LOW};} endgroup\n",
+     "covergroup memory @(posedge ce);\n"
+     "  a: coverpoint d {bins l = {LOW};}\n"
+     "endgroup\n"},
+    {// Fit with multiple elements
+     "covergroup memory @ (posedge ce); a :coverpoint d {"
+     "bins l={0,8};} endgroup\n",
+     "covergroup memory @(posedge ce);\n"
+     "  a: coverpoint d {bins l = {0, 8};}\n"
+     "endgroup\n"},
+};
+
+static constexpr FormatterTestCase kOnelineFormatExpandTestCases[] = {
+    {// Coverpoint that could fit on one line
+     "covergroup memory @ (posedge ce); a :coverpoint d {"
+     "bins l={0};} endgroup\n",
+     "covergroup memory @(posedge ce);\n"
+     "  a: coverpoint d {\n"
+     "    bins l = {0};\n"
+     "  }\n"
+     "endgroup\n"},
+    {// Fit with a reference
+     "covergroup memory @ (posedge ce); a :coverpoint d {"
+     "bins l={LOW};} endgroup\n",
+     "covergroup memory @(posedge ce);\n"
+     "  a: coverpoint d {\n"
+     "    bins l = {LOW};\n"
+     "  }\n"
+     "endgroup\n"},
+    {// Fit with multiple elements
+     "covergroup memory @ (posedge ce); a :coverpoint d {"
+     "bins l={0,8};} endgroup\n",
+     "covergroup memory @(posedge ce);\n"
+     "  a: coverpoint d {\n"
+     "    bins l = {0, 8};\n"
+     "  }\n"
+     "endgroup\n"},
+};
+
+TEST(FormatterEndToEndTest, OnelineFormatReferenceTest) {
+  // Use a fixed style.
+  FormatStyle style;
+  style.column_limit = 40;
+  style.indentation_spaces = 2;
+  style.wrap_spaces = 4;
+  style.expand_coverpoints = false;
+
+  for (const auto& test_case : kOnelineFormatReferenceTestCases) {
+    VLOG(1) << "code-to-format:\n" << test_case.input << "<EOF>";
+    std::ostringstream stream;
+    const auto status =
+        FormatVerilog(test_case.input, "<filename>", style, stream);
+    // Require these test cases to be valid.
+    EXPECT_OK(status) << status.message();
+    EXPECT_EQ(stream.str(), test_case.expected) << "code:\n" << test_case.input;
+  }
+}
+
+// Tests that constructs that could be formatted as one-liners are expanded
+// correctly. This is the baseline test with default style
+TEST(FormatterEndToEndTest, OnelineFormatExpandTest) {
+  // Use a fixed style.
+  FormatStyle style;
+  style.column_limit = 40;
+  style.indentation_spaces = 2;
+  style.wrap_spaces = 4;
+  style.expand_coverpoints = true;
+
+  for (const auto& test_case : kOnelineFormatExpandTestCases) {
+    VLOG(1) << "code-to-format:\n" << test_case.input << "<EOF>";
+    std::ostringstream stream;
+    const auto status =
+        FormatVerilog(test_case.input, "<filename>", style, stream);
+    // Require these test cases to be valid.
+    EXPECT_OK(status) << status.message();
+    EXPECT_EQ(stream.str(), test_case.expected) << "code:\n" << test_case.input;
+  }
+}
+
 // TODO(fangism): directed tests using style variations
 
 }  // namespace

--- a/verilog/formatting/tree_unwrapper.cc
+++ b/verilog/formatting/tree_unwrapper.cc
@@ -1002,8 +1002,8 @@ void TreeUnwrapper::SetIndentationsAndCreatePartitions(
 
     case NodeEnum::kBinOptionList: {
       PartitionPolicyEnum shouldExpand =
-        style_.expand_coverpoints ? PartitionPolicyEnum::kAlwaysExpand
-                                  : PartitionPolicyEnum::kFitOnLineElseExpand;
+          style_.expand_coverpoints ? PartitionPolicyEnum::kAlwaysExpand
+                                    : PartitionPolicyEnum::kFitOnLineElseExpand;
       // Do not further indent preprocessor clauses.
       const int indent = suppress_indentation ? 0 : style_.indentation_spaces;
       VisitIndentedSection(node, indent, shouldExpand);
@@ -1014,7 +1014,8 @@ void TreeUnwrapper::SetIndentationsAndCreatePartitions(
       if (style_.expand_coverpoints) {
         VisitIndentedSection(node, 0, PartitionPolicyEnum::kAlwaysExpand);
       } else
-        VisitIndentedSection(node, 0, PartitionPolicyEnum::kFitOnLineElseExpand);
+        VisitIndentedSection(node, 0,
+                             PartitionPolicyEnum::kFitOnLineElseExpand);
       break;
     }
       // Add a level of grouping that is treated as wrapping.

--- a/verilog/formatting/tree_unwrapper_test.cc
+++ b/verilog/formatting/tree_unwrapper_test.cc
@@ -8024,11 +8024,9 @@ const TreeUnwrapperTestData kUnwrapCovergroupTestCases[] = {
                              L(2, {"string", "s"}), L(0, {")", ";"})),
             CovergroupItemList(
                 1, L(1, {"q_cp", ":", "coverpoint", "cp", "{"}),
-                CoverpointItemList(2,
-                                   N(2, L(2, {"bins", "foo", "=", "{"}),
-                                     L(3, {"bar"}), L(2, {"}", ";"})),
-                                   N(2, L(2, {"bins", "zoo", "=", "{"}),
-                                     L(3, {"pig"}), L(2, {"}", ";"}))),
+                CoverpointItemList(
+                    2, L(2, {"bins", "foo", "=", "{", "bar", "}", ";"}),
+                    L(2, {"bins", "zoo", "=", "{", "pig", "}", ";"})),
                 L(1, {"}"})),
             L(0, {"endgroup"})),
     },

--- a/verilog/tools/formatter/verilog_format.cc
+++ b/verilog/tools/formatter/verilog_format.cc
@@ -166,6 +166,9 @@ ABSL_FLAG(AlignmentPolicy, assignment_statement_alignment,
           AlignmentPolicy::kInferUserIntent,
           "Format various assignments: {align,flush-left,preserve,infer}");
 
+ABSL_FLAG(bool, expand_coverpoints, false,
+          "If true, always expand coverpoints.");
+
 ABSL_FLAG(bool, try_wrap_long_lines, false,
           "If true, let the formatter attempt to optimize line wrapping "
           "decisions where wrapping is needed, else leave them unformatted.  "
@@ -224,6 +227,7 @@ static bool formatOneFile(absl::string_view filename,
 
     // formatting style flags
     format_style.try_wrap_long_lines = absl::GetFlag(FLAGS_try_wrap_long_lines);
+    format_style.expand_coverpoints = absl::GetFlag(FLAGS_expand_coverpoints);
 
     // various indentation control
     format_style.port_declarations_indentation =


### PR DESCRIPTION
Add a switch to the formatter to always expand coverpoint declarations, even if they would fit on one line.
The option is `--expand_coverpoints` and is disabled by default.

Fixes #813.